### PR TITLE
feat(skills): #1410 Phase 4-2 — hook 구이름 지원 제거 (D-12 정리)

### DIFF
--- a/claude/hooks/devx_autopilot_stop_guard.py
+++ b/claude/hooks/devx_autopilot_stop_guard.py
@@ -107,16 +107,20 @@ _STEP_LABELS: dict[str, str] = {
     "pr-reply": "Step 5 — Skill(gh-pr:reply, <PR_NUM>) (emit the marker even with no comments / [SKIP])",
 }
 
+# The marker namespace the skill emits — the only one it ships under since
+# the #1410 migration completed (#1680 / #1681 F-5). Named, not inlined: the
+# guard both RECOGNIZES this marker and INSTRUCTS the model to emit it, so a
+# drift between the two would re-block a compliant model forever.
+_STEP_MARKER_SKILL: str = "gh-flow-autopilot"
+
 # Strict step-marker regex. Requires the literal `[step:<skill>/<id>] OK`
 # so a partial `[step:gh-flow-autopilot/plan]` without ` OK` does NOT match.
-# `gh-flow-autopilot` is the only namespace the skill ships under since the
-# #1410 migration completed (#1680 / #1681 F-5).
-_STEP_MARKER_RE: re.Pattern[str] = re.compile(r"\[step:gh-flow-autopilot/([a-z-]+)\]\s+OK\b")
+_STEP_MARKER_RE: re.Pattern[str] = re.compile(rf"\[step:{_STEP_MARKER_SKILL}/([a-z-]+)\]\s+OK\b")
 
 # Terminal markers — presence in any *assistant text* block after the boundary
 # means the flow has finished (or hard-failed) and the model may stop.
 TERMINAL_PATTERNS: tuple[str, ...] = (
-    "[step:gh-flow-autopilot/report] OK",
+    f"[step:{_STEP_MARKER_SKILL}/report] OK",
     "[OK] gh-flow:autopilot",
     "[FAIL] gh-flow:autopilot",
 )
@@ -192,15 +196,15 @@ _SKILL_EXPANSION_RE: re.Pattern[str] = _line_anchored_alternation(
 # `<task-notification>` case is the norm here too.
 #
 # `isMeta` on the outer transcript entry is the primary defense; this tuple is
-# defense-in-depth for transcripts that lack the flag. `gh-flow:autopilot
-# incomplete:` is this hook's own block-reason prefix — exactly the string
-# that gets re-injected — so it is the strongest single signal available. It
-# is matched against this hook's own output, so the entry here and every
-# `_block()` reason must be renamed together or the #1275 self-defeat loop
-# reopens silently.
+# defense-in-depth for transcripts that lack the flag. `_BLOCK_REASON_PREFIX`
+# is this hook's own block-reason opener — exactly the string that gets
+# re-injected — so it is the strongest single signal available. It is shared
+# with the `_block()` reasons rather than re-typed here: a rename that hit
+# only one side would reopen the #1275 self-defeat loop silently.
+_BLOCK_REASON_PREFIX: str = "gh-flow:autopilot incomplete:"
 _HARNESS_INJECTION_MARKERS: tuple[str, ...] = (
     "Stop hook feedback:",
-    "gh-flow:autopilot incomplete:",
+    _BLOCK_REASON_PREFIX,
     "<task-notification>",
     "[SYSTEM NOTIFICATION - NOT USER INPUT]",
     "<local-command-caveat>",
@@ -533,20 +537,17 @@ def main() -> int:
             layer="L1.5",
         )
 
-    # Both reasons below open with the literal `gh-flow:autopilot incomplete:`
-    # prefix — `_HARNESS_INJECTION_MARKERS` matches that same string when
-    # Claude Code re-injects the reason, so the two move together.
     missing = _first_missing_step(steps)
     if missing is None:
         # All required steps emitted but no terminal report yet → ask for it.
         reason = (
-            f"gh-flow:autopilot incomplete: all {len(REQUIRED_STEPS)} Stage-B step "
+            f"{_BLOCK_REASON_PREFIX} all {len(REQUIRED_STEPS)} Stage-B step "
             f"markers are present but no terminal report has been emitted yet. Per "
             f"the CRITICAL CONTRACT in the gh-flow:autopilot SKILL.md, you "
             f"MUST continue immediately. Next action: Step 6 — emit the final "
             f"report per references/report-template.md ('[OK] gh-flow:autopilot ...' or "
             f"'[FAIL] gh-flow:autopilot ...') followed by "
-            f"'[step:gh-flow-autopilot/report] OK'. Output ZERO conversational text "
+            f"'[step:{_STEP_MARKER_SKILL}/report] OK'. Output ZERO conversational text "
             f"before it — no recap, no per-step bullets, no progress headers."
         )
         return _block(reason, layer="L1.5")
@@ -556,12 +557,12 @@ def main() -> int:
     seen_count = len(steps)
     label = _STEP_LABELS.get(missing, missing)
     reason = (
-        f"gh-flow:autopilot incomplete: {seen_count}/{len(REQUIRED_STEPS)} Stage-B "
+        f"{_BLOCK_REASON_PREFIX} {seen_count}/{len(REQUIRED_STEPS)} Stage-B "
         f"step markers emitted since the flow started, and no terminal report "
         f"('[OK] gh-flow:autopilot' / '[FAIL] gh-flow:autopilot') has been emitted yet. "
         f"Per the CRITICAL CONTRACT in the gh-flow:autopilot SKILL.md, you "
         f"MUST continue immediately. Next action: {label}; when it completes emit "
-        f"'[step:gh-flow-autopilot/{missing}] OK'. Output ZERO conversational text — "
+        f"'[step:{_STEP_MARKER_SKILL}/{missing}] OK'. Output ZERO conversational text — "
         f"no recap, no markdown summary, no per-step bullets, no progress headers — "
         f"just the next step's work and its completion marker."
     )

--- a/claude/hooks/devx_autopilot_stop_guard.py
+++ b/claude/hooks/devx_autopilot_stop_guard.py
@@ -1,12 +1,12 @@
 #!/usr/bin/env python3
-"""Claude Code Stop hook: harness-level guard for /devx-autopilot early-stop (issue #1138).
+"""Claude Code Stop hook: harness-level guard for /gh-flow:autopilot early-stop (issue #1138).
 
 Reads a Stop event JSON from stdin, parses the conversation transcript, and
 emits a `block` decision when the model tries to end its turn while a
-devx:autopilot chain (Stage-B: plan -> issue -> mode -> implement -> pr ->
+gh-flow:autopilot chain (Stage-B: plan -> issue -> mode -> implement -> pr ->
 simplify -> pr-reply -> report) is still in progress.
 
-Failure mode being mitigated: like gh:issue-flow, the model self-authors a
+Failure mode being mitigated: like gh-flow:issue, the model self-authors a
 success-looking summary between chained Skill() calls and treats it as a
 turn-ending answer, leaving the Stage-B chain half-run. Prose rules in
 SKILL.md alone are not enough — the harness must mechanically force
@@ -16,21 +16,21 @@ Why marker-based (not skill-count-based like gh_issue_flow_stop_guard.py):
 autopilot's *inline* implementation mode runs no implement sub-skill at all,
 so counting Skill() invocations would undercount a legitimately-complete
 flow. Instead this guard tracks the ORDERED STEP MARKERS the SKILL.md emits
-via `printf '[step:devx-autopilot/<id>] OK\\n'`. Because printf output lands
-in a Bash `tool_result` block, the step-marker scan intentionally includes
-tool_result payloads (fail-open direction is acceptable — a stray marker
-merely lets a stop through, it never traps the user). The terminal scan, by
-contrast, is restricted to `role=assistant` text (include_tool_results=False)
-so the report-template.md text — which literally contains `[OK] devx:autopilot`
-— cannot false-terminate the flow when read into a tool_result (mirrors the
-gh-issue-flow L1.5 fix).
+via `printf '[step:gh-flow-autopilot/<id>] OK\\n'`. Because printf output
+lands in a Bash `tool_result` block, the step-marker scan intentionally
+includes tool_result payloads (fail-open direction is acceptable — a stray
+marker merely lets a stop through, it never traps the user). The terminal
+scan, by contrast, is restricted to `role=assistant` text
+(include_tool_results=False) so the report-template.md text — which literally
+contains `[OK] gh-flow:autopilot` — cannot false-terminate the flow when read
+into a tool_result (mirrors the gh-flow:issue L1.5 fix).
 
 Safety rails (each is critical — never accidentally trap the user):
   - Empty / unreadable / malformed stdin → exit 0 (allow stop).
   - Missing or unreadable transcript_path → exit 0.
   - `stop_hook_active == True` → exit 0 (we already blocked once in this
     chain; bowing out prevents an infinite Stop→block→Stop loop).
-  - No devx-autopilot boundary in the transcript → exit 0 (not our flow).
+  - No gh-flow:autopilot boundary in the transcript → exit 0 (not our flow).
   - Terminal report marker present in assistant text → exit 0 (chain done).
   - Boundary went stale (N fresh user prompts since it) → exit 0 (#1275).
   - Any unexpected exception → exit 0 (fail open).
@@ -54,8 +54,8 @@ from typing import Any
 _TRACE_ENABLED: bool = os.environ.get("DEVX_AUTOPILOT_STOP_GUARD_TRACE") == "1"
 
 # Issue #1275 (ported from #1270 / PR #1272) — how many *fresh* user prompts
-# may accumulate after a devx-autopilot boundary before the hook declares that
-# boundary stale and fails open. Without this valve a boundary lives forever:
+# may accumulate after a gh-flow:autopilot boundary before the hook declares
+# that boundary stale and fails open. Without this valve a boundary lives forever:
 # `stop_hook_active` only prevents an infinite Stop→block→Stop loop *within*
 # one turn, and it resets the moment the user sends a new message, so an
 # abandoned Stage-B run that never emitted a terminal report would keep
@@ -108,25 +108,14 @@ _STEP_LABELS: dict[str, str] = {
 }
 
 # Strict step-marker regex. Requires the literal `[step:<skill>/<id>] OK`
-# so a partial `[step:devx-autopilot/plan]` without ` OK` does NOT match.
-#
-# Two skill names are honoured: the dotfiles-native `devx-autopilot` and,
-# since #1410 Phase 3, the migrated `gh-flow-autopilot` (D-12, issue #1678).
-# Both are accepted for the whole transition — NF-1 keeps the dotfiles
-# original emitting the old marker until Phase 4, while anyone running the
-# `gh-flow-skills` plugin emits the new one. Both are spelled out literally
-# here, like the `TERMINAL_PATTERNS` twins just below and the (a')-(d')
-# boundary twins further down, so that a `grep gh-flow-autopilot` surfaces
-# every namespace-sensitive site including the pattern actually compiled.
-_STEP_MARKER_RE: re.Pattern[str] = re.compile(r"\[step:(?:devx-autopilot|gh-flow-autopilot)/([a-z-]+)\]\s+OK\b")
+# so a partial `[step:gh-flow-autopilot/plan]` without ` OK` does NOT match.
+# `gh-flow-autopilot` is the only namespace the skill ships under since the
+# #1410 migration completed (#1680 / #1681 F-5).
+_STEP_MARKER_RE: re.Pattern[str] = re.compile(r"\[step:gh-flow-autopilot/([a-z-]+)\]\s+OK\b")
 
 # Terminal markers — presence in any *assistant text* block after the boundary
 # means the flow has finished (or hard-failed) and the model may stop.
 TERMINAL_PATTERNS: tuple[str, ...] = (
-    "[step:devx-autopilot/report] OK",
-    "[OK] devx:autopilot",
-    "[FAIL] devx:autopilot",
-    # Post-migration twins (#1678, D-12).
     "[step:gh-flow-autopilot/report] OK",
     "[OK] gh-flow:autopilot",
     "[FAIL] gh-flow:autopilot",
@@ -192,7 +181,7 @@ _SKILL_EXPANSION_RE: re.Pattern[str] = _line_anchored_alternation(
 # (which identifies an expanded SKILL.md body), so it lives in its own tuple;
 # both are consulted.
 #
-# WHY this exists (measured on gh-issue-flow's twin guard in PR #1272): a
+# WHY this exists (measured on gh-flow:issue's twin guard in PR #1272): a
 # naive `role=user` count reported 102 "fresh prompts" on a real transcript of
 # which only 4 were human — the rest were Stop-hook feedback blocks (Claude
 # Code re-injects THIS hook's own `reason` string as a `role=user` text
@@ -203,62 +192,53 @@ _SKILL_EXPANSION_RE: re.Pattern[str] = _line_anchored_alternation(
 # `<task-notification>` case is the norm here too.
 #
 # `isMeta` on the outer transcript entry is the primary defense; this tuple is
-# defense-in-depth for transcripts that lack the flag. `devx-autopilot
+# defense-in-depth for transcripts that lack the flag. `gh-flow:autopilot
 # incomplete:` is this hook's own block-reason prefix — exactly the string
-# that gets re-injected — so it is the strongest single signal available.
+# that gets re-injected — so it is the strongest single signal available. It
+# is matched against this hook's own output, so the entry here and every
+# `_block()` reason must be renamed together or the #1275 self-defeat loop
+# reopens silently.
 _HARNESS_INJECTION_MARKERS: tuple[str, ...] = (
     "Stop hook feedback:",
-    "devx-autopilot incomplete:",
+    "gh-flow:autopilot incomplete:",
     "<task-notification>",
     "[SYSTEM NOTIFICATION - NOT USER INPUT]",
     "<local-command-caveat>",
 )
 _HARNESS_INJECTION_RE: re.Pattern[str] = _line_anchored_alternation(_HARNESS_INJECTION_MARKERS)
 
-# Regex that marks the *start* of a devx-autopilot chain in a user message.
+# Regex that marks the *start* of a gh-flow:autopilot chain in a user message.
 # Matches four real-world surfaces (mirrors gh_issue_flow_stop_guard.py):
-#   (a) raw `/devx-autopilot ...` (or colon `/devx:autopilot ...`) at line start
-#   (b) the `<command-name>/devx-autopilot</command-name>` wrapper Claude Code
-#       emits when a user invokes the slash command interactively
-#   (c) the `Base directory for this skill: …/devx-autopilot` expansion marker
-#   (d) the SKILL.md H1 line `# devx:autopilot — …`
-# Each has a primed twin (a')–(d') for the post-migration `gh-flow:autopilot`
-# namespace (#1678, D-12). Without them the widened markers above would be
-# unreachable for anyone running the migrated plugin: the guard would never
-# arm, so it would never look for a marker in either namespace. (c') allows
-# arbitrary path segments between `gh-flow` and `/autopilot`: an installed
-# plugin's base dir is `plugins/marketplaces/gh-flow-skills/skills/autopilot`
-# or `plugins/cache/gh-flow-skills/gh-flow/<version>/skills/autopilot`, not
-# `<plugin>/skills/<skill>` (measured).
+#   (a) raw `/gh-flow:autopilot ...` (or hyphen `/gh-flow-autopilot ...`) at
+#       line start
+#   (b) the `<command-name>/gh-flow:autopilot</command-name>` wrapper Claude
+#       Code emits when a user invokes the slash command interactively
+#   (c) the `Base directory for this skill: …/autopilot` expansion marker —
+#       arbitrary path segments are allowed between `gh-flow` and `/autopilot`
+#       because an installed plugin's base dir is
+#       `plugins/marketplaces/gh-flow-skills/skills/autopilot` or
+#       `plugins/cache/gh-flow-skills/gh-flow/<version>/skills/autopilot`, not
+#       `<plugin>/skills/<skill>` (measured)
+#   (d) the SKILL.md H1 line `# gh-flow:autopilot — …`
 # `(?m)` anchors `^` to per-line starts. tool_result payloads are excluded by
 # `_iter_text_blocks(..., include_tool_results=False)` at the call site.
 _USER_BOUNDARY_RE: re.Pattern[str] = re.compile(
     r"""
     (?m)                                                          # multiline: ^ matches each line start
     (?:
-        ^\s*/devx[-:]autopilot\b                                  # (a) raw slash command
+        ^\s*/gh-flow[-:]autopilot(?![\w-])                        # (a) raw slash command
         |
-        <command-name>\s*/devx[-:]autopilot\s*</command-name>     # (b) Claude Code wrapped form
-        |
-        ^Base\s+directory\s+for\s+this\s+skill:\s+.*devx-autopilot\b  # (c) skill base dir
-        |
-        ^\#\s+devx:autopilot\s+—                                  # (d) SKILL.md H1
-        |
-        ^\s*/gh-flow[-:]autopilot(?![\w-])                        # (a') new namespace
-        |
-        <command-name>\s*/gh-flow[-:]autopilot\s*</command-name>  # (b') new namespace
+        <command-name>\s*/gh-flow[-:]autopilot\s*</command-name>  # (b) Claude Code wrapped form
         |
         ^Base\s+directory\s+for\s+this\s+skill:\s+
-            .*gh-flow(?:-autopilot(?![\w-])|[\w./-]*/autopilot(?![\w-]))  # (c') new namespace
+            .*gh-flow(?:-autopilot(?![\w-])|[\w./-]*/autopilot(?![\w-]))  # (c) skill base dir
         |
-        ^\#\s+gh-flow:autopilot\s+—                               # (d') new namespace
+        ^\#\s+gh-flow:autopilot\s+—                               # (d) SKILL.md H1
     )
     """,
     re.VERBOSE,
 )
 FLOW_SKILL_NAMES: set[str] = {
-    "devx-autopilot",
-    "devx:autopilot",
     "gh-flow-autopilot",
     "gh-flow:autopilot",
 }
@@ -274,7 +254,7 @@ def _allow(trace_reason: str = "", *, layer: str | None = None) -> int:
 def _block(reason: str, *, layer: str | None = None) -> int:
     """Block the stop with a directive shown to the model."""
     json.dump({"decision": "block", "reason": reason}, sys.stdout)
-    _trace("block: devx-autopilot incomplete — re-prompting model", layer=layer)
+    _trace("block: gh-flow:autopilot incomplete — re-prompting model", layer=layer)
     return 0
 
 
@@ -363,11 +343,11 @@ def _message_payload(entry: dict[str, Any]) -> dict[str, Any]:
 
 
 def _find_flow_boundary(messages: list[dict[str, Any]]) -> int:
-    """Return the index of the most recent devx-autopilot START, or -1.
+    """Return the index of the most recent gh-flow:autopilot START, or -1.
 
     Boundary signals (role-restricted to avoid false positives from file
     content read into tool_result blocks):
-      - assistant message: tool_use of Skill(devx-autopilot | devx:autopilot)
+      - assistant message: tool_use of Skill(gh-flow-autopilot | gh-flow:autopilot)
       - user message: text content matches `_USER_BOUNDARY_RE` (four surfaces).
         `tool_result` blocks are excluded so a doc mentioning the command
         does not trip the boundary.
@@ -394,9 +374,9 @@ def _scan_after_boundary(messages: list[dict[str, Any]], start: int) -> tuple[bo
     - Terminal detection is restricted to `role=assistant` text blocks with
       `include_tool_results=False`, and the boundary message itself is skipped
       (`start + 1`). This prevents report-template.md text (which literally
-      contains `[OK] devx:autopilot`) — whether delivered as the expanded
+      contains `[OK] gh-flow:autopilot`) — whether delivered as the expanded
       SKILL.md user block or read into a tool_result — from false-matching a
-      terminal marker (mirrors gh-issue-flow's L1.5 fix).
+      terminal marker (mirrors gh-flow:issue's L1.5 fix).
     - Step-marker detection scans ALL roles WITH tool_results, because the
       SKILL.md `printf '[step:...] OK'` output lands in Bash tool_result.
     """
@@ -522,7 +502,7 @@ def main() -> int:
 
     boundary = _find_flow_boundary(messages)
     if boundary < 0:
-        return _allow("no devx-autopilot boundary in transcript", layer="L1")
+        return _allow("no gh-flow-autopilot boundary in transcript", layer="L1")
 
     terminal, steps = _scan_after_boundary(messages, boundary)
     # Issue #1275 — the fresh-prompt count feeds nothing but the expiry valve
@@ -549,21 +529,24 @@ def main() -> int:
     if limit > 0 and fresh_prompts >= limit:
         return _allow(
             f"stale boundary expiry — {fresh_prompts} fresh user prompt(s) since the "
-            f"devx-autopilot boundary (limit {limit}); flow abandoned, failing open",
+            f"gh-flow:autopilot boundary (limit {limit}); flow abandoned, failing open",
             layer="L1.5",
         )
 
+    # Both reasons below open with the literal `gh-flow:autopilot incomplete:`
+    # prefix — `_HARNESS_INJECTION_MARKERS` matches that same string when
+    # Claude Code re-injects the reason, so the two move together.
     missing = _first_missing_step(steps)
     if missing is None:
         # All required steps emitted but no terminal report yet → ask for it.
         reason = (
-            f"devx-autopilot incomplete: all {len(REQUIRED_STEPS)} Stage-B step "
+            f"gh-flow:autopilot incomplete: all {len(REQUIRED_STEPS)} Stage-B step "
             f"markers are present but no terminal report has been emitted yet. Per "
-            f"the CRITICAL CONTRACT in claude/skills/devx-autopilot/SKILL.md, you "
+            f"the CRITICAL CONTRACT in the gh-flow:autopilot SKILL.md, you "
             f"MUST continue immediately. Next action: Step 6 — emit the final "
-            f"report per references/report-template.md ('[OK] devx:autopilot ...' or "
-            f"'[FAIL] devx:autopilot ...') followed by "
-            f"'[step:devx-autopilot/report] OK'. Output ZERO conversational text "
+            f"report per references/report-template.md ('[OK] gh-flow:autopilot ...' or "
+            f"'[FAIL] gh-flow:autopilot ...') followed by "
+            f"'[step:gh-flow-autopilot/report] OK'. Output ZERO conversational text "
             f"before it — no recap, no per-step bullets, no progress headers."
         )
         return _block(reason, layer="L1.5")
@@ -573,12 +556,12 @@ def main() -> int:
     seen_count = len(steps)
     label = _STEP_LABELS.get(missing, missing)
     reason = (
-        f"devx-autopilot incomplete: {seen_count}/{len(REQUIRED_STEPS)} Stage-B "
+        f"gh-flow:autopilot incomplete: {seen_count}/{len(REQUIRED_STEPS)} Stage-B "
         f"step markers emitted since the flow started, and no terminal report "
-        f"('[OK] devx:autopilot' / '[FAIL] devx:autopilot') has been emitted yet. "
-        f"Per the CRITICAL CONTRACT in claude/skills/devx-autopilot/SKILL.md, you "
+        f"('[OK] gh-flow:autopilot' / '[FAIL] gh-flow:autopilot') has been emitted yet. "
+        f"Per the CRITICAL CONTRACT in the gh-flow:autopilot SKILL.md, you "
         f"MUST continue immediately. Next action: {label}; when it completes emit "
-        f"'[step:devx-autopilot/{missing}] OK'. Output ZERO conversational text — "
+        f"'[step:gh-flow-autopilot/{missing}] OK'. Output ZERO conversational text — "
         f"no recap, no markdown summary, no per-step bullets, no progress headers — "
         f"just the next step's work and its completion marker."
     )

--- a/claude/hooks/gh_issue_flow_stop_guard.py
+++ b/claude/hooks/gh_issue_flow_stop_guard.py
@@ -360,7 +360,7 @@ _HARNESS_INJECTION_RE: re.Pattern[str] = _line_anchored_alternation(_HARNESS_INJ
 #       (issue #608 — second wrapper-independent anchor, useful if the
 #       `<command-name>` / `Base directory` lines ever stop being emitted).
 #
-# (a)–(c) end on `(?![\w-])` rather than `\b`: a word boundary sits between
+# (a) and (c) end on `(?![\w-])` rather than `\b`: a word boundary sits between
 # `issue` and the `-relay` of the sibling `gh-flow:issue-relay`, so `\b` would
 # arm this six-step chain guard on a skill that has no such chain.
 #
@@ -898,13 +898,13 @@ def _count_fresh_user_prompts(messages: list[dict[str, Any]], start: int) -> int
 def _next_step_label(seen: list[str]) -> str:
     """Map the highest-index sub-skill seen to a human label for the *next* one.
 
-    Both names of the slot are quoted (#1678): the canonical dotfiles one the
-    model is most likely to have installed, and the post-migration alias. A
-    session running the `gh-flow-skills` plugin has only the latter, so naming
-    the canonical form alone would answer a block with an instruction to invoke
-    a skill that does not exist there. The canonical name stays first and
-    unparenthesised, which is also what keeps the existing
-    `"Step 2.2 — Skill(gh-pr-commit)"` substring assertions matching.
+    Both spellings of the slot are quoted: the hyphen form and the colon form
+    of the same `gh-flow-skills` skill. Claude Code accepts either, and which
+    one a transcript records depends on how the skill was invoked, so quoting
+    only one would answer a block with a name the session may never have
+    produced. The hyphen form stays first and unparenthesised, which is also
+    what keeps the existing `"Step 2.2 — Skill(gh-pr-commit)"` substring
+    assertions matching.
 
     The alias comes from `_SUB_SKILL_HINT_ALIAS`, keyed by slot — never from
     a position inside the slot's alias tuple.

--- a/claude/hooks/gh_issue_flow_stop_guard.py
+++ b/claude/hooks/gh_issue_flow_stop_guard.py
@@ -1,18 +1,18 @@
 #!/usr/bin/env python3
-"""Claude Code Stop hook: harness-level guard for /gh-issue-flow early-stop (issue #383).
+"""Claude Code Stop hook: harness-level guard for /gh-flow:issue early-stop (issue #383).
 
 Reads a `Stop` or `SubagentStop` event JSON from stdin, parses the
 conversation transcript, and emits a `block` decision when the model tries
-to end its turn while a gh-issue-flow chain is still in progress (6
+to end its turn while a gh-flow:issue chain is still in progress (6
 sub-skills + Step 3 report).
 
 Registered on BOTH turn-ending events (issue #1434): a subagent ending its
-turn fires `SubagentStop`, never `Stop`, so an unattended `gh:issue-flow`
+turn fires `SubagentStop`, never `Stop`, so an unattended `gh-flow:issue`
 dispatched inside a subagent (#1389) would otherwise run with the harness
 layer of the three-layer guard entirely absent.
 
 Failure mode being mitigated: the model self-authors a markdown success
-report between Skill() calls in Step 2 of gh-issue-flow and treats that
+report between Skill() calls in Step 2 of gh-flow:issue and treats that
 report as a turn-ending answer, even though `--no-next-hint` suppressed
 the sub-skill's own trailing `Next:` line. Prose rules in SKILL.md alone
 are not enough — the harness must mechanically force continuation.
@@ -27,7 +27,7 @@ Safety rails (each is critical — never accidentally trap the user):
     `_resolve_transcript_path`).
   - `stop_hook_active == True` → exit 0 (we already blocked once in this
     chain; bowing out prevents an infinite Stop→block→Stop loop).
-  - No gh-issue-flow boundary in the transcript → exit 0 (not our flow).
+  - No gh-flow:issue boundary in the transcript → exit 0 (not our flow).
   - Terminal Step 3 marker present → exit 0 (chain finished cleanly).
   - Boundary went stale (N fresh user prompts since it) → exit 0 (#1270).
   - `[flow:async-wait]` marker streak within the grace limit → exit 0
@@ -61,7 +61,7 @@ from typing import Any
 _TRACE_ENABLED: bool = os.environ.get("GH_ISSUE_FLOW_STOP_GUARD_TRACE") == "1"
 
 # Issue #1270 — how many *fresh* user prompts may accumulate after a
-# gh-issue-flow boundary before the hook declares that boundary stale and
+# gh-flow:issue boundary before the hook declares that boundary stale and
 # fails open. Without this valve a boundary lives forever: `stop_hook_active`
 # only prevents an infinite Stop→block→Stop loop *within* one turn, and it
 # resets the moment the user sends a new message, so a flow that never
@@ -109,7 +109,7 @@ def _trace(message: str, *, layer: str | None = None) -> None:
     Acceptance Criteria: standardize trace fields):
       - `L1`   — boundary detection (`_find_flow_boundary`)
       - `L1.5` — terminal-marker / sub-skill scan (`_scan_after_boundary`)
-      - `L2`   — state file (`.claude/.gh-issue-flow-state.json`, future)
+      - `L2`   — state file (`.claude/.gh-flow-issue-state.json`, future)
       - `L3`   — heartbeat cron (`CronCreate(durable=true)`, future)
     Boundary *expiry* (#1270) is scored `L1.5` even though it invalidates an
     `L1` boundary: it is decided purely from the post-boundary window that
@@ -125,47 +125,44 @@ def _trace(message: str, *, layer: str | None = None) -> None:
             pass
 
 
-# One entry per slot of the canonical 6-step gh-issue-flow chain; order
-# matters. Each entry lists EVERY name that addresses that slot — the
-# dotfiles-native pair (hyphen, colon) plus, since #1410 Phase 3, the
-# post-migration pair the skill answers to once installed from its own
-# plugin repo (D-12, issue #1678).
+# One entry per slot of the canonical 6-step gh-flow:issue chain; order
+# matters. Each entry lists both names that address that slot — the hyphen
+# form and the colon form of the skill now installed from its own plugin
+# repo (#1410 Phase 3, D-12).
 #
-# Why both, and not a swap: NF-1 keeps the dotfiles originals in place until
-# Phase 4, and the live automation in `shell-common/functions/gh_flow.sh` +
-# `shell-common/tools/custom/issue_watcher_cron.sh` still dispatches the old
-# slash commands. Narrowing this list to the new names would drop the
-# harness guard off that operational path the moment it landed; ignoring the
-# new names would leave anyone running the migrated plugin unguarded. Phase 4
-# removes the old forms, here and there, together.
+# The migration is COMPLETE (#1681, #1410 Phase 4-2): the dotfiles-native
+# originals (`gh-commit`, `gh:pr`, `devx:pr-review-all`, …) were deleted in
+# Phase 4-1 (#1680) and the automation in `shell-common/functions/gh_flow.sh`
+# + `shell-common/tools/custom/issue_watcher_cron.sh` was switched to the new
+# slash commands in Phase 4-3 (#1682), so listing the old forms here would
+# only match names nothing can invoke any more.
 #
 # Element 0 is the CANONICAL name of the slot: it is what `seen` records and
-# what `_next_step_label` quotes back to the model. It stays the old hyphen
-# form on purpose — the copy actually installed in this repo is still the one
-# the model is being told to invoke.
+# what `_next_step_label` quotes back to the model.
 EXPECTED_CHAIN: list[tuple[str, ...]] = [
-    # `gh-issue-implement`'s hyphen form is unchanged by the migration; only
-    # its colon form moves namespace (`gh:issue-implement` → `gh-issue:implement`).
-    ("gh-issue-implement", "gh:issue-implement", "gh-issue:implement"),
-    ("gh-commit", "gh:commit", "gh-pr-commit", "gh-pr:commit"),
-    ("gh-pr", "gh:pr", "gh-pr-create", "gh-pr:create"),
-    ("devx-pr-review-all", "devx:pr-review-all", "gh-verify-review-all", "gh-verify:review-all"),
-    ("gh-pr-resolve-conflict", "gh:pr-resolve-conflict", "gh-resolve-conflict", "gh-resolve:conflict"),
-    ("gh-pr-resolve-outdated", "gh:pr-resolve-outdated", "gh-resolve-outdated", "gh-resolve:outdated"),
+    ("gh-issue-implement", "gh-issue:implement"),
+    ("gh-pr-commit", "gh-pr:commit"),
+    ("gh-pr-create", "gh-pr:create"),
+    ("gh-verify-review-all", "gh-verify:review-all"),
+    ("gh-resolve-conflict", "gh-resolve:conflict"),
+    ("gh-resolve-outdated", "gh-resolve:outdated"),
 ]
 SUB_SKILL_NAMES: set[str] = {n for forms in EXPECTED_CHAIN for n in forms}
 
-# Alias → canonical slot name. This replaces the old `skill.replace(":", "-")`
-# normalization, which only ever worked because a slot's colon and hyphen
-# forms were the same string modulo the separator. That stops being true
-# under the migration — `gh-pr:commit` normalizes to `gh-pr-commit`, which is
-# NOT `gh-commit` — so the mapping has to be explicit or two aliases of one
-# slot would count as two distinct steps.
+# Alias → canonical slot name. Deliberately derived from EXPECTED_CHAIN
+# rather than computed with the old `skill.replace(":", "-")` normalization
+# (#1678): that shortcut only works while every slot's colon form is its
+# hyphen form modulo the separator, which the migration already broke once
+# (`gh-pr:commit` normalizes to `gh-pr-commit`, which was NOT the then-canonical
+# `gh-commit`). Reading the membership straight off the chain table cannot
+# drift that way, so a slot whose two forms diverge again still counts as one
+# step instead of two.
 _SUB_SKILL_CANONICAL: dict[str, str] = {n: forms[0] for forms in EXPECTED_CHAIN for n in forms}
 
 # The one alias `_next_step_label` quotes alongside the canonical name, so a
-# session running only the migrated plugin is told a skill it actually has.
-# Spelled out per slot rather than taken positionally out of EXPECTED_CHAIN
+# block names the slot in the colon form Claude Code's own slash-command
+# surface uses as well as the hyphen form. Spelled out per slot rather than
+# taken positionally out of EXPECTED_CHAIN
 # (`forms[-1]`): those tuples are alias *sets* whose order carries no meaning
 # past element 0, so adding a form later would silently change which name the
 # model is told to invoke (agy review, PR #1693). `_assert_hint_aliases_known`
@@ -173,11 +170,11 @@ _SUB_SKILL_CANONICAL: dict[str, str] = {n: forms[0] for forms in EXPECTED_CHAIN 
 # than a wrong hint at block time.
 _SUB_SKILL_HINT_ALIAS: dict[str, str] = {
     "gh-issue-implement": "gh-issue:implement",
-    "gh-commit": "gh-pr:commit",
-    "gh-pr": "gh-pr:create",
-    "devx-pr-review-all": "gh-verify:review-all",
-    "gh-pr-resolve-conflict": "gh-resolve:conflict",
-    "gh-pr-resolve-outdated": "gh-resolve:outdated",
+    "gh-pr-commit": "gh-pr:commit",
+    "gh-pr-create": "gh-pr:create",
+    "gh-verify-review-all": "gh-verify:review-all",
+    "gh-resolve-conflict": "gh-resolve:conflict",
+    "gh-resolve-outdated": "gh-resolve:outdated",
 }
 
 
@@ -200,7 +197,7 @@ def _assert_hint_aliases_known() -> None:
 _assert_hint_aliases_known()
 
 # Human-facing SKILL.md step labels, parallel to EXPECTED_CHAIN. These are
-# NOT derived arithmetically because gh-pr-resolve-outdated is labeled
+# NOT derived arithmetically because gh-resolve-outdated is labeled
 # "Step 2.5.1" in SKILL.md (it runs after the "Step 2.5" resolve-conflict
 # step), not "Step 2.6". Keep this list in lockstep with EXPECTED_CHAIN.
 STEP_LABELS: list[str] = [
@@ -213,16 +210,13 @@ STEP_LABELS: list[str] = [
 ]
 
 # Terminal Step 3 markers — presence in any assistant text after the
-# gh-issue-flow boundary means the flow has finished and the model may stop.
-# The `gh-flow:issue` / `gh-flow-issue` half is the post-migration name
-# (#1678, D-12). Each pattern keeps the trailing space or `(#` that follows
-# the skill name, which is also what keeps the sibling `gh-flow:issue-relay`
-# out: its name continues with `-relay` exactly where these demand a space.
+# gh-flow:issue boundary means the flow has finished and the model may stop.
+# `gh-flow:issue` / `gh-flow-issue` is the only namespace left after the
+# migration (#1681, #1410 Phase 4-2). Each pattern keeps the trailing space
+# or `(#` that follows the skill name, which is also what keeps the sibling
+# `gh-flow:issue-relay` out: its name continues with `-relay` exactly where
+# these demand a space.
 TERMINAL_PATTERNS: tuple[str, ...] = (
-    "gh:issue-flow complete (#",
-    "gh:issue-flow stopped at step",
-    "gh-issue-flow complete (#",
-    "gh-issue-flow stopped at step",
     "gh-flow:issue complete (#",
     "gh-flow:issue stopped at step",
     "gh-flow-issue complete (#",
@@ -235,29 +229,28 @@ TERMINAL_PATTERNS: tuple[str, ...] = (
 # Deliberately STRICTER than TERMINAL_PATTERNS: it demands a literal digit
 # exactly where the SKILL.md / report-template.md templates carry the
 # placeholders `<N>` and `<i>`. A command that merely mentions or greps the
-# template text — `grep "gh:issue-flow complete" SKILL.md`, `rg
-# 'gh:issue-flow stopped at step'` — therefore cannot match, while a real
-# report (`gh:issue-flow complete (#1270)`, `gh:issue-flow stopped at step
+# template text — `grep "gh-flow:issue complete" SKILL.md`, `rg
+# 'gh-flow:issue stopped at step'` — therefore cannot match, while a real
+# report (`gh-flow:issue complete (#1270)`, `gh-flow:issue stopped at step
 # 2/6`) does.
 #
-# The two namespaces are kept as SEPARATE alternatives rather than folded
-# into one character class (#1678 Error Cases): `gh[-:]issue-flow` and
-# `gh-flow[-:]issue` share no safe common shape, and a naive merge would
-# widen the match in ways neither name intends. The shared report shape is
-# factored out instead, so the two branches can never drift apart.
+# Only one namespace survives the migration (#1681, #1410 Phase 4-2), so the
+# pattern is a single branch. The report shape stays factored out because
+# `_TERMINAL_REPORT_SHAPE` is what carries the literal-digit strictness this
+# comment is about, and keeping it named is what makes that legible.
 _TERMINAL_REPORT_SHAPE: str = r"(?:complete\s+\(#\d+\)|stopped\s+at\s+step\s+\d)"
 _TERMINAL_COMMAND_RE: re.Pattern[str] = re.compile(
-    rf"(?:gh[-:]issue-flow|gh-flow[-:]issue)\s+{_TERMINAL_REPORT_SHAPE}",
+    rf"gh-flow[-:]issue\s+{_TERMINAL_REPORT_SHAPE}",
 )
 
 # Issue #1274 — report-SHAPE requirement, applied to the paired
 # `tool_result` only (never to the command; why: `_scan_after_boundary`).
-# `_TERMINAL_COMMAND_RE` alone still let `grep "gh:issue-flow complete
+# `_TERMINAL_COMMAND_RE` alone still let `grep "gh-flow:issue complete
 # (#1270)" some.log` terminate a flow: the command carries the literal-digit
 # marker and grep echoes the matched line straight back into the
 # tool_result, so both halves of the #1272 pair were satisfied by a plain
-# log search. A real Step 3 report is never one line — per
-# `claude/skills/gh-issue-flow/references/report-template.md` the success
+# log search. A real Step 3 report is never one line — per the
+# `gh-flow:issue` skill's `references/report-template.md` the success
 # form always carries a `PR URL:` line and the failure form a `Resume after
 # fix:` line, neither of which a single grepped marker line reproduces.
 # Kept as its own pattern (not folded into `_TERMINAL_COMMAND_RE`) because
@@ -324,7 +317,7 @@ _SKILL_EXPANSION_RE: re.Pattern[str] = _line_anchored_alternation(
 # `_SKILL_EXPANSION_MARKERS` above (which identifies an expanded SKILL.md
 # body), so it lives in its own tuple; both are consulted.
 #
-# WHY this exists: measured on a real 2489-entry gh-issue-flow transcript,
+# WHY this exists: measured on a real 2489-entry gh-flow:issue transcript,
 # `_count_fresh_user_prompts` reported 102 "fresh prompts" of which only 4
 # were human — 62 were Stop-hook feedback blocks (Claude Code re-injects
 # THIS hook's own `reason` string as a `role=user` text message) and 40 were
@@ -335,43 +328,43 @@ _SKILL_EXPANSION_RE: re.Pattern[str] = _line_anchored_alternation(
 # three background agents, guaranteeing that outcome.
 #
 # `isMeta` on the outer transcript entry is the primary defense; this tuple
-# is defense-in-depth for transcripts that lack the flag. `gh-issue-flow
+# is defense-in-depth for transcripts that lack the flag. `gh-flow:issue
 # incomplete:` is this hook's own block-reason prefix — exactly the string
 # that gets re-injected — so it is the strongest single signal available.
 _HARNESS_INJECTION_MARKERS: tuple[str, ...] = (
     "Stop hook feedback:",
-    "gh-issue-flow incomplete:",
+    "gh-flow:issue incomplete:",
     "<task-notification>",
     "[SYSTEM NOTIFICATION - NOT USER INPUT]",
     "<local-command-caveat>",
 )
 _HARNESS_INJECTION_RE: re.Pattern[str] = _line_anchored_alternation(_HARNESS_INJECTION_MARKERS)
 
-# Regex that marks the *start* of a gh-issue-flow chain in a user message.
+# Regex that marks the *start* of a gh-flow:issue chain in a user message.
 # Matches four real-world forms that user-typed slash commands take in Claude
-# Code transcripts (issues #607 / #609 / #608):
+# Code transcripts (issues #607 / #609 / #608), all in the post-migration
+# `gh-flow:issue` / `gh-flow-issue` namespace — the only one left once #1410
+# Phase 4-1 deleted the dotfiles originals (#1681, Phase 4-2):
 #
-#   (a) Raw `/gh-issue-flow ...` (or colon form `/gh:issue-flow ...`) at the
+#   (a) Raw `/gh-flow:issue ...` (or hyphen form `/gh-flow-issue ...`) at the
 #       start of a line — historical fixture form, still valid for tests
 #       and for users who paste the command into a longer message.
-#   (b) The `<command-name>/gh-issue-flow</command-name>` (or colon form)
+#   (b) The `<command-name>/gh-flow:issue</command-name>` (or hyphen form)
 #       wrapper that Claude Code emits when a user invokes the slash
 #       command interactively.
-#   (c) The `Base directory for this skill: …/gh-issue-flow` marker line
+#   (c) The `Base directory for this skill: …/gh-flow…/issue` marker line
 #       Claude Code emits when expanding a slash command into the
 #       SKILL.md prompt (issue #608 — defense in depth against future
 #       wrapper format drift; matches the resolved skill base path).
-#   (d) The SKILL.md H1 line `# gh:issue-flow — Issue → PR composition`
+#   (d) The SKILL.md H1 line `# gh-flow:issue — Issue → PR composition`
 #       (issue #608 — second wrapper-independent anchor, useful if the
 #       `<command-name>` / `Base directory` lines ever stop being emitted).
 #
-# Each of the four has a primed twin (a')–(d') for the post-migration
-# `gh-flow:issue` / `gh-flow-issue` namespace (#1678, D-12). Those twins end
-# on `(?![\w-])` rather than `\b`: a word boundary sits between `issue` and
-# the `-relay` of the sibling `gh-flow:issue-relay`, so `\b` would arm this
-# six-step chain guard on a skill that has no such chain.
+# (a)–(c) end on `(?![\w-])` rather than `\b`: a word boundary sits between
+# `issue` and the `-relay` of the sibling `gh-flow:issue-relay`, so `\b` would
+# arm this six-step chain guard on a skill that has no such chain.
 #
-# (c') allows arbitrary path segments between `gh-flow` and `/issue` because
+# (c) allows arbitrary path segments between `gh-flow` and `/issue` because
 # an installed plugin's base directory is not `<plugin>/skills/<skill>` —
 # measured, the two real Claude Code layouts are
 # `plugins/marketplaces/gh-flow-skills/skills/issue` and
@@ -379,7 +372,7 @@ _HARNESS_INJECTION_RE: re.Pattern[str] = _line_anchored_alternation(_HARNESS_INJ
 # pinned to one nesting depth silently matches neither.
 #
 # The `(?m)` prefix anchors `^` to per-line starts so a mid-sentence
-# mention like "I was reading about /gh-issue-flow..." stays out.
+# mention like "I was reading about /gh-flow:issue..." stays out.
 # False-positive guards for `tool_result` payloads (e.g. SKILL.md being
 # read by the model) are layered separately in `_iter_text_blocks(...,
 # include_tool_results=False)`.
@@ -387,32 +380,19 @@ _USER_BOUNDARY_RE: re.Pattern[str] = re.compile(
     r"""
     (?m)                                                    # multiline: ^ matches each line start
     (?:
-        ^\s*/gh[-:]issue-flow\b                             # (a) raw slash command
+        ^\s*/gh-flow[-:]issue(?![\w-])                       # (a) raw slash command
         |
-        <command-name>\s*/gh[-:]issue-flow\s*</command-name>  # (b) Claude Code wrapped form
-        |
-        ^Base\s+directory\s+for\s+this\s+skill:\s+.*gh-issue-flow\b  # (c) skill base dir
-        |
-        ^\#\s+gh:issue-flow\s+—\s+Issue\s+→\s+PR\s+composition\s*$  # (d) SKILL.md H1
-        |
-        ^\s*/gh-flow[-:]issue(?![\w-])                       # (a') new namespace
-        |
-        <command-name>\s*/gh-flow[-:]issue\s*</command-name>  # (b') new namespace
+        <command-name>\s*/gh-flow[-:]issue\s*</command-name>  # (b) Claude Code wrapped form
         |
         ^Base\s+directory\s+for\s+this\s+skill:\s+
-            .*gh-flow(?:-issue(?![\w-])|[\w./-]*/issue(?![\w-]))  # (c') new namespace
+            .*gh-flow(?:-issue(?![\w-])|[\w./-]*/issue(?![\w-]))  # (c) skill base dir
         |
-        ^\#\s+gh-flow:issue\s+—\s+Issue\s+→\s+PR\s+composition\s*$  # (d') new namespace
+        ^\#\s+gh-flow:issue\s+—\s+Issue\s+→\s+PR\s+composition\s*$  # (d) SKILL.md H1
     )
     """,
     re.VERBOSE,
 )
-FLOW_SKILL_NAMES: set[str] = {
-    "gh-issue-flow",
-    "gh:issue-flow",
-    "gh-flow-issue",
-    "gh-flow:issue",
-}
+FLOW_SKILL_NAMES: set[str] = {"gh-flow-issue", "gh-flow:issue"}
 
 
 def _allow(trace_reason: str = "", *, layer: str | None = None) -> int:
@@ -425,7 +405,7 @@ def _allow(trace_reason: str = "", *, layer: str | None = None) -> int:
 def _block(reason: str, *, layer: str | None = None) -> int:
     """Block the stop with a directive shown to the model."""
     json.dump({"decision": "block", "reason": reason}, sys.stdout)
-    _trace("block: gh-issue-flow incomplete — re-prompting model", layer=layer)
+    _trace("block: gh-flow:issue incomplete — re-prompting model", layer=layer)
     return 0
 
 
@@ -458,7 +438,7 @@ def _iter_text_blocks(message: dict[str, Any], include_tool_results: bool = Fals
     than removed) so future callers needing inclusive scans can opt in
     explicitly, but the safe default is now the default. In particular,
     the SKILL.md Step 3 template literally contains the lines
-    `gh:issue-flow complete (#<N>)` and `gh:issue-flow stopped at step
+    `gh-flow:issue complete (#<N>)` and `gh-flow:issue stopped at step
     <i>/5` as instructions; if those were visible to the terminal scan
     via tool_result, every Read of SKILL.md during a flow would falsely
     flag completion (issue #608, layer L1.5; PR #635 review tightening).
@@ -581,7 +561,7 @@ def _iter_tool_results(message: dict[str, Any]) -> list[tuple[str, str]]:
     Joined with `""`, not `"\\n"` (PR #1279 codex review): the sub-blocks are
     fragments of ONE underlying stdout string, and nothing guarantees the
     split points fall on line boundaries. Inserting a synthetic `"\\n"`
-    between two fragments that split mid-token (e.g. `"gh:issue-flow compl"`
+    between two fragments that split mid-token (e.g. `"gh-flow:issue compl"`
     + `"ete (#42)"`) would sever the very marker this function exists to
     detect — the opposite of `_count_fresh_user_prompts`'s join, which
     concatenates distinct, already-line-bounded *messages* and so safely
@@ -634,14 +614,14 @@ def _message_payload(entry: dict[str, Any]) -> dict[str, Any]:
 
 
 def _find_flow_boundary(messages: list[dict[str, Any]]) -> int:
-    """Return the index of the most recent gh-issue-flow START, or -1.
+    """Return the index of the most recent gh-flow:issue START, or -1.
 
     Boundary signals (role-restricted to avoid false positives from file
     content read into tool_result blocks — see PR #386 review feedback):
-      - assistant message: tool_use of Skill(gh-issue-flow | gh:issue-flow)
+      - assistant message: tool_use of Skill(gh-flow-issue | gh-flow:issue)
       - user message: text content matches `_USER_BOUNDARY_RE`, which
-        recognizes both the raw `/gh-issue-flow ...` form (line start) and
-        the `<command-name>/gh-issue-flow</command-name>` wrapper Claude
+        recognizes both the raw `/gh-flow:issue ...` form (line start) and
+        the `<command-name>/gh-flow:issue</command-name>` wrapper Claude
         Code emits when the user invokes the slash command interactively
         (issues #607 / #609). `tool_result` blocks are excluded so a file
         mentioning the command does not trip the boundary.
@@ -672,11 +652,11 @@ def _scan_after_boundary(messages: list[dict[str, Any]], start: int) -> tuple[bo
     motivation: the SKILL.md body (delivered as a `role=user` text
     block when Claude Code expands a slash command) literally contains
     the lines
-        gh:issue-flow complete (#<N>)
-        gh:issue-flow stopped at step <i>/5
+        gh-flow:issue complete (#<N>)
+        gh-flow:issue stopped at step <i>/5
     as Step 3 *instructions*. Without this restriction the scan would
     false-match those template lines and fail-open on every real
-    `/gh-issue-flow` invocation, defeating the harness guard. Sub-skill
+    `/gh-flow:issue` invocation, defeating the harness guard. Sub-skill
     invocation tracking is already restricted to assistant `tool_use`
     blocks (`_iter_skill_uses` only inspects that block type), so the
     skill counter is unaffected — only the terminal-marker scan
@@ -714,7 +694,7 @@ def _scan_after_boundary(messages: list[dict[str, Any]], start: int) -> tuple[bo
     also carry a report *field* line (`_TERMINAL_REPORT_FIELDS` — `PR
     URL:` for the success form, `Resume after fix:` for the failure form).
     The marker line alone used to be enough, which let `grep
-    "gh:issue-flow complete (#1270)" some.log` terminate a live flow: the
+    "gh-flow:issue complete (#1270)" some.log` terminate a live flow: the
     command holds a literal-digit marker and grep echoes the matched line
     back, satisfying both halves without any report being produced. A real
     Step 3 report is multi-line and always carries one of those fields, so
@@ -725,7 +705,7 @@ def _scan_after_boundary(messages: list[dict[str, Any]], start: int) -> tuple[bo
 
     Residual risk after #1274, stated honestly: a context-grep that happens
     to pull a real report's field line along with its marker line — e.g.
-    `grep -A5 "gh:issue-flow complete (#1270)" some.log` over a log that
+    `grep -A5 "gh-flow:issue complete (#1270)" some.log` over a log that
     stores a genuine past report. That is markedly more contrived than the
     bare `grep` it replaces (concrete issue number, matching the *live*
     flow's number, plus a context flag wide enough to reach the field
@@ -935,7 +915,7 @@ def _next_step_label(seen: list[str]) -> str:
         if name in seen:
             next_idx = i + 1
     if next_idx >= len(canonical):
-        return "Step 3 — emit the final 'gh:issue-flow complete (#N)' / 'gh-flow:issue complete (#N)' report"
+        return "Step 3 — emit the final 'gh-flow:issue complete (#N)' report"
     alias = _SUB_SKILL_HINT_ALIAS[canonical[next_idx]]
     return f"{STEP_LABELS[next_idx]} — Skill({canonical[next_idx]}) (or Skill({alias}))"
 
@@ -1016,7 +996,7 @@ def main() -> int:
 
     boundary = _find_flow_boundary(messages)
     if boundary < 0:
-        return _allow("no gh-issue-flow boundary in transcript", layer="L1")
+        return _allow("no gh-flow:issue boundary in transcript", layer="L1")
 
     terminal, seen = _scan_after_boundary(messages, boundary)
     # Issue #1270 — the fresh-prompt count feeds nothing but the expiry
@@ -1052,7 +1032,7 @@ def main() -> int:
     if limit > 0 and fresh_prompts >= limit:
         return _allow(
             f"stale boundary expiry — {fresh_prompts} fresh user prompt(s) since the "
-            f"gh-issue-flow boundary (limit {limit}); flow abandoned, failing open",
+            f"gh-flow:issue boundary (limit {limit}); flow abandoned, failing open",
             layer="L1.5",
         )
 
@@ -1073,10 +1053,10 @@ def main() -> int:
 
     next_label = _next_step_label(seen)
     reason = (
-        f"gh-issue-flow incomplete: {len(seen)}/{len(EXPECTED_CHAIN)} sub-skills invoked since the "
-        f"flow started, and no terminal Step 3 report ('gh:issue-flow complete' "
-        f"or 'gh:issue-flow stopped at step') has been emitted yet. Per the "
-        f"CRITICAL CONTRACT in claude/skills/gh-issue-flow/SKILL.md, you MUST "
+        f"gh-flow:issue incomplete: {len(seen)}/{len(EXPECTED_CHAIN)} sub-skills invoked since the "
+        f"flow started, and no terminal Step 3 report ('gh-flow:issue complete' "
+        f"or 'gh-flow:issue stopped at step') has been emitted yet. Per the "
+        f"CRITICAL CONTRACT in the gh-flow:issue SKILL.md, you MUST "
         f"continue immediately. Next action: {next_label}. Output ZERO "
         f"conversational text — no recap, no markdown summary, no per-step "
         f"bullets, no progress headers — just the next Skill() call (or, if all "

--- a/claude/hooks/gh_issue_flow_stop_guard.py
+++ b/claude/hooks/gh_issue_flow_stop_guard.py
@@ -235,12 +235,9 @@ TERMINAL_PATTERNS: tuple[str, ...] = (
 # 2/6`) does.
 #
 # Only one namespace survives the migration (#1681, #1410 Phase 4-2), so the
-# pattern is a single branch. The report shape stays factored out because
-# `_TERMINAL_REPORT_SHAPE` is what carries the literal-digit strictness this
-# comment is about, and keeping it named is what makes that legible.
-_TERMINAL_REPORT_SHAPE: str = r"(?:complete\s+\(#\d+\)|stopped\s+at\s+step\s+\d)"
+# pattern is a single branch.
 _TERMINAL_COMMAND_RE: re.Pattern[str] = re.compile(
-    rf"gh-flow[-:]issue\s+{_TERMINAL_REPORT_SHAPE}",
+    r"gh-flow[-:]issue\s+(?:complete\s+\(#\d+\)|stopped\s+at\s+step\s+\d)",
 )
 
 # Issue #1274 — report-SHAPE requirement, applied to the paired
@@ -328,12 +325,15 @@ _SKILL_EXPANSION_RE: re.Pattern[str] = _line_anchored_alternation(
 # three background agents, guaranteeing that outcome.
 #
 # `isMeta` on the outer transcript entry is the primary defense; this tuple
-# is defense-in-depth for transcripts that lack the flag. `gh-flow:issue
-# incomplete:` is this hook's own block-reason prefix — exactly the string
-# that gets re-injected — so it is the strongest single signal available.
+# is defense-in-depth for transcripts that lack the flag. `_BLOCK_REASON_PREFIX`
+# is this hook's own block-reason opener — exactly the string that gets
+# re-injected — so it is the strongest single signal available. It is shared
+# with the `_block()` reason rather than re-typed here: a rename that hit only
+# one side would reopen the #1270 self-defeat loop silently.
+_BLOCK_REASON_PREFIX: str = "gh-flow:issue incomplete:"
 _HARNESS_INJECTION_MARKERS: tuple[str, ...] = (
     "Stop hook feedback:",
-    "gh-flow:issue incomplete:",
+    _BLOCK_REASON_PREFIX,
     "<task-notification>",
     "[SYSTEM NOTIFICATION - NOT USER INPUT]",
     "<local-command-caveat>",
@@ -904,7 +904,7 @@ def _next_step_label(seen: list[str]) -> str:
     the canonical form alone would answer a block with an instruction to invoke
     a skill that does not exist there. The canonical name stays first and
     unparenthesised, which is also what keeps the existing
-    `"Step 2.2 — Skill(gh-commit)"` substring assertions matching.
+    `"Step 2.2 — Skill(gh-pr-commit)"` substring assertions matching.
 
     The alias comes from `_SUB_SKILL_HINT_ALIAS`, keyed by slot — never from
     a position inside the slot's alias tuple.
@@ -1053,7 +1053,7 @@ def main() -> int:
 
     next_label = _next_step_label(seen)
     reason = (
-        f"gh-flow:issue incomplete: {len(seen)}/{len(EXPECTED_CHAIN)} sub-skills invoked since the "
+        f"{_BLOCK_REASON_PREFIX} {len(seen)}/{len(EXPECTED_CHAIN)} sub-skills invoked since the "
         f"flow started, and no terminal Step 3 report ('gh-flow:issue complete' "
         f"or 'gh-flow:issue stopped at step') has been emitted yet. Per the "
         f"CRITICAL CONTRACT in the gh-flow:issue SKILL.md, you MUST "

--- a/claude/hooks/skill_completion_guard.py
+++ b/claude/hooks/skill_completion_guard.py
@@ -3,13 +3,13 @@
 
 Generalizes the boundary-detection / counting logic from
 `gh_issue_flow_stop_guard.py` (#383) into a catalog-driven guard that
-backstops INNER steps of individually-invoked skills (gh:issue-implement,
-gh:pr, gh:commit, …). The motivation is identical: prompt rules in
+backstops INNER steps of individually-invoked skills (gh-issue:implement,
+gh-pr:create, gh-pr:commit, …). The motivation is identical: prompt rules in
 SKILL.md alone are insufficient — the harness must mechanically force
 the model to emit a completion marker per step before allowing turn end.
 
 Sister hook of `gh_issue_flow_stop_guard.py`:
-  - That one guards the OUTER 5-sub-skill chain of `/gh-issue-flow`.
+  - That one guards the OUTER 6-sub-skill chain of `/gh-flow:issue`.
   - This one guards INNER required-step emit of each catalog skill.
   - Both can coexist on the Stop hook chain — if either says block, the
     model is re-prompted with the union of their reasons.
@@ -99,7 +99,7 @@ _DEFAULT_ASYNC_WAIT_LIMIT: int = 2
 # must read `tool_result` because the step markers come from a `printf` in a
 # Bash call. This marker is only ever the model's own turn-ending prose, and a
 # `tool_result` can carry arbitrary file content — including this file and
-# `claude/skills/gh-issue-flow/references/stop-guard.md`, both of which now
+# the gh-flow:issue skill's `references/stop-guard.md`, both of which now
 # document the marker literally. Reading tool_results here would
 # false-positive on any `Read` of those files (the issue #608 precedent).
 #

--- a/claude/hooks/skill_step_catalog.yml
+++ b/claude/hooks/skill_step_catalog.yml
@@ -57,19 +57,13 @@ gh-issue-implement:
     - implement
     - report
 
-# --- #1410 Phase 3 migration (#1677), Phase 4 cutover (#1681) ----------------
-# The eight commit-to-merge skills moved to the `gh-pr-skills` repo, where the
-# plugin namespace `gh-pr` plus the de-prefixed directory names `create` /
-# `commit` spell the markers below: `[step:gh-pr-create/<id>]` and
-# `[step:gh-pr-commit/<id>]`.
-#
-# The pre-migration `gh-pr` / `gh-commit` keys are gone with the dotfiles
-# originals they guarded (Phase 4-1 / #1680) — the migrated copies are now the
-# only thing that emits either step set.
+# Keys are the plugin-namespace marker names the migrated skills emit —
+# `[step:gh-pr-create/<id>]`, `[step:gh-pr-commit/<id>]` — from the
+# `gh-pr-skills` repo (#1410 Phase 3 / #1677, Phase 4 cutover / #1681).
 
 gh-pr-create:
   enforce: true
-  description: "Create Pull Request from current branch (gh-pr-skills)"
+  description: "Create Pull Request from current branch"
   required:
     - push-and-create
     - labels
@@ -78,7 +72,7 @@ gh-pr-create:
 
 gh-pr-commit:
   enforce: true
-  description: "Git commit with issue linking (gh-pr-skills)"
+  description: "Git commit with issue linking"
   required:
     - stage-commit
     - metrics-board-sync

--- a/claude/hooks/skill_step_catalog.yml
+++ b/claude/hooks/skill_step_catalog.yml
@@ -40,7 +40,7 @@
 #     `[flow:async-wait] step=<skill>/<step-id> agent=<id>
 #     reason=background-worker-delegated` line instead of its OK marker, for
 #     up to `GH_SKILL_GUARD_ASYNC_WAIT_LIMIT` turns (`0` disables). Default
-#     and mechanism: `claude/skills/gh-issue-flow/references/stop-guard.md`.
+#     and mechanism: the gh-flow:issue skill's `references/stop-guard.md`.
 #
 # Coexistence with gh_issue_flow_stop_guard.py:
 #   Stop hooks chain in `claude/settings.json` and run independently. Both
@@ -57,37 +57,15 @@ gh-issue-implement:
     - implement
     - report
 
-gh-pr:
-  enforce: true
-  description: "Create Pull Request from current branch"
-  required:
-    - push-and-create
-    - labels
-    - board-sync
-    - report
-
-gh-commit:
-  enforce: true
-  description: "Git commit with issue linking"
-  required:
-    - stage-commit
-    - metrics-board-sync
-    - report
-
-# --- #1410 Phase 3 migration (#1677) -----------------------------------------
+# --- #1410 Phase 3 migration (#1677), Phase 4 cutover (#1681) ----------------
 # The eight commit-to-merge skills moved to the `gh-pr-skills` repo, where the
 # plugin namespace `gh-pr` plus the de-prefixed directory names `create` /
-# `commit` spell markers the old keys above do not match. The migrated copies
-# therefore emit `[step:gh-pr-create/<id>]` and `[step:gh-pr-commit/<id>]`.
+# `commit` spell the markers below: `[step:gh-pr-create/<id>]` and
+# `[step:gh-pr-commit/<id>]`.
 #
-# The two keys below are ADDED, not renamed (#1677 D-12): the dotfiles
-# originals in `claude/skills/{gh-pr,gh-commit}/` are kept until Phase 4
-# (#1410 NF-1) and still emit the old markers, so deleting `gh-pr` / `gh-commit`
-# would strip their guard. Both paths are protected until Phase 4 removes the
-# originals and the old keys together.
-#
-# NF-4: each `required` list must stay identical to the key it mirrors —
-# migrating a skill does not change its steps.
+# The pre-migration `gh-pr` / `gh-commit` keys are gone with the dotfiles
+# originals they guarded (Phase 4-1 / #1680) — the migrated copies are now the
+# only thing that emits either step set.
 
 gh-pr-create:
   enforce: true

--- a/claude/setup.sh
+++ b/claude/setup.sh
@@ -381,7 +381,7 @@ _migrate_install_gh_issue_flow_stop_hook() {
     if [ "${existing_stop:-0}" -gt 0 ]; then
         log_warning "settings.json 에 다른 Stop hook 이 이미 있습니다 — 자동 머지 생략."
         log_warning "  수동 추가 필요: claude/hooks/gh_issue_flow_stop_guard.py"
-        log_warning "  참조: claude/skills/gh-issue-flow/references/stop-guard.md"
+        log_warning "  참조: gh-flow:issue 스킬의 references/stop-guard.md (gh-flow-skills 플러그인)"
         return 0
     fi
 

--- a/shell-common/functions/claude_stop_hook_install.sh
+++ b/shell-common/functions/claude_stop_hook_install.sh
@@ -1,15 +1,15 @@
 #!/bin/sh
 # shell-common/functions/claude_stop_hook_install.sh
 #
-# Auto-install the gh-issue-flow Stop hook into claude/settings.json on
+# Auto-install the gh-flow:issue Stop hook into claude/settings.json on
 # interactive shell startup (issue #505).
 #
 # Background: claude/setup.sh:_migrate_install_gh_issue_flow_stop_hook
 # already performs this migration, but it only runs when the user
 # explicitly re-executes setup.sh. Users on a multi-account layout
 # whose live settings.json predates issue #383 silently miss the hook —
-# the harness backstop documented in gh-issue-flow/SKILL.md never
-# fires, and /gh-issue-flow regresses to the early-stop pattern.
+# the harness backstop documented in the gh-flow:issue SKILL.md never
+# fires, and /gh-flow:issue regresses to the early-stop pattern.
 #
 # This helper closes that gap by re-running the same idempotent
 # migration on every interactive shell. Hot-path is silent (no jq
@@ -79,7 +79,7 @@ _claude_install_gh_issue_flow_stop_hook() {
     if jq --arg cmd "$_csh_hook_command" \
         '.hooks = ((.hooks // {}) | .Stop = ((.Stop // []) + [{"hooks":[{"type":"command","command":$cmd}]}]))' \
         "$_csh_source_file" >"$_csh_tmp" && command mv "$_csh_tmp" "$_csh_source_file"; then
-        echo "claude/settings.json: gh-issue-flow Stop hook 자동 등록 (issue #505 / #383, backup: $_csh_backup)" >&2
+        echo "claude/settings.json: gh-flow:issue Stop hook 자동 등록 (issue #505 / #383, backup: $_csh_backup)" >&2
         _csh_rc=0
     else
         command rm -f "$_csh_tmp"

--- a/tests/integration/test_devx_autopilot_stop_guard.py
+++ b/tests/integration/test_devx_autopilot_stop_guard.py
@@ -298,26 +298,13 @@ def test_boundary_surfaces(tmp_path: Path, label: str, boundary: str) -> None:
     assert json.loads(result.stdout)["decision"] == "block"
 
 
-def test_boundary_via_skill_tool_use(tmp_path: Path) -> None:
-    """Boundary can be a Skill(gh-flow-autopilot) tool_use, not just user text."""
+@pytest.mark.parametrize("skill", ["gh-flow-autopilot", "gh-flow:autopilot"])
+def test_boundary_via_skill_tool_use(tmp_path: Path, skill: str) -> None:
+    """Boundary can be a Skill() tool_use, not just user text — either form."""
     transcript = _write_transcript(
         tmp_path,
         [
-            _assistant_skill("gh-flow-autopilot"),
-            _step_markers_result("plan"),
-        ],
-    )
-    result = _run_hook(_hook_event(transcript))
-    assert result.returncode == 0
-    decision = json.loads(result.stdout)
-    assert decision["decision"] == "block"
-
-
-def test_boundary_via_colon_skill_tool_use(tmp_path: Path) -> None:
-    transcript = _write_transcript(
-        tmp_path,
-        [
-            _assistant_skill("gh-flow:autopilot"),
+            _assistant_skill(skill),
             _step_markers_result("plan"),
         ],
     )

--- a/tests/integration/test_devx_autopilot_stop_guard.py
+++ b/tests/integration/test_devx_autopilot_stop_guard.py
@@ -8,9 +8,9 @@ event['transcript_path'], and either:
   - exits 0 with `{"decision":"block","reason":"..."}` on stdout
     → block the stop and re-prompt the model.
 
-Unlike the gh-issue-flow guard (which counts sub-skill invocations),
-devx:autopilot's inline mode runs no implement sub-skill, so this guard
-tracks the ORDERED STEP MARKERS `[step:devx-autopilot/<id>] OK` that the
+Unlike the gh-flow:issue guard (which counts sub-skill invocations),
+gh-flow:autopilot's inline mode runs no implement sub-skill, so this guard
+tracks the ORDERED STEP MARKERS `[step:gh-flow-autopilot/<id>] OK` that the
 SKILL.md emits via printf. Because printf output lands in a Bash
 tool_result block, the step-marker scan includes tool_result payloads;
 the terminal scan does not (report-template.md text must not false-terminate).
@@ -169,10 +169,10 @@ def _step_markers_result(*step_ids: str) -> dict[str, Any]:
     """A tool_result block carrying the printf step markers for the given ids.
 
     This mirrors the real transcript shape: the SKILL.md emits
-    `printf '[step:devx-autopilot/<id>] OK\\n'`, whose stdout lands in a
+    `printf '[step:gh-flow-autopilot/<id>] OK\\n'`, whose stdout lands in a
     Bash tool_result block.
     """
-    body = "\n".join(f"[step:devx-autopilot/{sid}] OK" for sid in step_ids)
+    body = "\n".join(f"[step:gh-flow-autopilot/{sid}] OK" for sid in step_ids)
     return _user_tool_result(body)
 
 
@@ -237,7 +237,7 @@ def test_stop_hook_active_short_circuits(tmp_path: Path) -> None:
     transcript = _write_transcript(
         tmp_path,
         [
-            _user_text("/devx-autopilot"),
+            _user_text("/gh-flow:autopilot"),
             _step_markers_result("plan"),
         ],
     )
@@ -251,7 +251,7 @@ def test_malformed_jsonl_lines_skipped(tmp_path: Path) -> None:
     """Garbage lines in the middle of the transcript don't crash the hook."""
     p = tmp_path / "transcript.jsonl"
     with p.open("w", encoding="utf-8") as f:
-        f.write(json.dumps(_user_text("/devx-autopilot")) + "\n")
+        f.write(json.dumps(_user_text("/gh-flow:autopilot")) + "\n")
         f.write("not valid json at all {{{\n")
         f.write(json.dumps(_step_markers_result("plan")) + "\n")
         f.write("\n")  # blank line
@@ -266,75 +266,44 @@ def test_malformed_jsonl_lines_skipped(tmp_path: Path) -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_boundary_via_raw_slash_command(tmp_path: Path) -> None:
-    transcript = _write_transcript(
-        tmp_path,
-        [
-            _user_text("/devx-autopilot"),
-            _step_markers_result("plan"),
-        ],
-    )
+@pytest.mark.parametrize(
+    ("label", "boundary"),
+    [
+        ("colon-form", "/gh-flow:autopilot"),
+        ("hyphen-form", "/gh-flow-autopilot"),
+        ("command-name-wrapper", "<command-name>/gh-flow:autopilot</command-name>"),
+        (
+            "skill-base-dir-marketplace",
+            "Base directory for this skill: /home/u/.claude/plugins/marketplaces/gh-flow-skills/skills/autopilot",
+        ),
+        (
+            "skill-base-dir-cache",
+            "Base directory for this skill: "
+            "/home/u/.claude/plugins/cache/gh-flow-skills/gh-flow/0.1.0/skills/autopilot",
+        ),
+        ("skill-base-dir-flat", "Base directory for this skill: /home/u/.claude/skills/gh-flow/skills/autopilot"),
+        ("skill-h1", "# gh-flow:autopilot — spec → PR"),
+    ],
+)
+def test_boundary_surfaces(tmp_path: Path, label: str, boundary: str) -> None:
+    """Every boundary surface (a)-(d) arms the guard.
+
+    Without a boundary the guard never looks for a step marker at all, so
+    each surface is load-bearing on its own.
+    """
+    transcript = _write_transcript(tmp_path, [_user_text(boundary), _assistant_text("done!")])
     result = _run_hook(_hook_event(transcript))
     assert result.returncode == 0
-    decision = json.loads(result.stdout)
-    assert decision["decision"] == "block"
-
-
-def test_boundary_via_command_name_wrapper(tmp_path: Path) -> None:
-    content = (
-        "<command-message>devx-autopilot</command-message>\n"
-        "<command-name>/devx-autopilot</command-name>\n"
-        "<command-args></command-args>\n"
-    )
-    transcript = _write_transcript(
-        tmp_path,
-        [
-            {"type": "user", "message": {"role": "user", "content": content}},
-            _step_markers_result("plan"),
-        ],
-    )
-    result = _run_hook(_hook_event(transcript))
-    assert result.returncode == 0
-    decision = json.loads(result.stdout)
-    assert decision["decision"] == "block"
-
-
-def test_boundary_via_base_dir_line(tmp_path: Path) -> None:
-    content = "Base directory for this skill: /home/user/.claude/skills/devx-autopilot\n"
-    transcript = _write_transcript(
-        tmp_path,
-        [
-            {"type": "user", "message": {"role": "user", "content": content}},
-            _step_markers_result("plan"),
-        ],
-    )
-    result = _run_hook(_hook_event(transcript))
-    assert result.returncode == 0
-    decision = json.loads(result.stdout)
-    assert decision["decision"] == "block"
-
-
-def test_boundary_via_h1_line(tmp_path: Path) -> None:
-    content = "# devx:autopilot — Stage-B 자율 실행 (spec → PR)\n"
-    transcript = _write_transcript(
-        tmp_path,
-        [
-            {"type": "user", "message": {"role": "user", "content": content}},
-            _step_markers_result("plan"),
-        ],
-    )
-    result = _run_hook(_hook_event(transcript))
-    assert result.returncode == 0
-    decision = json.loads(result.stdout)
-    assert decision["decision"] == "block"
+    assert result.stdout.strip(), f"{label}: expected a block, got empty stdout"
+    assert json.loads(result.stdout)["decision"] == "block"
 
 
 def test_boundary_via_skill_tool_use(tmp_path: Path) -> None:
-    """Boundary can be a Skill(devx-autopilot) tool_use, not just user text."""
+    """Boundary can be a Skill(gh-flow-autopilot) tool_use, not just user text."""
     transcript = _write_transcript(
         tmp_path,
         [
-            _assistant_skill("devx-autopilot"),
+            _assistant_skill("gh-flow-autopilot"),
             _step_markers_result("plan"),
         ],
     )
@@ -348,7 +317,7 @@ def test_boundary_via_colon_skill_tool_use(tmp_path: Path) -> None:
     transcript = _write_transcript(
         tmp_path,
         [
-            _assistant_skill("devx:autopilot"),
+            _assistant_skill("gh-flow:autopilot"),
             _step_markers_result("plan"),
         ],
     )
@@ -363,7 +332,7 @@ def test_mid_sentence_mention_not_a_boundary(tmp_path: Path) -> None:
         tmp_path,
         [
             _user_text(
-                "I was reading the docs about /devx-autopilot and got confused — "
+                "I was reading the docs about /gh-flow:autopilot and got confused — "
                 "could you summarize how the chain works?"
             ),
             _assistant_text("Sure — here's a summary: ..."),
@@ -384,7 +353,7 @@ def test_mid_flow_only_plan_and_issue_blocks_naming_mode(tmp_path: Path) -> None
     transcript = _write_transcript(
         tmp_path,
         [
-            _user_text("/devx-autopilot"),
+            _user_text("/gh-flow:autopilot"),
             _step_markers_result("plan", "issue"),
             # The model writes a fake-looking progress note but no terminal report.
             _assistant_text("plan and issue done, continuing..."),
@@ -405,7 +374,7 @@ def test_mid_flow_partial_markers_split_across_results(tmp_path: Path) -> None:
     transcript = _write_transcript(
         tmp_path,
         [
-            _user_text("/devx-autopilot"),
+            _user_text("/gh-flow:autopilot"),
             _step_markers_result("plan"),
             _step_markers_result("issue"),
             _step_markers_result("mode"),
@@ -417,17 +386,17 @@ def test_mid_flow_partial_markers_split_across_results(tmp_path: Path) -> None:
     decision = json.loads(result.stdout)
     assert decision["decision"] == "block"
     # First missing after implement is pr.
-    assert "gh:pr" in decision["reason"] or "pr" in decision["reason"]
+    assert "gh-pr:create" in decision["reason"]
     assert "4/7" in decision["reason"]
 
 
 def test_partial_marker_without_ok_does_not_count(tmp_path: Path) -> None:
-    """A `[step:devx-autopilot/plan]` without ` OK` must not satisfy the step."""
+    """A `[step:gh-flow-autopilot/plan]` without ` OK` must not satisfy the step."""
     transcript = _write_transcript(
         tmp_path,
         [
-            _user_text("/devx-autopilot"),
-            _user_tool_result("[step:devx-autopilot/plan]\n(no OK suffix here)"),
+            _user_text("/gh-flow:autopilot"),
+            _user_tool_result("[step:gh-flow-autopilot/plan]\n(no OK suffix here)"),
         ],
     )
     result = _run_hook(_hook_event(transcript))
@@ -445,7 +414,7 @@ def test_all_steps_present_but_no_terminal_blocks_for_report(tmp_path: Path) -> 
     transcript = _write_transcript(
         tmp_path,
         [
-            _user_text("/devx-autopilot"),
+            _user_text("/gh-flow:autopilot"),
             _step_markers_result("plan", "issue", "mode", "implement", "pr", "simplify", "pr-reply"),
             # No terminal report yet.
         ],
@@ -464,68 +433,51 @@ def test_all_steps_present_but_no_terminal_blocks_for_report(tmp_path: Path) -> 
 # ---------------------------------------------------------------------------
 
 
-def test_terminal_ok_marker_in_assistant_text_allows_stop(tmp_path: Path) -> None:
-    """A real `[OK] devx:autopilot` in assistant text ends the flow."""
+@pytest.mark.parametrize(
+    ("label", "terminal"),
+    [
+        ("report-marker", "[step:gh-flow-autopilot/report] OK"),
+        ("ok-report", "[OK] gh-flow:autopilot #1678 — PR https://github.com/o/r/pull/1"),
+        ("fail-report", "[FAIL] gh-flow:autopilot #1678 — stopped at Step 3"),
+    ],
+)
+def test_terminal_markers_allow_stop(tmp_path: Path, label: str, terminal: str) -> None:
+    """Each terminal marker ends the flow — even with steps still outstanding.
+
+    Only 3 of the 7 step markers are present, so this also pins the ordering
+    inside the hook: the terminal check runs BEFORE the missing-step check
+    (a `[FAIL]` hard stop is legitimate mid-chain).
+    """
     transcript = _write_transcript(
         tmp_path,
         [
-            _user_text("/devx-autopilot"),
-            _step_markers_result("plan", "issue", "mode", "implement", "pr", "simplify", "pr-reply"),
-            _assistant_text("[OK] devx:autopilot 완료 — my-feature-design.md\n  PR: #42"),
-        ],
-    )
-    result = _run_hook(_hook_event(transcript))
-    assert result.returncode == 0
-    assert result.stdout.strip() == ""
-
-
-def test_terminal_report_step_marker_in_assistant_text_allows_stop(tmp_path: Path) -> None:
-    """`[step:devx-autopilot/report] OK` echoed in assistant text is terminal."""
-    transcript = _write_transcript(
-        tmp_path,
-        [
-            _user_text("/devx-autopilot"),
-            _step_markers_result("plan", "issue", "mode", "implement", "pr", "simplify", "pr-reply"),
-            _assistant_text("[step:devx-autopilot/report] OK"),
-        ],
-    )
-    result = _run_hook(_hook_event(transcript))
-    assert result.returncode == 0
-    assert result.stdout.strip() == ""
-
-
-def test_terminal_fail_marker_in_assistant_text_allows_stop(tmp_path: Path) -> None:
-    """A `[FAIL] devx:autopilot` hard-stop report also ends the flow."""
-    transcript = _write_transcript(
-        tmp_path,
-        [
-            _user_text("/devx-autopilot"),
+            _user_text("/gh-flow:autopilot"),
             _step_markers_result("plan", "issue", "mode"),
-            _assistant_text("[FAIL] devx:autopilot 정지 — Step 2 (구현)"),
+            _assistant_text(terminal),
         ],
     )
     result = _run_hook(_hook_event(transcript))
     assert result.returncode == 0
-    assert result.stdout.strip() == ""
+    assert result.stdout.strip() == "", f"{label}: expected allow, got {result.stdout!r}"
 
 
 def test_report_template_text_in_tool_result_does_not_terminate(tmp_path: Path) -> None:
     """L1.5 false-positive guard: report-template.md text (which literally
-    contains `[OK] devx:autopilot 완료`) read into a tool_result during a
+    contains `[OK] gh-flow:autopilot 완료`) read into a tool_result during a
     real flow must NOT count as a terminal marker → still block.
     """
     template_excerpt = (
         "# Report Templates\n\n"
         "## 성공 ([OK])\n"
-        "    [OK] devx:autopilot 완료 — <spec 파일명>\n"
+        "    [OK] gh-flow:autopilot 완료 — <spec 파일명>\n"
         "    - 이슈:   #<N>  <issue-url>\n"
         "## 실패 ([FAIL])\n"
-        "    [FAIL] devx:autopilot 정지 — Step <k>\n"
+        "    [FAIL] gh-flow:autopilot 정지 — Step <k>\n"
     )
     transcript = _write_transcript(
         tmp_path,
         [
-            _user_text("/devx-autopilot"),
+            _user_text("/gh-flow:autopilot"),
             _step_markers_result("plan", "issue"),
             # Model reads the report template while mid-flow.
             _user_tool_result(template_excerpt),
@@ -546,7 +498,7 @@ def test_report_template_text_in_tool_result_does_not_terminate(tmp_path: Path) 
 def test_step_marker_in_doc_read_as_tool_result_is_fail_open_safe(tmp_path: Path) -> None:
     """Documented behavior: step markers are counted from tool_result on
     purpose (that is where the SKILL.md printf output lands). So if a doc
-    that quotes `[step:devx-autopilot/<id>] OK` is read into a tool_result
+    that quotes `[step:gh-flow-autopilot/<id>] OK` is read into a tool_result
     during a real flow, those ids count toward the step set — a fail-OPEN
     direction (it can only let a stop through sooner, never trap the user).
 
@@ -557,7 +509,7 @@ def test_step_marker_in_doc_read_as_tool_result_is_fail_open_safe(tmp_path: Path
     doc_quoting_markers = (
         "The autopilot skill emits, in order:\n"
         + "\n".join(
-            f"[step:devx-autopilot/{sid}] OK"
+            f"[step:gh-flow-autopilot/{sid}] OK"
             for sid in ("plan", "issue", "mode", "implement", "pr", "simplify", "pr-reply")
         )
         + "\n"
@@ -565,7 +517,7 @@ def test_step_marker_in_doc_read_as_tool_result_is_fail_open_safe(tmp_path: Path
     transcript = _write_transcript(
         tmp_path,
         [
-            _user_text("/devx-autopilot"),
+            _user_text("/gh-flow:autopilot"),
             _user_tool_result(doc_quoting_markers),
         ],
     )
@@ -588,7 +540,7 @@ def test_trace_off_by_default_no_stderr(tmp_path: Path) -> None:
     transcript = _write_transcript(
         tmp_path,
         [
-            _user_text("/devx-autopilot"),
+            _user_text("/gh-flow:autopilot"),
             _step_markers_result("plan"),
         ],
     )
@@ -604,7 +556,7 @@ def test_trace_on_emits_block_diagnostics(tmp_path: Path) -> None:
     transcript = _write_transcript(
         tmp_path,
         [
-            _user_text("/devx-autopilot"),
+            _user_text("/gh-flow:autopilot"),
             _step_markers_result("plan"),
         ],
     )
@@ -632,7 +584,7 @@ def test_trace_on_emits_allow_reason_for_no_boundary(tmp_path: Path) -> None:
     assert result.returncode == 0
     assert result.stdout.strip() == ""
     assert "[autopilot-stop-guard] allow:" in result.stderr
-    assert "no devx-autopilot boundary" in result.stderr
+    assert "no gh-flow-autopilot boundary" in result.stderr
 
 
 # ---------------------------------------------------------------------------
@@ -649,7 +601,7 @@ def test_three_fresh_user_prompts_expire_the_boundary(tmp_path: Path) -> None:
     transcript = _write_transcript(
         tmp_path,
         [
-            _user_text("/devx-autopilot"),
+            _user_text("/gh-flow:autopilot"),
             _step_markers_result("plan"),
             _user_text("actually, forget that — what does mise tasks list?"),
             _assistant_text("It lists the repo's lint/test tasks."),
@@ -662,7 +614,7 @@ def test_three_fresh_user_prompts_expire_the_boundary(tmp_path: Path) -> None:
     result = _run_hook(_hook_event(transcript))
     assert result.returncode == 0
     assert result.stdout.strip() == "", (
-        f"Stale devx-autopilot boundary kept blocking unrelated turns. stdout={result.stdout!r}"
+        f"Stale gh-flow:autopilot boundary kept blocking unrelated turns. stdout={result.stdout!r}"
     )
 
 
@@ -671,7 +623,7 @@ def test_boundary_expiry_reported_in_trace(tmp_path: Path) -> None:
     transcript = _write_transcript(
         tmp_path,
         [
-            _user_text("/devx-autopilot"),
+            _user_text("/gh-flow:autopilot"),
             _step_markers_result("plan"),
             _user_text("unrelated question one"),
             _user_text("unrelated question two"),
@@ -694,7 +646,7 @@ def test_two_fresh_user_prompts_still_block(tmp_path: Path) -> None:
     transcript = _write_transcript(
         tmp_path,
         [
-            _user_text("/devx-autopilot"),
+            _user_text("/gh-flow:autopilot"),
             _user_text("wait, is the PR going to close the issue?"),
             _assistant_text("Yes, via Closes #1275."),
             _user_text("ok continue"),
@@ -714,7 +666,7 @@ def test_skill_expansion_user_messages_are_not_fresh_prompts(tmp_path: Path) -> 
     transcript = _write_transcript(
         tmp_path,
         [
-            _user_text("/devx-autopilot"),
+            _user_text("/gh-flow:autopilot"),
             _user_text("Base directory for this skill: /home/user/.claude/skills/gh-issue-create\n"),
             _assistant_skill("gh-issue-create"),
             _user_text("<command-message>gh-pr</command-message>\n<command-args></command-args>\n"),
@@ -741,7 +693,7 @@ def test_tool_result_messages_are_not_fresh_prompts(tmp_path: Path) -> None:
     transcript = _write_transcript(
         tmp_path,
         [
-            _user_text("/devx-autopilot"),
+            _user_text("/gh-flow:autopilot"),
             _step_markers_result("plan"),
             _user_tool_result("tests: 42 passed"),
             _user_tool_result("commit abc123 created"),
@@ -766,7 +718,7 @@ def test_system_reminder_only_user_message_is_not_a_fresh_prompt(
     transcript = _write_transcript(
         tmp_path,
         [
-            _user_text("/devx-autopilot"),
+            _user_text("/gh-flow:autopilot"),
             _step_markers_result("plan"),
             _user_text(reminder),
             _user_text(reminder),
@@ -787,7 +739,7 @@ def test_expiry_disabled_by_env_zero(tmp_path: Path) -> None:
     transcript = _write_transcript(
         tmp_path,
         [
-            _user_text("/devx-autopilot"),
+            _user_text("/gh-flow:autopilot"),
             _step_markers_result("plan"),
             *[_user_text(f"unrelated prompt {i}") for i in range(5)],
         ],
@@ -806,7 +758,7 @@ def test_expiry_limit_configurable_via_env(tmp_path: Path) -> None:
     transcript = _write_transcript(
         tmp_path,
         [
-            _user_text("/devx-autopilot"),
+            _user_text("/gh-flow:autopilot"),
             _step_markers_result("plan"),
             _user_text("never mind, different topic now"),
         ],
@@ -822,7 +774,7 @@ def test_expiry_limit_configurable_via_env(tmp_path: Path) -> None:
 def test_invalid_expiry_env_falls_back_to_default(tmp_path: Path) -> None:
     """An unparseable / negative value degrades to the default of 3."""
     two_prompts = [
-        _user_text("/devx-autopilot"),
+        _user_text("/gh-flow:autopilot"),
         _step_markers_result("plan"),
         _user_text("question one"),
         _user_text("question two"),
@@ -841,7 +793,7 @@ def test_invalid_expiry_env_falls_back_to_default(tmp_path: Path) -> None:
 # ---------------------------------------------------------------------------
 # Issue #1275 — fresh-prompt counter over/under-counting.
 #
-# Measured on gh-issue-flow's twin guard (PR #1272): a naive `role=user` count
+# Measured on gh-flow:issue's twin guard (PR #1272): a naive `role=user` count
 # saw 102 "fresh prompts" on a real transcript of which only 4 were human —
 # the rest were Stop-hook feedback re-injections and `<task-notification>`
 # background-subagent completions, so the limit of 3 was hit mid-flow and the
@@ -856,7 +808,7 @@ def test_ismeta_user_messages_are_not_fresh_prompts(tmp_path: Path) -> None:
     transcript = _write_transcript(
         tmp_path,
         [
-            _user_text("/devx-autopilot"),
+            _user_text("/gh-flow:autopilot"),
             _step_markers_result("plan"),
             _user_meta_text("please continue with the next step"),
             _user_meta_text("keep going, do not stop"),
@@ -879,11 +831,11 @@ def test_ismeta_user_messages_are_not_fresh_prompts(tmp_path: Path) -> None:
             # this is the self-defeat loop: every block the guard emits comes back
             # as a "fresh user prompt", and three of them would expire the guard's
             # own boundary.
-            "Stop hook feedback: devx-autopilot incomplete: 1/7 Stage-B step markers "
-            "emitted since the flow started, and no terminal report "
-            "('[OK] devx:autopilot' / '[FAIL] devx:autopilot') has been emitted yet. "
-            "Per the CRITICAL CONTRACT in claude/skills/devx-autopilot/SKILL.md, you "
-            "MUST continue immediately. Next action: Step 0b — Skill(gh:issue-create).",
+            "Stop hook feedback: gh-flow:autopilot incomplete: 1/7 Stage-B step "
+            "markers emitted since the flow started, and no terminal report "
+            "('[OK] gh-flow:autopilot' / '[FAIL] gh-flow:autopilot') has been emitted "
+            "yet. Per the CRITICAL CONTRACT in the gh-flow:autopilot SKILL.md, you "
+            "MUST continue immediately. Next action: Step 0b — Skill(gh-issue:create).",
         ),
         (
             "task-notification",
@@ -902,7 +854,7 @@ def test_harness_injection_markers_are_not_fresh_prompts(tmp_path: Path, label: 
     transcript = _write_transcript(
         tmp_path,
         [
-            _user_text("/devx-autopilot"),
+            _user_text("/gh-flow:autopilot"),
             _step_markers_result("plan"),
             _user_text(notice),
             _user_text(notice),
@@ -927,7 +879,7 @@ def test_mixed_text_and_tool_result_message_counts_as_fresh_prompt(
     transcript = _write_transcript(
         tmp_path,
         [
-            _user_text("/devx-autopilot"),
+            _user_text("/gh-flow:autopilot"),
             _step_markers_result("plan"),
             _user_text_with_tool_result("stop that — what does mise tasks list?"),
             _user_text_with_tool_result("and where is the zsh env file?"),
@@ -949,7 +901,7 @@ def test_tool_result_only_message_still_not_a_fresh_prompt(tmp_path: Path) -> No
     transcript = _write_transcript(
         tmp_path,
         [
-            _user_text("/devx-autopilot"),
+            _user_text("/gh-flow:autopilot"),
             _user_tool_result("tests: 42 passed"),
             _user_tool_result("commit abc123 created"),
             _user_tool_result("PR https://x/pull/9 opened"),
@@ -992,7 +944,7 @@ def test_quoted_marker_mid_sentence_still_counts_as_fresh_prompt(tmp_path: Path,
     transcript = _write_transcript(
         tmp_path,
         [
-            _user_text("/devx-autopilot"),
+            _user_text("/gh-flow:autopilot"),
             _step_markers_result("plan"),
             _user_text(prompt),
         ],
@@ -1022,9 +974,9 @@ def test_already_loaded_injection_alone_is_not_a_fresh_prompt(tmp_path: Path) ->
     transcript = _write_transcript(
         tmp_path,
         [
-            _user_text("/devx-autopilot"),
+            _user_text("/gh-flow:autopilot"),
             _step_markers_result("plan"),
-            _user_text("Skill /devx-autopilot is already loaded above; instructions unchanged. Arguments: "),
+            _user_text("Skill /gh-flow:autopilot is already loaded above; instructions unchanged. Arguments: "),
         ],
     )
     result = _run_hook(
@@ -1056,7 +1008,7 @@ def test_marker_quoted_at_true_line_start_is_still_not_a_fresh_prompt(tmp_path: 
     transcript = _write_transcript(
         tmp_path,
         [
-            _user_text("/devx-autopilot"),
+            _user_text("/gh-flow:autopilot"),
             _step_markers_result("plan"),
             _user_text("Stop hook feedback: I'm quoting this exactly to ask you about it."),
         ],
@@ -1103,144 +1055,8 @@ def test_hook_callable_two_ways(tmp_path: Path, exec_form: list[str]) -> None:
 
 
 # ---------------------------------------------------------------------------
-# D-12 dual-form namespace recognition (#1678)
-#
-# Phase 3 of #1410 migrates this skill into the `gh-flow-skills` repo as
-# `gh-flow:autopilot`, while NF-1 keeps the dotfiles original (emitting the
-# old `[step:devx-autopilot/...]` markers) alive until Phase 4. The guard
-# must recognize BOTH marker namespaces at once. Every case below is an
-# ADDITION — no existing assertion above is modified (issue #1678, NF-4).
+# Post-migration step labels (#1678 F-9)
 # ---------------------------------------------------------------------------
-
-
-def _step_markers_result_new(*step_ids: str) -> dict[str, Any]:
-    """`_step_markers_result`'s post-migration twin (`gh-flow-autopilot`)."""
-    body = "\n".join(f"[step:gh-flow-autopilot/{sid}] OK" for sid in step_ids)
-    return _user_tool_result(body)
-
-
-@pytest.mark.parametrize(
-    ("label", "boundary"),
-    [
-        ("colon-form", "/gh-flow:autopilot"),
-        ("hyphen-form", "/gh-flow-autopilot"),
-        ("command-name-wrapper", "<command-name>/gh-flow:autopilot</command-name>"),
-        (
-            "skill-base-dir-marketplace",
-            "Base directory for this skill: /home/u/.claude/plugins/marketplaces/gh-flow-skills/skills/autopilot",
-        ),
-        (
-            "skill-base-dir-cache",
-            "Base directory for this skill: "
-            "/home/u/.claude/plugins/cache/gh-flow-skills/gh-flow/0.1.0/skills/autopilot",
-        ),
-        ("skill-base-dir-flat", "Base directory for this skill: /home/u/.claude/skills/gh-flow/skills/autopilot"),
-        ("skill-h1", "# gh-flow:autopilot — spec → PR"),
-    ],
-)
-def test_new_namespace_boundary_surfaces(tmp_path: Path, label: str, boundary: str) -> None:
-    """The post-migration name opens a Stage-B flow on every boundary surface.
-
-    Without this the F-9 marker widening would be unreachable: the guard
-    never arms, so it never looks for a marker in either namespace.
-    """
-    transcript = _write_transcript(tmp_path, [_user_text(boundary), _assistant_text("done!")])
-    result = _run_hook(_hook_event(transcript))
-    assert result.returncode == 0
-    assert result.stdout.strip(), f"{label}: expected a block, got empty stdout"
-    assert json.loads(result.stdout)["decision"] == "block"
-
-
-def test_new_namespace_step_markers_are_counted(tmp_path: Path) -> None:
-    """`[step:gh-flow-autopilot/<id>] OK` satisfies the same required steps."""
-    transcript = _write_transcript(
-        tmp_path,
-        [
-            _user_text("/gh-flow:autopilot"),
-            _step_markers_result_new("plan", "issue"),
-            _assistant_text("continuing..."),
-        ],
-    )
-    result = _run_hook(_hook_event(transcript))
-    assert result.returncode == 0
-    decision = json.loads(result.stdout)
-    assert decision["decision"] == "block"
-    assert "2/7" in decision["reason"], decision["reason"]
-    assert "mode" in decision["reason"], decision["reason"]
-
-
-def test_old_namespace_step_markers_still_counted_after_widening(tmp_path: Path) -> None:
-    """Regression twin of the case above: the old marker keeps working."""
-    transcript = _write_transcript(
-        tmp_path,
-        [
-            _user_text("/gh-flow:autopilot"),
-            _step_markers_result("plan", "issue"),
-            _assistant_text("continuing..."),
-        ],
-    )
-    result = _run_hook(_hook_event(transcript))
-    assert result.returncode == 0
-    decision = json.loads(result.stdout)
-    assert decision["decision"] == "block"
-    assert "2/7" in decision["reason"], decision["reason"]
-
-
-def test_mixed_namespace_step_markers_reach_all_seven(tmp_path: Path) -> None:
-    """A run that switches namespace mid-flow still completes its step set."""
-    transcript = _write_transcript(
-        tmp_path,
-        [
-            _user_text("/devx-autopilot"),
-            _step_markers_result("plan", "issue", "mode"),
-            _step_markers_result_new("implement", "pr", "simplify", "pr-reply"),
-            _assistant_text("continuing..."),
-        ],
-    )
-    result = _run_hook(_hook_event(transcript))
-    assert result.returncode == 0
-    decision = json.loads(result.stdout)
-    assert decision["decision"] == "block"
-    assert "all 7 Stage-B step" in decision["reason"], decision["reason"]
-
-
-@pytest.mark.parametrize(
-    ("label", "terminal"),
-    [
-        ("report-marker", "[step:gh-flow-autopilot/report] OK"),
-        ("ok-report", "[OK] gh-flow:autopilot #1678 — PR https://github.com/o/r/pull/1"),
-        ("fail-report", "[FAIL] gh-flow:autopilot #1678 — stopped at Step 3"),
-    ],
-)
-def test_new_namespace_terminal_markers_allow_stop(tmp_path: Path, label: str, terminal: str) -> None:
-    transcript = _write_transcript(
-        tmp_path,
-        [
-            _user_text("/gh-flow:autopilot"),
-            _step_markers_result_new("plan", "issue", "mode", "implement", "pr", "simplify", "pr-reply"),
-            _assistant_text(terminal),
-        ],
-    )
-    result = _run_hook(_hook_event(transcript))
-    assert result.returncode == 0
-    assert result.stdout.strip() == "", f"{label}: expected allow, got {result.stdout!r}"
-
-
-def test_partial_new_marker_without_ok_does_not_count(tmp_path: Path) -> None:
-    """The strictness of the marker regex survives the widening."""
-    transcript = _write_transcript(
-        tmp_path,
-        [
-            _user_text("/gh-flow:autopilot"),
-            _user_tool_result("[step:gh-flow-autopilot/plan]"),
-            _assistant_text("continuing..."),
-        ],
-    )
-    result = _run_hook(_hook_event(transcript))
-    assert result.returncode == 0
-    decision = json.loads(result.stdout)
-    assert decision["decision"] == "block"
-    assert "0/7" in decision["reason"], decision["reason"]
 
 
 def test_step_labels_name_the_post_migration_sub_skills(tmp_path: Path) -> None:
@@ -1248,7 +1064,7 @@ def test_step_labels_name_the_post_migration_sub_skills(tmp_path: Path) -> None:
     transcript = _write_transcript(
         tmp_path,
         [
-            _user_text("/devx-autopilot"),
+            _user_text("/gh-flow:autopilot"),
             _step_markers_result("plan"),
             _assistant_text("continuing..."),
         ],

--- a/tests/integration/test_gh_issue_flow_stop_guard.py
+++ b/tests/integration/test_gh_issue_flow_stop_guard.py
@@ -80,7 +80,7 @@ def _user_tool_result(text: str, tool_use_id: str = "toolu_test") -> dict[str, A
     """Build a user message carrying a single tool_result block.
 
     Used to simulate Read/Bash tool output landing in the transcript — i.e.
-    file content that happens to mention "/gh-issue-flow" but is NOT a
+    file content that happens to mention "/gh-flow:issue" but is NOT a
     user-typed command. `tool_use_id` is explicit because the #1270 Bash
     terminal channel pairs a command with its OWN result by that id
     (PR #1272 review).
@@ -214,22 +214,22 @@ def _assistant_bash_no_id(command: str) -> dict[str, Any]:
     }
 
 
-# The canonical 6-step gh-issue-flow chain, restated here on purpose: these
+# The canonical 6-step gh-flow:issue chain, restated here on purpose: these
 # tests drive the hook as a black box via subprocess and never import its
 # EXPECTED_CHAIN, so a change to the chain must break the tests loudly.
 _ALL_SIX_SUB_SKILLS = [
     "gh-issue-implement",
-    "gh-commit",
-    "gh-pr",
-    "devx-pr-review-all",
-    "gh-pr-resolve-conflict",
-    "gh-pr-resolve-outdated",
+    "gh-pr-commit",
+    "gh-pr-create",
+    "gh-verify-review-all",
+    "gh-resolve-conflict",
+    "gh-resolve-outdated",
 ]
 
 
 def _full_chain_prefix() -> list[dict[str, Any]]:
     """Boundary + all six sub-skill invocations, with no Step 3 report yet."""
-    return [_user_text("/gh-issue-flow 1270"), *(_assistant_skill(n) for n in _ALL_SIX_SUB_SKILLS)]
+    return [_user_text("/gh-flow:issue 1270"), *(_assistant_skill(n) for n in _ALL_SIX_SUB_SKILLS)]
 
 
 def _hook_event(transcript_path: Path | None, /, **extras: Any) -> str:
@@ -307,7 +307,7 @@ def test_stop_hook_active_short_circuits(tmp_path: Path) -> None:
     transcript = _write_transcript(
         tmp_path,
         [
-            _user_text("/gh-issue-flow 42"),
+            _user_text("/gh-flow:issue 42"),
             _assistant_skill("gh-issue-implement", "42 direct origin --no-next-hint"),
         ],
     )
@@ -322,29 +322,14 @@ def test_completed_flow_allows_stop(tmp_path: Path) -> None:
     transcript = _write_transcript(
         tmp_path,
         [
-            _user_text("/gh-issue-flow 42"),
+            _user_text("/gh-flow:issue 42"),
             _assistant_skill("gh-issue-implement"),
-            _assistant_skill("gh-commit"),
-            _assistant_skill("gh-pr"),
-            _assistant_skill("devx-pr-review-all"),
-            _assistant_skill("gh-pr-resolve-conflict"),
-            _assistant_skill("gh-pr-resolve-outdated"),
-            _assistant_text("gh:issue-flow complete (#42)\n  PR URL: https://github.com/example/repo/pull/99"),
-        ],
-    )
-    result = _run_hook(_hook_event(transcript))
-    assert result.returncode == 0
-    assert result.stdout.strip() == ""
-
-
-def test_stopped_marker_also_allows_stop(tmp_path: Path) -> None:
-    """The 'stopped at step' failure marker counts as terminal too."""
-    transcript = _write_transcript(
-        tmp_path,
-        [
-            _user_text("/gh-issue-flow 42"),
-            _assistant_skill("gh-issue-implement"),
-            _assistant_text("gh:issue-flow stopped at step 1/5 (gh:issue-implement)"),
+            _assistant_skill("gh-pr-commit"),
+            _assistant_skill("gh-pr-create"),
+            _assistant_skill("gh-verify-review-all"),
+            _assistant_skill("gh-resolve-conflict"),
+            _assistant_skill("gh-resolve-outdated"),
+            _assistant_text("gh-flow:issue complete (#42)\n  PR URL: https://github.com/example/repo/pull/99"),
         ],
     )
     result = _run_hook(_hook_event(transcript))
@@ -353,14 +338,14 @@ def test_stopped_marker_also_allows_stop(tmp_path: Path) -> None:
 
 
 def test_mid_flow_after_step_2_1_blocks_with_next_hint(tmp_path: Path) -> None:
-    """Only gh-issue-implement called → block, naming gh-commit as next."""
+    """Only gh-issue-implement called → block, naming gh-pr-commit as next."""
     transcript = _write_transcript(
         tmp_path,
         [
-            _user_text("/gh-issue-flow 42"),
+            _user_text("/gh-flow:issue 42"),
             _assistant_skill("gh-issue-implement", "42 direct origin --no-next-hint"),
             # The model writes a fake-looking success block but no Step 3 marker.
-            _assistant_text("gh:issue-implement #42 complete\n  Mode: direct\n  Tests: 42 passed, 0 failed"),
+            _assistant_text("gh-issue:implement #42 complete\n  Mode: direct\n  Tests: 42 passed, 0 failed"),
         ],
     )
     result = _run_hook(_hook_event(transcript))
@@ -369,26 +354,26 @@ def test_mid_flow_after_step_2_1_blocks_with_next_hint(tmp_path: Path) -> None:
     decision = json.loads(result.stdout)
     assert decision.get("decision") == "block"
     reason = decision.get("reason", "")
-    assert "gh-commit" in reason
+    assert "gh-pr-commit" in reason
     assert "Step 2.2" in reason
     assert "1/6" in reason
 
 
 def test_mid_flow_skill_call_with_colon_namespace_counted(tmp_path: Path) -> None:
-    """Skill names like 'gh:issue-implement' (colon form) count too."""
+    """Skill names like 'gh-issue:implement' (colon form) count too."""
     transcript = _write_transcript(
         tmp_path,
         [
-            _user_text("/gh-issue-flow 42"),
-            _assistant_skill("gh:issue-implement"),
-            _assistant_skill("gh:commit"),
+            _user_text("/gh-flow:issue 42"),
+            _assistant_skill("gh-issue:implement"),
+            _assistant_skill("gh-pr:commit"),
         ],
     )
     result = _run_hook(_hook_event(transcript))
     assert result.returncode == 0
     decision = json.loads(result.stdout)
     assert decision["decision"] == "block"
-    assert "gh-pr" in decision["reason"]
+    assert "gh-pr-create" in decision["reason"]
     assert "Step 2.3" in decision["reason"]
     assert "2/6" in decision["reason"]
 
@@ -398,13 +383,13 @@ def test_mid_flow_after_all_6_blocks_for_step_3_report(tmp_path: Path) -> None:
     transcript = _write_transcript(
         tmp_path,
         [
-            _user_text("/gh-issue-flow 42"),
+            _user_text("/gh-flow:issue 42"),
             _assistant_skill("gh-issue-implement"),
-            _assistant_skill("gh-commit"),
-            _assistant_skill("gh-pr"),
-            _assistant_skill("devx-pr-review-all"),
-            _assistant_skill("gh-pr-resolve-conflict"),
-            _assistant_skill("gh-pr-resolve-outdated"),
+            _assistant_skill("gh-pr-commit"),
+            _assistant_skill("gh-pr-create"),
+            _assistant_skill("gh-verify-review-all"),
+            _assistant_skill("gh-resolve-conflict"),
+            _assistant_skill("gh-resolve-outdated"),
             # No Step 3 report yet.
         ],
     )
@@ -417,17 +402,17 @@ def test_mid_flow_after_all_6_blocks_for_step_3_report(tmp_path: Path) -> None:
 
 
 def test_mid_flow_after_resolve_conflict_blocks_for_resolve_outdated(tmp_path: Path) -> None:
-    """5 sub-skills through gh-pr-resolve-conflict, no terminal → block,
-    naming gh-pr-resolve-outdated (Step 2.5.1) as the next step."""
+    """5 sub-skills through gh-resolve-conflict, no terminal → block,
+    naming gh-resolve-outdated (Step 2.5.1) as the next step."""
     transcript = _write_transcript(
         tmp_path,
         [
-            _user_text("/gh-issue-flow 42"),
+            _user_text("/gh-flow:issue 42"),
             _assistant_skill("gh-issue-implement"),
-            _assistant_skill("gh-commit"),
-            _assistant_skill("gh-pr"),
-            _assistant_skill("devx-pr-review-all"),
-            _assistant_skill("gh-pr-resolve-conflict"),
+            _assistant_skill("gh-pr-commit"),
+            _assistant_skill("gh-pr-create"),
+            _assistant_skill("gh-verify-review-all"),
+            _assistant_skill("gh-resolve-conflict"),
             # No Step 3 report yet — resolve-outdated still pending.
         ],
     )
@@ -436,23 +421,23 @@ def test_mid_flow_after_resolve_conflict_blocks_for_resolve_outdated(tmp_path: P
     decision = json.loads(result.stdout)
     assert decision["decision"] == "block"
     reason = decision["reason"]
-    assert "gh-pr-resolve-outdated" in reason
+    assert "gh-resolve-outdated" in reason
     assert "Step 2.5.1" in reason
     assert "5/6" in reason
 
 
 def test_missing_pr_review_all_blocks_naming_step_2_4(tmp_path: Path) -> None:
-    """A run that reaches gh-pr but has not yet invoked devx:pr-review-all
+    """A run that reaches gh-pr but has not yet invoked gh-verify:review-all
     (Step 2.4) → block, and the reason names that step as the next action."""
     transcript = _write_transcript(
         tmp_path,
         [
-            _user_text("/gh-issue-flow 42"),
+            _user_text("/gh-flow:issue 42"),
             _assistant_skill("gh-issue-implement"),
-            _assistant_skill("gh-commit"),
-            _assistant_skill("gh-pr"),
-            # devx:pr-review-all NOT invoked; model authors a fake wrap-up.
-            _assistant_text("gh:pr #42 opened — PR URL: https://x/pull/9\nAll done!"),
+            _assistant_skill("gh-pr-commit"),
+            _assistant_skill("gh-pr-create"),
+            # gh-verify:review-all NOT invoked; model authors a fake wrap-up.
+            _assistant_text("gh-pr:create #42 opened — PR URL: https://x/pull/9\nAll done!"),
         ],
     )
     result = _run_hook(_hook_event(transcript))
@@ -460,17 +445,17 @@ def test_missing_pr_review_all_blocks_naming_step_2_4(tmp_path: Path) -> None:
     decision = json.loads(result.stdout)
     assert decision["decision"] == "block"
     reason = decision["reason"]
-    assert "devx-pr-review-all" in reason
+    assert "gh-verify-review-all" in reason
     assert "Step 2.4" in reason
     assert "3/6" in reason
 
 
 def test_skill_invocation_via_assistant_works_as_boundary(tmp_path: Path) -> None:
-    """Boundary can be a Skill(gh-issue-flow) tool_use, not just user text."""
+    """Boundary can be a Skill(gh-flow:issue) tool_use, not just user text."""
     transcript = _write_transcript(
         tmp_path,
         [
-            _assistant_skill("gh-issue-flow", "42"),
+            _assistant_skill("gh-flow:issue", "42"),
             _assistant_skill("gh-issue-implement"),
         ],
     )
@@ -481,11 +466,11 @@ def test_skill_invocation_via_assistant_works_as_boundary(tmp_path: Path) -> Non
 
 
 def test_unrelated_skill_after_boundary_not_counted(tmp_path: Path) -> None:
-    """Random other Skill() calls don't advance the gh-issue-flow counter."""
+    """Random other Skill() calls don't advance the gh-flow:issue counter."""
     transcript = _write_transcript(
         tmp_path,
         [
-            _user_text("/gh-issue-flow 42"),
+            _user_text("/gh-flow:issue 42"),
             _assistant_skill("gh-issue-implement"),
             _assistant_skill("some-unrelated-skill"),
             _assistant_skill("another-helper"),
@@ -503,7 +488,7 @@ def test_malformed_jsonl_lines_skipped(tmp_path: Path) -> None:
     """Garbage lines in the middle of the transcript don't crash the hook."""
     p = tmp_path / "transcript.jsonl"
     with p.open("w", encoding="utf-8") as f:
-        f.write(json.dumps(_user_text("/gh-issue-flow 42")) + "\n")
+        f.write(json.dumps(_user_text("/gh-flow:issue 42")) + "\n")
         f.write("not valid json at all {{{\n")
         f.write(json.dumps(_assistant_skill("gh-issue-implement")) + "\n")
         f.write("\n")  # blank line
@@ -514,24 +499,24 @@ def test_malformed_jsonl_lines_skipped(tmp_path: Path) -> None:
 
 
 def test_tool_result_mentioning_command_not_treated_as_boundary(tmp_path: Path) -> None:
-    """File content read by the model that contains "/gh-issue-flow" must
+    """File content read by the model that contains "/gh-flow:issue" must
     NOT be treated as the user invoking the command (PR #386 review fix).
 
     Regression for the boundary-detection false positive: previously,
     `_find_flow_boundary` did `tok in text` across all blocks including
     tool_result, so any session that read this skill's own SKILL.md (which
-    documents `/gh-issue-flow ...`) would be flagged as in-flow and stops
+    documents `/gh-flow:issue ...`) would be flagged as in-flow and stops
     would be blocked.
     """
     transcript = _write_transcript(
         tmp_path,
         [
-            _user_text("can you read the gh-issue-flow SKILL.md and explain it?"),
+            _user_text("can you read the gh-flow:issue SKILL.md and explain it?"),
             # Simulate a Read tool_result returning the SKILL.md content,
             # which legitimately contains the command string.
             _user_tool_result(
-                "# gh:issue-flow — Issue → PR composition\n\n"
-                "Use when the user runs /gh-issue-flow N or /gh:issue-flow N.\n"
+                "# gh-flow:issue — Issue → PR composition\n\n"
+                "Use when the user runs /gh-flow:issue N or /gh-flow-issue N.\n"
                 "Step 2.1 invokes Skill(gh-issue-implement) ...\n"
             ),
             _assistant_text("Here's how the skill works: ..."),
@@ -539,14 +524,14 @@ def test_tool_result_mentioning_command_not_treated_as_boundary(tmp_path: Path) 
     )
     result = _run_hook(_hook_event(transcript))
     assert result.returncode == 0
-    # No real /gh-issue-flow boundary anywhere — must allow stop.
+    # No real /gh-flow:issue boundary anywhere — must allow stop.
     assert result.stdout.strip() == "", (
         f"Hook treated tool_result file content as a flow boundary. stdout={result.stdout!r}"
     )
 
 
 def test_command_only_at_start_of_user_text_counts(tmp_path: Path) -> None:
-    """User text that *mentions* /gh-issue-flow mid-sentence is NOT a
+    """User text that *mentions* /gh-flow:issue mid-sentence is NOT a
     command; only text starting with the token counts as a boundary
     (PR #386 review fix — preferred form per gemini suggestion).
     """
@@ -554,7 +539,7 @@ def test_command_only_at_start_of_user_text_counts(tmp_path: Path) -> None:
         tmp_path,
         [
             _user_text(
-                "I was reading the docs about /gh-issue-flow and got confused — "
+                "I was reading the docs about /gh-flow:issue and got confused — "
                 "could you summarize how Step 2.x chains together?"
             ),
             _assistant_text("Sure — here's a summary: ..."),
@@ -563,18 +548,18 @@ def test_command_only_at_start_of_user_text_counts(tmp_path: Path) -> None:
     result = _run_hook(_hook_event(transcript))
     assert result.returncode == 0
     assert result.stdout.strip() == "", (
-        f"Hook treated mid-sentence mention of /gh-issue-flow as a command. stdout={result.stdout!r}"
+        f"Hook treated mid-sentence mention of /gh-flow:issue as a command. stdout={result.stdout!r}"
     )
 
 
 def test_command_with_leading_whitespace_still_counts(tmp_path: Path) -> None:
-    """Leading whitespace before /gh-issue-flow is tolerated (typo-friendly)
+    """Leading whitespace before /gh-flow:issue is tolerated (typo-friendly)
     so users who paste with indent still get the chain protection.
     """
     transcript = _write_transcript(
         tmp_path,
         [
-            _user_text("   /gh-issue-flow 42"),
+            _user_text("   /gh-flow:issue 42"),
             _assistant_skill("gh-issue-implement"),
         ],
     )
@@ -618,7 +603,7 @@ def test_trace_off_by_default_no_stderr(tmp_path: Path) -> None:
     transcript = _write_transcript(
         tmp_path,
         [
-            _user_text("/gh-issue-flow 42"),
+            _user_text("/gh-flow:issue 42"),
             _assistant_skill("gh-issue-implement"),
         ],
     )
@@ -635,7 +620,7 @@ def test_trace_on_emits_block_diagnostics(tmp_path: Path) -> None:
     transcript = _write_transcript(
         tmp_path,
         [
-            _user_text("/gh-issue-flow 42"),
+            _user_text("/gh-flow:issue 42"),
             _assistant_skill("gh-issue-implement"),
         ],
     )
@@ -657,7 +642,7 @@ def test_trace_on_emits_allow_reason_for_no_boundary(tmp_path: Path) -> None:
     """Allow path should also report its reason when trace mode is on."""
     transcript = _write_transcript(
         tmp_path,
-        [_user_text("just a chat unrelated to gh-issue-flow")],
+        [_user_text("just a chat unrelated to gh-flow:issue")],
     )
     result = _run_hook(
         _hook_event(transcript),
@@ -666,7 +651,7 @@ def test_trace_on_emits_allow_reason_for_no_boundary(tmp_path: Path) -> None:
     assert result.returncode == 0
     assert result.stdout.strip() == ""
     assert "[stop-guard] allow:" in result.stderr
-    assert "no gh-issue-flow boundary" in result.stderr
+    assert "no gh-flow:issue boundary" in result.stderr
 
 
 def test_trace_on_emits_allow_reason_for_terminal_marker(tmp_path: Path) -> None:
@@ -674,14 +659,14 @@ def test_trace_on_emits_allow_reason_for_terminal_marker(tmp_path: Path) -> None
     transcript = _write_transcript(
         tmp_path,
         [
-            _user_text("/gh-issue-flow 42"),
+            _user_text("/gh-flow:issue 42"),
             _assistant_skill("gh-issue-implement"),
-            _assistant_skill("gh-commit"),
-            _assistant_skill("gh-pr"),
-            _assistant_skill("devx-pr-review-all"),
-            _assistant_skill("gh-pr-resolve-conflict"),
-            _assistant_skill("gh-pr-resolve-outdated"),
-            _assistant_text("gh:issue-flow complete (#42)"),
+            _assistant_skill("gh-pr-commit"),
+            _assistant_skill("gh-pr-create"),
+            _assistant_skill("gh-verify-review-all"),
+            _assistant_skill("gh-resolve-conflict"),
+            _assistant_skill("gh-resolve-outdated"),
+            _assistant_text("gh-flow:issue complete (#42)"),
         ],
     )
     result = _run_hook(
@@ -697,21 +682,21 @@ def test_trace_on_emits_allow_reason_for_terminal_marker(tmp_path: Path) -> None
 # ---------------------------------------------------------------------------
 # Wrapped slash-command boundary (issues #607 / #609)
 #
-# When a user invokes `/gh-issue-flow N` interactively, Claude Code does not
+# When a user invokes `/gh-flow:issue N` interactively, Claude Code does not
 # place the raw command in the transcript. Instead it writes a multi-line
 # user message of the form:
 #
-#     <command-message>gh-issue-flow</command-message>
-#     <command-name>/gh-issue-flow</command-name>
+#     <command-message>gh-flow:issue</command-message>
+#     <command-name>/gh-flow:issue</command-name>
 #     <command-args>N</command-args>
-#     Base directory for this skill: .../skills/gh-issue-flow
-#     # gh:issue-flow — Issue → PR composition
+#     Base directory for this skill: .../gh-flow-skills/skills/issue
+#     # gh-flow:issue — Issue → PR composition
 #     ...(SKILL.md body)...
 #     ARGUMENTS: N
 #
-# The pre-#607 boundary detector used `lstrip().startswith("/gh-issue-flow")`,
+# The pre-#607 boundary detector used `lstrip().startswith("/gh-flow:issue")`,
 # which never matched this wrapped form — so every Stop event in a real
-# `/gh-issue-flow` session fell through to fail-open and the chain stopped
+# `/gh-flow:issue` session fell through to fail-open and the chain stopped
 # the moment the model emitted any prose between sub-skills. These fixtures
 # reproduce the actual transcript form and pin down the regression.
 # ---------------------------------------------------------------------------
@@ -738,59 +723,59 @@ def _user_slash_command(skill_name: str, args: str) -> dict[str, Any]:
 
 
 def test_wrapped_slash_command_recognized_as_flow_start(tmp_path: Path) -> None:
-    """`<command-name>/gh-issue-flow</command-name>` must mark a boundary."""
+    """`<command-name>/gh-flow-issue</command-name>` must mark a boundary."""
     transcript = _write_transcript(
         tmp_path,
         [
-            _user_slash_command("gh-issue-flow", "457"),
+            _user_slash_command("gh-flow-issue", "457"),
             _assistant_skill("gh-issue-implement", "457 direct origin --no-next-hint"),
-            _assistant_text("gh:issue-implement #457 complete\n  Tests: 12 passed"),
+            _assistant_text("gh-issue:implement #457 complete\n  Tests: 12 passed"),
         ],
     )
     result = _run_hook(_hook_event(transcript))
     assert result.returncode == 0
     assert result.stdout.strip(), (
-        "Hook must recognize the <command-name>/gh-issue-flow</command-name> "
+        "Hook must recognize the <command-name>/gh-flow-issue</command-name> "
         f"wrapped form as a flow boundary. stdout={result.stdout!r}"
     )
     decision = json.loads(result.stdout)
     assert decision["decision"] == "block"
-    assert "gh-commit" in decision["reason"]
+    assert "gh-pr-commit" in decision["reason"]
     assert "Step 2.2" in decision["reason"]
 
 
 def test_wrapped_slash_command_colon_namespace_recognized(tmp_path: Path) -> None:
-    """The colon-namespace form `<command-name>/gh:issue-flow</command-name>`
+    """The colon-namespace form `<command-name>/gh-flow:issue</command-name>`
     must also be recognized — Claude Code occasionally emits either form
     depending on how the skill is registered.
     """
     transcript = _write_transcript(
         tmp_path,
         [
-            _user_slash_command("gh:issue-flow", "457"),
+            _user_slash_command("gh-flow:issue", "457"),
             _assistant_skill("gh-issue-implement"),
-            _assistant_skill("gh-commit"),
+            _assistant_skill("gh-pr-commit"),
         ],
     )
     result = _run_hook(_hook_event(transcript))
     assert result.returncode == 0
     decision = json.loads(result.stdout)
     assert decision["decision"] == "block"
-    assert "gh-pr" in decision["reason"]
+    assert "gh-pr-create" in decision["reason"]
     assert "Step 2.3" in decision["reason"]
 
 
 def test_wrapped_command_inside_tool_result_does_not_trigger(tmp_path: Path) -> None:
-    """A `<command-name>/gh-issue-flow</command-name>` substring landing in
+    """A `<command-name>/gh-flow:issue</command-name>` substring landing in
     a tool_result block (e.g. the model reads a doc that quotes Claude
     Code's wrapping format) must NOT be treated as a real invocation —
     the existing `include_tool_results=False` guard still applies to the
     new regex matcher.
     """
     wrapped_inside_doc = (
-        "Example: when a user types /gh-issue-flow N, the transcript looks like\n"
+        "Example: when a user types /gh-flow:issue N, the transcript looks like\n"
         "\n"
-        "    <command-name>/gh-issue-flow</command-name>\n"
+        "    <command-name>/gh-flow:issue</command-name>\n"
         "    <command-args>N</command-args>\n"
         "\n"
         "and the hook treats that as the flow start.\n"
@@ -798,7 +783,7 @@ def test_wrapped_command_inside_tool_result_does_not_trigger(tmp_path: Path) -> 
     transcript = _write_transcript(
         tmp_path,
         [
-            _user_text("can you read the docs about the gh-issue-flow stop hook?"),
+            _user_text("can you read the docs about the gh-flow:issue stop hook?"),
             _user_tool_result(wrapped_inside_doc),
             _assistant_text("Sure — the hook ..."),
         ],
@@ -816,7 +801,7 @@ def test_wrapped_command_full_session_blocks_with_step_2_2_reason(
 ) -> None:
     """End-to-end shape of the production regression in #607 / #609:
 
-    user invokes /gh-issue-flow → Claude Code wraps it in <command-name>
+    user invokes /gh-flow:issue → Claude Code wraps it in <command-name>
     tags → assistant invokes Skill(gh-issue-implement) → assistant emits
     a self-authored success summary and tries to stop. The hook must
     block and route the model to Step 2.2.
@@ -824,17 +809,17 @@ def test_wrapped_command_full_session_blocks_with_step_2_2_reason(
     transcript = _write_transcript(
         tmp_path,
         [
-            _user_slash_command("gh-issue-flow", "457"),
+            _user_slash_command("gh-flow-issue", "457"),
             _assistant_skill("gh-issue-implement", "457 direct origin --no-next-hint"),
             _assistant_text(
-                "gh:issue-implement complete for #457.\n\n"
+                "gh-issue:implement complete for #457.\n\n"
                 "Summary\n"
                 "  Issue:        #457 feat(db): index strategy\n"
                 "  Mode:         direct\n"
                 "  Files:        1 new\n"
                 "  Tests:        12 passed\n\n"
                 "[ai-metrics:gh-issue-implement] ~7 min — will be included "
-                "in gh-commit metrics\n"
+                "in gh-pr-commit metrics\n"
             ),
         ],
     )
@@ -844,7 +829,7 @@ def test_wrapped_command_full_session_blocks_with_step_2_2_reason(
     assert decision["decision"] == "block"
     reason = decision["reason"]
     assert "Step 2.2" in reason
-    assert "gh-commit" in reason
+    assert "gh-pr-commit" in reason
     assert "1/6" in reason
 
 
@@ -854,8 +839,8 @@ def test_wrapped_command_full_session_blocks_with_step_2_2_reason(
 # Two motivations layered together:
 #
 # 1. **L1 (defense-in-depth boundary surfaces).** Add the `Base directory
-#    for this skill: …/gh-issue-flow` marker line and the SKILL.md H1
-#    `# gh:issue-flow — Issue → PR composition` as additional boundary
+#    for this skill: …/gh-flow-issue` marker line and the SKILL.md H1
+#    `# gh-flow:issue — Issue → PR composition` as additional boundary
 #    anchors so the hook keeps working even if Claude Code ever changes
 #    the `<command-name>` wrapper format (preserves chain protection
 #    across CLI version drift).
@@ -864,8 +849,8 @@ def test_wrapped_command_full_session_blocks_with_step_2_2_reason(
 #    it was that `_scan_after_boundary` matched `TERMINAL_PATTERNS`
 #    against the SKILL.md body delivered as a `role=user` text block.
 #    The template literally contains the lines
-#        gh:issue-flow complete (#<N>)
-#        gh:issue-flow stopped at step <i>/5
+#        gh-flow:issue complete (#<N>)
+#        gh-flow:issue stopped at step <i>/5
 #    as Step 3 instructions, so the scan saw a terminal marker before
 #    any sub-skill ran and fail-opened every invocation. Restricting
 #    the scan to `role=assistant` text (excluding the boundary message
@@ -881,17 +866,17 @@ _SKILL_TEMPLATE_FALSE_POSITIVE = (
     "\n"
     "If all steps succeeded:\n"
     "```\n"
-    "gh:issue-flow complete (#<N>)\n"
-    "  [OK] Step 1: gh:issue-implement\n"
+    "gh-flow:issue complete (#<N>)\n"
+    "  [OK] Step 1: gh-issue:implement\n"
     "```\n"
     "If a step failed:\n"
     "```\n"
-    "gh:issue-flow stopped at step <i>/5 (<skill-name>)\n"
+    "gh-flow:issue stopped at step <i>/5 (<skill-name>)\n"
     "```\n"
 )
 
 
-def _user_skill_base_dir_marker(skill_name: str = "gh-issue-flow") -> dict[str, Any]:
+def _user_skill_base_dir_marker(skill_name: str = "gh-flow-issue") -> dict[str, Any]:
     """User message containing only the `Base directory for this skill:` line.
 
     Mirrors the line Claude Code emits when expanding a slash command,
@@ -907,24 +892,24 @@ def _user_skill_h1_marker() -> dict[str, Any]:
 
     Exercises surface (d) — the H1 anchor — in isolation.
     """
-    content = "# gh:issue-flow — Issue → PR composition\n"
+    content = "# gh-flow:issue — Issue → PR composition\n"
     return {"type": "user", "message": {"role": "user", "content": content}}
 
 
 def test_base_dir_marker_recognized_as_flow_start(tmp_path: Path) -> None:
-    """Surface (c): `Base directory for this skill: …/gh-issue-flow` marks the flow."""
+    """Surface (c): `Base directory for this skill: …/gh-flow-issue` marks the flow."""
     transcript = _write_transcript(
         tmp_path,
         [
             _user_skill_base_dir_marker(),
             _assistant_skill("gh-issue-implement", "608 direct origin --no-next-hint"),
-            _assistant_text("gh:issue-implement #608 complete\n  Tests: 12 passed"),
+            _assistant_text("gh-issue:implement #608 complete\n  Tests: 12 passed"),
         ],
     )
     result = _run_hook(_hook_event(transcript))
     assert result.returncode == 0
     assert result.stdout.strip(), (
-        "Hook must recognize 'Base directory for this skill: …/gh-issue-flow' "
+        "Hook must recognize 'Base directory for this skill: …/gh-flow-issue' "
         f"as a flow boundary. stdout={result.stdout!r}"
     )
     decision = json.loads(result.stdout)
@@ -933,11 +918,11 @@ def test_base_dir_marker_recognized_as_flow_start(tmp_path: Path) -> None:
 
 
 def test_base_dir_marker_does_not_match_unrelated_skill(tmp_path: Path) -> None:
-    """Surface (c) only matches when the path ends with gh-issue-flow.
+    """Surface (c) only matches a `gh-flow`-rooted issue-skill path.
 
     False-positive guard: a base-directory line for some *other* skill
-    (e.g. `gh-issue-implement` or `gh-issue-flow-archive`) must not be
-    treated as a gh-issue-flow boundary.
+    (e.g. `gh-issue-implement` or `gh-flow-issue-archive`) must not be
+    treated as a gh-flow:issue boundary.
     """
     transcript = _write_transcript(
         tmp_path,
@@ -950,7 +935,7 @@ def test_base_dir_marker_does_not_match_unrelated_skill(tmp_path: Path) -> None:
     result = _run_hook(_hook_event(transcript))
     assert result.returncode == 0
     assert result.stdout.strip() == "", (
-        f"Hook treated a non-gh-issue-flow skill base directory as a flow boundary. stdout={result.stdout!r}"
+        f"Hook treated an unrelated skill base directory as a flow boundary. stdout={result.stdout!r}"
     )
 
 
@@ -961,7 +946,7 @@ def test_skill_h1_marker_recognized_as_flow_start(tmp_path: Path) -> None:
         [
             _user_skill_h1_marker(),
             _assistant_skill("gh-issue-implement"),
-            _assistant_skill("gh-commit"),
+            _assistant_skill("gh-pr-commit"),
         ],
     )
     result = _run_hook(_hook_event(transcript))
@@ -969,13 +954,13 @@ def test_skill_h1_marker_recognized_as_flow_start(tmp_path: Path) -> None:
     decision = json.loads(result.stdout)
     assert decision["decision"] == "block"
     assert "Step 2.3" in decision["reason"]
-    assert "gh-pr" in decision["reason"]
+    assert "gh-pr-create" in decision["reason"]
 
 
 def test_skill_h1_mid_sentence_does_not_match(tmp_path: Path) -> None:
     """Surface (d) requires the H1 to occupy its own line.
 
-    A mid-sentence quote like "the file starts with # gh:issue-flow — Issue
+    A mid-sentence quote like "the file starts with # gh-flow:issue — Issue
     → PR composition and ..." must not trip the boundary.
     """
     transcript = _write_transcript(
@@ -983,7 +968,7 @@ def test_skill_h1_mid_sentence_does_not_match(tmp_path: Path) -> None:
         [
             _user_text(
                 "I was reading the source — it has the line "
-                "# gh:issue-flow — Issue → PR composition embedded in a paragraph."
+                "# gh-flow:issue — Issue → PR composition embedded in a paragraph."
             ),
             _assistant_text("ok"),
         ],
@@ -1002,7 +987,7 @@ def test_base_dir_marker_inside_tool_result_does_not_trigger(tmp_path: Path) -> 
     """
     doc_excerpt = (
         "Each skill invocation begins with a banner like\n"
-        "    Base directory for this skill: /home/user/.claude/skills/gh-issue-flow\n"
+        "    Base directory for this skill: /home/user/.claude/skills/gh-flow:issue\n"
         "which the hook detects as a boundary.\n"
     )
     transcript = _write_transcript(
@@ -1025,9 +1010,9 @@ def test_skill_h1_inside_tool_result_does_not_trigger(tmp_path: Path) -> None:
     transcript = _write_transcript(
         tmp_path,
         [
-            _user_text("explain the gh-issue-flow SKILL.md"),
+            _user_text("explain the gh-flow:issue SKILL.md"),
             _user_tool_result(
-                "# gh:issue-flow — Issue → PR composition\n\n(rest of SKILL.md body that the model just read)\n"
+                "# gh-flow:issue — Issue → PR composition\n\n(rest of SKILL.md body that the model just read)\n"
             ),
             _assistant_text("It chains 5 sub-skills..."),
         ],
@@ -1043,11 +1028,11 @@ def test_skill_template_text_in_user_message_does_not_false_terminate(
     tmp_path: Path,
 ) -> None:
     """L1.5 (issue #608 root cause): SKILL.md template lines literally
-    containing `gh:issue-flow complete (#<N>)` and `gh:issue-flow stopped
+    containing `gh-flow:issue complete (#<N>)` and `gh-flow:issue stopped
     at step <i>/5` must NOT count as a terminal marker.
 
     Reproduction of the 5th regression: when a user types
-    `/gh-issue-flow N`, Claude Code expands the SKILL.md body inline as
+    `/gh-flow:issue N`, Claude Code expands the SKILL.md body inline as
     a `role=user` text block. The body contains the Step 3 template
     *as instructions*. Before this fix, `_scan_after_boundary` saw the
     template text, set `terminal=True`, and the hook fail-opened on
@@ -1058,12 +1043,12 @@ def test_skill_template_text_in_user_message_does_not_false_terminate(
     # User message contains BOTH the wrapped slash command (boundary)
     # AND the SKILL.md Step 3 template lines (would-be false-terminator).
     boundary_with_template = (
-        "<command-message>gh-issue-flow</command-message>\n"
-        "<command-name>/gh-issue-flow</command-name>\n"
+        "<command-message>gh-flow:issue</command-message>\n"
+        "<command-name>/gh-flow:issue</command-name>\n"
         "<command-args>608</command-args>\n"
-        "Base directory for this skill: /home/user/.claude/skills/gh-issue-flow\n"
+        "Base directory for this skill: /home/user/.claude/skills/gh-flow:issue\n"
         "\n"
-        "# gh:issue-flow — Issue → PR composition\n"
+        "# gh-flow:issue — Issue → PR composition\n"
         "\n" + _SKILL_TEMPLATE_FALSE_POSITIVE + "ARGUMENTS: 608\n"
     )
     transcript = _write_transcript(
@@ -1074,20 +1059,20 @@ def test_skill_template_text_in_user_message_does_not_false_terminate(
                 "message": {"role": "user", "content": boundary_with_template},
             },
             _assistant_skill("gh-issue-implement", "608 direct origin --no-next-hint"),
-            _assistant_text("gh:issue-implement #608 complete\n  Files: 2 changed\n  Tests: 32 passed"),
+            _assistant_text("gh-issue:implement #608 complete\n  Files: 2 changed\n  Tests: 32 passed"),
         ],
     )
     result = _run_hook(_hook_event(transcript))
     assert result.returncode == 0
     assert result.stdout.strip(), (
-        "Hook fail-opened on a real /gh-issue-flow invocation — the SKILL.md "
+        "Hook fail-opened on a real /gh-flow:issue invocation — the SKILL.md "
         "template text in the user message false-matched TERMINAL_PATTERNS. "
         f"stdout={result.stdout!r}"
     )
     decision = json.loads(result.stdout)
     assert decision["decision"] == "block"
     assert "Step 2.2" in decision["reason"]
-    assert "gh-commit" in decision["reason"]
+    assert "gh-pr-commit" in decision["reason"]
     assert "1/6" in decision["reason"]
 
 
@@ -1107,13 +1092,13 @@ def test_skill_template_text_in_tool_result_does_not_false_terminate(
     transcript = _write_transcript(
         tmp_path,
         [
-            _user_text("/gh-issue-flow 608"),
+            _user_text("/gh-flow:issue 608"),
             _assistant_skill("gh-issue-implement"),
             # Model reads the hook source while inside the flow.
             _user_tool_result(
                 "TERMINAL_PATTERNS: tuple[str, ...] = (\n"
-                '    "gh:issue-flow complete (#",\n'
-                '    "gh:issue-flow stopped at step",\n'
+                '    "gh-flow:issue complete (#",\n'
+                '    "gh-flow:issue stopped at step",\n'
                 "    ...\n"
                 ")\n"
             ),
@@ -1141,8 +1126,8 @@ def test_real_terminal_marker_in_assistant_text_still_allows_stop(
     accidental "block everything forever" regression.
     """
     boundary_with_template = (
-        "<command-name>/gh-issue-flow</command-name>\n"
-        "Base directory for this skill: /home/user/.claude/skills/gh-issue-flow\n" + _SKILL_TEMPLATE_FALSE_POSITIVE
+        "<command-name>/gh-flow:issue</command-name>\n"
+        "Base directory for this skill: /home/user/.claude/skills/gh-flow:issue\n" + _SKILL_TEMPLATE_FALSE_POSITIVE
     )
     transcript = _write_transcript(
         tmp_path,
@@ -1152,13 +1137,13 @@ def test_real_terminal_marker_in_assistant_text_still_allows_stop(
                 "message": {"role": "user", "content": boundary_with_template},
             },
             _assistant_skill("gh-issue-implement"),
-            _assistant_skill("gh-commit"),
-            _assistant_skill("gh-pr"),
-            _assistant_skill("devx-pr-review-all"),
-            _assistant_skill("gh-pr-resolve-conflict"),
-            _assistant_skill("gh-pr-resolve-outdated"),
+            _assistant_skill("gh-pr-commit"),
+            _assistant_skill("gh-pr-create"),
+            _assistant_skill("gh-verify-review-all"),
+            _assistant_skill("gh-resolve-conflict"),
+            _assistant_skill("gh-resolve-outdated"),
             # Real Step 3 success report — assistant role, real terminal marker.
-            _assistant_text("gh:issue-flow complete (#608)\n  PR URL: https://x/pull/9"),
+            _assistant_text("gh-flow:issue complete (#608)\n  PR URL: https://x/pull/9"),
         ],
     )
     result = _run_hook(_hook_event(transcript))
@@ -1175,7 +1160,7 @@ def test_trace_emits_layer_field_for_block(tmp_path: Path) -> None:
     transcript = _write_transcript(
         tmp_path,
         [
-            _user_text("/gh-issue-flow 608"),
+            _user_text("/gh-flow:issue 608"),
             _assistant_skill("gh-issue-implement"),
         ],
     )
@@ -1213,19 +1198,19 @@ def test_trace_emits_layer_field_for_no_boundary_allow(tmp_path: Path) -> None:
 # (PR #1272 review, Codex BLOCKER — a command string alone proves the model
 # mentioned the marker, not that it emitted a report). `tool_result` on its
 # own (issue #608) and non-`Bash` tool inputs stay non-terminal. Mechanism
-# and rationale: claude/skills/gh-issue-flow/references/stop-guard.md step 4.
+# and rationale: gh-flow-skills/skills/issue/references/stop-guard.md step 4.
 # ---------------------------------------------------------------------------
 
 _BASH_REPORT_HEREDOC = (
     "cat <<'EOF'\n"
-    "gh:issue-flow complete (#1270)\n"
-    "  [OK] Step 1: gh:issue-implement\n"
+    "gh-flow:issue complete (#1270)\n"
+    "  [OK] Step 1: gh-issue:implement\n"
     "  PR URL: https://github.com/example/repo/pull/99\n"
     "EOF\n"
 )
 _BASH_REPORT_HEREDOC_STDOUT = (
-    "gh:issue-flow complete (#1270)\n"
-    "  [OK] Step 1: gh:issue-implement\n"
+    "gh-flow:issue complete (#1270)\n"
+    "  [OK] Step 1: gh-issue:implement\n"
     "  PR URL: https://github.com/example/repo/pull/99\n"
 )
 
@@ -1235,13 +1220,13 @@ _BASH_REPORT_HEREDOC_STDOUT = (
     [
         pytest.param(_BASH_REPORT_HEREDOC, _BASH_REPORT_HEREDOC_STDOUT, id="heredoc"),
         pytest.param(
-            "printf 'gh:issue-flow complete (#42)\\n  PR URL: https://github.com/example/repo/pull/7\\n'",
-            "gh:issue-flow complete (#42)\n  PR URL: https://github.com/example/repo/pull/7\n",
+            "printf 'gh-flow:issue complete (#42)\\n  PR URL: https://github.com/example/repo/pull/7\\n'",
+            "gh-flow:issue complete (#42)\n  PR URL: https://github.com/example/repo/pull/7\n",
             id="printf",
         ),
         pytest.param(
-            "echo 'gh:issue-flow stopped at step 2/6 (gh:commit)\\n\\nResume after fix:\\n  /gh-pr-resolve-conflict 7'",
-            "gh:issue-flow stopped at step 2/6 (gh:commit)\n\nResume after fix:\n  /gh-pr-resolve-conflict 7\n",
+            "echo 'gh-flow:issue stopped at step 2/6 (gh-pr:commit)\\n\\nResume after fix:\\n  /gh-resolve-conflict 7'",
+            "gh-flow:issue stopped at step 2/6 (gh-pr:commit)\n\nResume after fix:\n  /gh-resolve-conflict 7\n",
             id="stopped-at-step",
         ),
     ],
@@ -1274,7 +1259,7 @@ def test_bash_terminal_report_list_shaped_tool_result_allows_stop(tmp_path: Path
             *_full_chain_prefix(),
             _assistant_bash(_BASH_REPORT_HEREDOC, "toolu_report"),
             _user_tool_result_blocks(
-                ["gh:issue-flow complete (#1270)", "  PR URL: https://github.com/example/repo/pull/99"],
+                ["gh-flow:issue complete (#1270)", "  PR URL: https://github.com/example/repo/pull/99"],
                 "toolu_report",
             ),
         ],
@@ -1296,7 +1281,7 @@ def test_bash_terminal_report_split_mid_token_still_allows_stop(tmp_path: Path) 
             *_full_chain_prefix(),
             _assistant_bash(_BASH_REPORT_HEREDOC, "toolu_report"),
             _user_tool_result_blocks(
-                ["gh:issue-flow compl", "ete (#1270)\n  PR URL: https://github.com/example/repo/pull/99"],
+                ["gh-flow:issue compl", "ete (#1270)\n  PR URL: https://github.com/example/repo/pull/99"],
                 "toolu_report",
             ),
         ],
@@ -1317,7 +1302,7 @@ def test_bash_report_redirected_to_file_does_not_terminate(tmp_path: Path) -> No
         [
             *_full_chain_prefix(),
             _assistant_bash(
-                "cat <<'EOF' > /tmp/report.txt\ngh:issue-flow complete (#1270)\nEOF\n",
+                "cat <<'EOF' > /tmp/report.txt\ngh-flow:issue complete (#1270)\nEOF\n",
                 "toolu_redirect",
             ),
             _user_tool_result("", "toolu_redirect"),
@@ -1342,7 +1327,7 @@ def test_bash_marker_in_comment_with_unrelated_output_does_not_terminate(
         [
             *_full_chain_prefix(),
             _assistant_bash(
-                "# next up: gh:issue-flow complete (#1270)\ngit status --short\n",
+                "# next up: gh-flow:issue complete (#1270)\ngit status --short\n",
                 "toolu_comment",
             ),
             _user_tool_result(" M claude/hooks/gh_issue_flow_stop_guard.py\n", "toolu_comment"),
@@ -1367,9 +1352,9 @@ def test_marker_in_tool_result_without_matching_command_does_not_terminate(
         tmp_path,
         [
             *_full_chain_prefix(),
-            _assistant_bash("cat claude/skills/gh-issue-flow/references/report-template.md", "toolu_cat"),
+            _assistant_bash("cat gh-flow-skills/skills/issue/references/report-template.md", "toolu_cat"),
             _user_tool_result(
-                "If all steps succeeded:\n```\ngh:issue-flow complete (#<N>)\n```\n",
+                "If all steps succeeded:\n```\ngh-flow:issue complete (#<N>)\n```\n",
                 "toolu_cat",
             ),
         ],
@@ -1425,9 +1410,9 @@ def test_bash_grep_of_template_text_does_not_terminate(tmp_path: Path) -> None:
     transcript = _write_transcript(
         tmp_path,
         [
-            _user_text("/gh-issue-flow 1270"),
+            _user_text("/gh-flow:issue 1270"),
             _assistant_skill("gh-issue-implement"),
-            _assistant_bash('grep "gh:issue-flow complete" claude/skills/gh-issue-flow/SKILL.md'),
+            _assistant_bash('grep "gh-flow:issue complete" gh-flow-skills/skills/issue/SKILL.md'),
         ],
     )
     result = _run_hook(_hook_event(transcript))
@@ -1449,7 +1434,7 @@ def test_bash_grep_of_template_text_does_not_terminate(tmp_path: Path) -> None:
 
 
 def test_bash_grep_of_real_report_line_does_not_terminate(tmp_path: Path) -> None:
-    """Issue #1274: `grep "gh:issue-flow complete (#1270)" some.log` echoes
+    """Issue #1274: `grep "gh-flow:issue complete (#1270)" some.log` echoes
     exactly the line it searched for, so before #1274 both halves of the
     #1272 pair matched and a live flow terminated on a log search. The result
     carries no `PR URL:` / `Resume after fix:` field, so it is not a report
@@ -1458,8 +1443,8 @@ def test_bash_grep_of_real_report_line_does_not_terminate(tmp_path: Path) -> Non
         tmp_path,
         [
             *_full_chain_prefix(),
-            _assistant_bash('grep "gh:issue-flow complete (#1270)" some.log', "toolu_grep"),
-            _user_tool_result("gh:issue-flow complete (#1270)\n", "toolu_grep"),
+            _assistant_bash('grep "gh-flow:issue complete (#1270)" some.log', "toolu_grep"),
+            _user_tool_result("gh-flow:issue complete (#1270)\n", "toolu_grep"),
         ],
     )
     result = _run_hook(_hook_event(transcript))
@@ -1480,17 +1465,17 @@ def test_template_text_in_tool_result_of_bash_cat_does_not_terminate(
     transcript = _write_transcript(
         tmp_path,
         [
-            _user_text("/gh-issue-flow 1270"),
+            _user_text("/gh-flow:issue 1270"),
             _assistant_skill("gh-issue-implement"),
-            _assistant_bash("cat claude/skills/gh-issue-flow/references/report-template.md"),
+            _assistant_bash("cat gh-flow-skills/skills/issue/references/report-template.md"),
             _user_tool_result(
                 "If all steps succeeded:\n"
                 "```\n"
-                "gh:issue-flow complete (#<N>)\n"
+                "gh-flow:issue complete (#<N>)\n"
                 "```\n"
                 "If a step failed:\n"
                 "```\n"
-                "gh:issue-flow stopped at step <i>/6 (<skill-name>)\n"
+                "gh-flow:issue stopped at step <i>/6 (<skill-name>)\n"
                 "```\n"
             ),
         ],
@@ -1509,28 +1494,28 @@ def test_edit_and_write_tool_inputs_are_not_scanned_for_terminal(
     """F-1 scope guard: only `Bash` tool inputs are scanned.
 
     Editing SKILL.md / report-template.md legitimately puts a real-looking
-    `gh:issue-flow complete (#1270)` string into an `Edit.new_string` or
+    `gh-flow:issue complete (#1270)` string into an `Edit.new_string` or
     `Write.content` — exactly what the #1270 change itself did. Those must
     never terminate the flow.
     """
     transcript = _write_transcript(
         tmp_path,
         [
-            _user_text("/gh-issue-flow 1270"),
+            _user_text("/gh-flow:issue 1270"),
             _assistant_skill("gh-issue-implement"),
             _assistant_tool_use(
                 "Edit",
                 {
-                    "file_path": "claude/skills/gh-issue-flow/references/report-template.md",
+                    "file_path": "gh-flow-skills/skills/issue/references/report-template.md",
                     "old_string": "example report",
-                    "new_string": "example report: gh:issue-flow complete (#1270)",
+                    "new_string": "example report: gh-flow:issue complete (#1270)",
                 },
             ),
             _assistant_tool_use(
                 "Write",
                 {
                     "file_path": "notes.md",
-                    "content": "gh:issue-flow stopped at step 3/6 (gh:pr)",
+                    "content": "gh-flow:issue stopped at step 3/6 (gh-pr:create)",
                 },
             ),
         ],
@@ -1550,7 +1535,7 @@ def test_edit_and_write_tool_inputs_are_not_scanned_for_terminal(
 # (default 3, `GH_ISSUE_FLOW_STOP_GUARD_MAX_USER_TURNS`, `0` = disabled)
 # the boundary is abandoned and the hook fails open. What counts as
 # "fresh", and why the valve is needed at all:
-# claude/skills/gh-issue-flow/references/stop-guard.md step 5.
+# gh-flow-skills/skills/issue/references/stop-guard.md step 5.
 # ---------------------------------------------------------------------------
 
 
@@ -1559,7 +1544,7 @@ def test_three_fresh_user_prompts_expire_the_boundary(tmp_path: Path) -> None:
     transcript = _write_transcript(
         tmp_path,
         [
-            _user_text("/gh-issue-flow 1270"),
+            _user_text("/gh-flow:issue 1270"),
             _assistant_skill("gh-issue-implement"),
             _user_text("actually, forget that — what does mise tasks list?"),
             _assistant_text("It lists the repo's lint/test tasks."),
@@ -1572,7 +1557,7 @@ def test_three_fresh_user_prompts_expire_the_boundary(tmp_path: Path) -> None:
     result = _run_hook(_hook_event(transcript))
     assert result.returncode == 0
     assert result.stdout.strip() == "", (
-        f"Stale gh-issue-flow boundary kept blocking unrelated turns. stdout={result.stdout!r}"
+        f"Stale gh-flow:issue boundary kept blocking unrelated turns. stdout={result.stdout!r}"
     )
 
 
@@ -1581,7 +1566,7 @@ def test_boundary_expiry_reported_in_trace(tmp_path: Path) -> None:
     transcript = _write_transcript(
         tmp_path,
         [
-            _user_text("/gh-issue-flow 1270"),
+            _user_text("/gh-flow:issue 1270"),
             _assistant_skill("gh-issue-implement"),
             _user_text("unrelated question one"),
             _user_text("unrelated question two"),
@@ -1604,7 +1589,7 @@ def test_two_fresh_user_prompts_still_block(tmp_path: Path) -> None:
     transcript = _write_transcript(
         tmp_path,
         [
-            _user_text("/gh-issue-flow 1270"),
+            _user_text("/gh-flow:issue 1270"),
             _assistant_skill("gh-issue-implement"),
             _user_text("wait, is the PR going to close the issue?"),
             _assistant_text("Yes, via Closes #1270."),
@@ -1625,14 +1610,14 @@ def test_skill_expansion_user_messages_are_not_fresh_prompts(tmp_path: Path) -> 
     transcript = _write_transcript(
         tmp_path,
         [
-            _user_text("/gh-issue-flow 1270"),
+            _user_text("/gh-flow:issue 1270"),
             _assistant_skill("gh-issue-implement"),
             _user_text("Base directory for this skill: /home/user/.claude/skills/gh-issue-implement\n"),
-            _assistant_skill("gh-commit"),
-            _user_slash_command("gh-commit", ""),
-            _user_text("<command-name>/gh-commit</command-name>\n<command-args></command-args>\n"),
+            _assistant_skill("gh-pr-commit"),
+            _user_slash_command("gh-pr-commit", ""),
+            _user_text("<command-name>/gh-pr-commit</command-name>\n<command-args></command-args>\n"),
             _user_text("<local-command-stdout>ok</local-command-stdout>"),
-            _user_text("Skill /gh-commit is already loaded above; instructions unchanged. Arguments: "),
+            _user_text("Skill /gh-pr-commit is already loaded above; instructions unchanged. Arguments: "),
         ],
     )
     result = _run_hook(_hook_event(transcript))
@@ -1649,7 +1634,7 @@ def test_tool_result_messages_are_not_fresh_prompts(tmp_path: Path) -> None:
     transcript = _write_transcript(
         tmp_path,
         [
-            _user_text("/gh-issue-flow 1270"),
+            _user_text("/gh-flow:issue 1270"),
             _assistant_skill("gh-issue-implement"),
             _user_tool_result("tests: 42 passed"),
             _user_tool_result("commit abc123 created"),
@@ -1674,7 +1659,7 @@ def test_system_reminder_only_user_message_is_not_a_fresh_prompt(
     transcript = _write_transcript(
         tmp_path,
         [
-            _user_text("/gh-issue-flow 1270"),
+            _user_text("/gh-flow:issue 1270"),
             _assistant_skill("gh-issue-implement"),
             _user_text(reminder),
             _user_text(reminder),
@@ -1695,7 +1680,7 @@ def test_expiry_disabled_by_env_zero(tmp_path: Path) -> None:
     transcript = _write_transcript(
         tmp_path,
         [
-            _user_text("/gh-issue-flow 1270"),
+            _user_text("/gh-flow:issue 1270"),
             _assistant_skill("gh-issue-implement"),
             *[_user_text(f"unrelated prompt {i}") for i in range(5)],
         ],
@@ -1714,7 +1699,7 @@ def test_expiry_limit_configurable_via_env(tmp_path: Path) -> None:
     transcript = _write_transcript(
         tmp_path,
         [
-            _user_text("/gh-issue-flow 1270"),
+            _user_text("/gh-flow:issue 1270"),
             _assistant_skill("gh-issue-implement"),
             _user_text("never mind, different topic now"),
         ],
@@ -1730,7 +1715,7 @@ def test_expiry_limit_configurable_via_env(tmp_path: Path) -> None:
 def test_invalid_expiry_env_falls_back_to_default(tmp_path: Path) -> None:
     """F-2: an unparseable / negative value degrades to the default of 3."""
     two_prompts = [
-        _user_text("/gh-issue-flow 1270"),
+        _user_text("/gh-flow:issue 1270"),
         _assistant_skill("gh-issue-implement"),
         _user_text("question one"),
         _user_text("question two"),
@@ -1749,12 +1734,12 @@ def test_invalid_expiry_env_falls_back_to_default(tmp_path: Path) -> None:
 # ---------------------------------------------------------------------------
 # Issue #1270 / PR #1272 review — fresh-prompt counter over-counting.
 #
-# Measured on a real 2489-entry gh-issue-flow transcript: 102 "fresh
+# Measured on a real 2489-entry gh-flow:issue transcript: 102 "fresh
 # prompts" of which only 4 were human. 62 were Stop-hook feedback blocks
 # (Claude Code re-injects the hook's own `reason` as a `role=user` message)
 # and 40 were `<task-notification>` background-subagent completions — so the
 # limit of 3 was hit at entry 322 with 1/6 sub-skills done and the guard
-# disabled itself mid-flow. `devx:pr-review-all` (Step 2.4 of the guarded
+# disabled itself mid-flow. `gh-verify:review-all` (Step 2.4 of the guarded
 # chain) fans out three background agents, which makes that self-defeat the
 # normal case rather than an edge case.
 #
@@ -1769,7 +1754,7 @@ def test_ismeta_user_messages_are_not_fresh_prompts(tmp_path: Path) -> None:
     transcript = _write_transcript(
         tmp_path,
         [
-            _user_text("/gh-issue-flow 1270"),
+            _user_text("/gh-flow:issue 1270"),
             _assistant_skill("gh-issue-implement"),
             _user_meta_text("please continue with the next step"),
             _user_meta_text("keep going, do not stop"),
@@ -1790,14 +1775,14 @@ def test_stop_hook_feedback_messages_are_not_fresh_prompts(tmp_path: Path) -> No
     a "fresh user prompt" and three of them expired the guard's own boundary.
     """
     feedback = (
-        "Stop hook feedback: gh-issue-flow incomplete: 1/6 sub-skills invoked since "
+        "Stop hook feedback: gh-flow:issue incomplete: 1/6 sub-skills invoked since "
         "the flow started, and no terminal Step 3 report has been emitted yet. "
-        "Next action: Step 2.2 — Skill(gh-commit)."
+        "Next action: Step 2.2 — Skill(gh-pr-commit)."
     )
     transcript = _write_transcript(
         tmp_path,
         [
-            _user_text("/gh-issue-flow 1270"),
+            _user_text("/gh-flow:issue 1270"),
             _assistant_skill("gh-issue-implement"),
             _user_text(feedback),
             _user_text(feedback),
@@ -1817,7 +1802,7 @@ def test_task_notification_messages_are_not_fresh_prompts(tmp_path: Path) -> Non
     transcript = _write_transcript(
         tmp_path,
         [
-            _user_text("/gh-issue-flow 1270"),
+            _user_text("/gh-flow:issue 1270"),
             _assistant_skill("gh-issue-implement"),
             _user_text(notice),
             _user_text(notice),
@@ -1837,7 +1822,7 @@ def test_system_notification_messages_are_not_fresh_prompts(tmp_path: Path) -> N
     transcript = _write_transcript(
         tmp_path,
         [
-            _user_text("/gh-issue-flow 1270"),
+            _user_text("/gh-flow:issue 1270"),
             _assistant_skill("gh-issue-implement"),
             _user_text(notice),
             _user_text(notice),
@@ -1864,7 +1849,7 @@ def test_mixed_text_and_tool_result_message_counts_as_fresh_prompt(
     transcript = _write_transcript(
         tmp_path,
         [
-            _user_text("/gh-issue-flow 1270"),
+            _user_text("/gh-flow:issue 1270"),
             _assistant_skill("gh-issue-implement"),
             _user_text_with_tool_result("stop that — what does mise tasks list?"),
             _user_text_with_tool_result("and where is the zsh env file?"),
@@ -1886,7 +1871,7 @@ def test_tool_result_only_message_still_not_a_fresh_prompt(tmp_path: Path) -> No
     transcript = _write_transcript(
         tmp_path,
         [
-            _user_text("/gh-issue-flow 1270"),
+            _user_text("/gh-flow:issue 1270"),
             _assistant_skill("gh-issue-implement"),
             _user_tool_result("tests: 42 passed"),
             _user_tool_result("commit abc123 created"),
@@ -1930,7 +1915,7 @@ def test_quoted_marker_mid_sentence_still_counts_as_fresh_prompt(tmp_path: Path,
     transcript = _write_transcript(
         tmp_path,
         [
-            _user_text("/gh-issue-flow 1281"),
+            _user_text("/gh-flow:issue 1281"),
             _assistant_skill("gh-issue-implement"),
             _user_text(prompt),
         ],
@@ -1960,9 +1945,9 @@ def test_already_loaded_injection_alone_is_not_a_fresh_prompt(tmp_path: Path) ->
     transcript = _write_transcript(
         tmp_path,
         [
-            _user_text("/gh-issue-flow 1281"),
+            _user_text("/gh-flow:issue 1281"),
             _assistant_skill("gh-issue-implement"),
-            _user_text("Skill /gh-issue-flow is already loaded above; instructions unchanged. Arguments: 1281"),
+            _user_text("Skill /gh-flow:issue is already loaded above; instructions unchanged. Arguments: 1281"),
         ],
     )
     result = _run_hook(
@@ -1994,7 +1979,7 @@ def test_marker_quoted_at_true_line_start_is_still_not_a_fresh_prompt(tmp_path: 
     transcript = _write_transcript(
         tmp_path,
         [
-            _user_text("/gh-issue-flow 1281"),
+            _user_text("/gh-flow:issue 1281"),
             _assistant_skill("gh-issue-implement"),
             _user_text("Stop hook feedback: I'm quoting this exactly to ask you about it."),
         ],
@@ -2013,7 +1998,7 @@ def test_marker_quoted_at_true_line_start_is_still_not_a_fresh_prompt(tmp_path: 
 
 # ---------------------------------------------------------------------------
 # Issue #1434 — the `SubagentStop` path. The guard used to be registered on
-# `Stop` only, so a `gh:issue-flow` chain running inside a subagent (the
+# `Stop` only, so a `gh-flow:issue` chain running inside a subagent (the
 # unattended issue-watcher dispatch, #1389) lost the harness layer of the
 # three-layer guard entirely.
 #
@@ -2066,13 +2051,13 @@ def _subagent_hook_event(
 def _mid_flow_messages() -> list[dict[str, Any]]:
     """Boundary + one sub-skill, no Step 3 report — the blockable state."""
     return [
-        _user_text("/gh-issue-flow 1434"),
+        _user_text("/gh-flow:issue 1434"),
         _assistant_skill("gh-issue-implement", "1434 direct origin --no-next-hint"),
     ]
 
 
 def _unrelated_messages() -> list[dict[str, Any]]:
-    """A transcript with no gh-issue-flow boundary anywhere."""
+    """A transcript with no gh-flow:issue boundary anywhere."""
     return [
         _user_text("summarize this directory for me"),
         _assistant_text("here is the summary you asked for."),
@@ -2113,7 +2098,7 @@ def test_subagent_stop_mid_flow_blocks(tmp_path: Path) -> None:
     )
     decision = json.loads(result.stdout)
     assert decision["decision"] == "block"
-    assert "gh-issue-flow incomplete" in decision["reason"]
+    assert "gh-flow:issue incomplete" in decision["reason"]
 
 
 def test_subagent_stop_does_not_inherit_parent_flow(tmp_path: Path) -> None:
@@ -2151,9 +2136,9 @@ def test_subagent_stop_terminal_marker_allows_stop(tmp_path: Path) -> None:
     agent, parent = _write_subagent_pair(
         tmp_path,
         [
-            _user_text("/gh-issue-flow 1434"),
+            _user_text("/gh-flow:issue 1434"),
             *(_assistant_skill(n) for n in _ALL_SIX_SUB_SKILLS),
-            _assistant_text("gh:issue-flow complete (#1434)\n  PR URL: https://github.com/example/repo/pull/1435"),
+            _assistant_text("gh-flow:issue complete (#1434)\n  PR URL: https://github.com/example/repo/pull/1435"),
         ],
         _unrelated_messages(),
     )
@@ -2211,8 +2196,8 @@ def test_stop_event_trace_names_transcript_path_source(tmp_path: Path) -> None:
     [
         # Measured: the subagent transcript's FIRST entry is the dispatch
         # prompt as plain user text, exactly this shape.
-        ("dispatch-prompt-user-text", _user_text("/gh-issue-flow 1434")),
-        ("assistant-skill-tool-use", _assistant_skill("gh-issue-flow", "1434")),
+        ("dispatch-prompt-user-text", _user_text("/gh-flow:issue 1434")),
+        ("assistant-skill-tool-use", _assistant_skill("gh-flow:issue", "1434")),
         ("skill-expansion-base-dir", _user_skill_base_dir_marker()),
     ],
 )
@@ -2247,7 +2232,7 @@ def test_real_subagent_entry_shapes_parse_and_block(tmp_path: Path) -> None:
                 "isSidechain": True,
                 "agentId": "agent-test-1434",
                 "uuid": "11111111-1111-1111-1111-111111111111",
-                "message": {"role": "user", "content": "/gh-issue-flow 1434"},
+                "message": {"role": "user", "content": "/gh-flow:issue 1434"},
             },
             {"type": "attachment", "attachment": {"type": "file", "path": "/tmp/context.md"}},
             {
@@ -2523,10 +2508,10 @@ def test_subagent_harness_entries_never_expire_the_boundary(tmp_path: Path) -> N
         [
             *_mid_flow_messages(),
             _user_tool_result("tests: 42 passed", tool_use_id="toolu_subagent_1"),
-            _user_text("Stop hook feedback:\ngh-issue-flow incomplete: 1/6 sub-skills invoked since the flow started."),
+            _user_text("Stop hook feedback:\ngh-flow:issue incomplete: 1/6 sub-skills invoked since the flow started."),
             _user_text("<task-notification>Agent 'reviewer' finished.</task-notification>"),
-            _user_skill_base_dir_marker("gh-commit"),
-            _user_meta_text("Skill gh-commit is already loaded above; instructions unchanged."),
+            _user_skill_base_dir_marker("gh-pr-commit"),
+            _user_meta_text("Skill gh-pr-commit is already loaded above; instructions unchanged."),
         ],
         _unrelated_messages(),
     )
@@ -2647,14 +2632,14 @@ def test_three_consecutive_async_wait_markers_block(tmp_path: Path) -> None:
     assert result.stdout.strip(), "3 markers with no progress is stagnation and must block"
     decision = json.loads(result.stdout)
     assert decision["decision"] == "block"
-    assert "gh-issue-flow incomplete" in decision["reason"]
-    assert "Step 2.2 — Skill(gh-commit)" in decision["reason"]
+    assert "gh-flow:issue incomplete" in decision["reason"]
+    assert "Step 2.2 — Skill(gh-pr-commit)" in decision["reason"]
 
 
 def test_progress_resets_the_async_wait_streak(tmp_path: Path) -> None:
     """A real sub-skill call after a marker restarts the count from zero.
 
-    Marker → `Skill(gh:commit)` (progress) → stop with no further marker.
+    Marker → `Skill(gh-pr:commit)` (progress) → stop with no further marker.
     The pre-progress marker must not carry over, so the ordinary 2/6 block
     applies. This is what stops a streak accumulating across a whole flow.
     """
@@ -2663,7 +2648,7 @@ def test_progress_resets_the_async_wait_streak(tmp_path: Path) -> None:
         [
             *_mid_flow_messages(),
             _async_wait_text(),
-            _assistant_skill("gh:commit"),
+            _assistant_skill("gh-pr:commit"),
         ],
     )
     result = _run_hook(_hook_event(transcript))
@@ -2804,21 +2789,22 @@ def test_async_wait_limit_one_allows_exactly_one(tmp_path: Path, marker_count: i
 
 
 # ---------------------------------------------------------------------------
-# D-12 dual-form namespace recognition (#1678)
+# Post-migration namespace recognition (#1678, finished by #1681 / #1410
+# Phase 4-2)
 #
-# Phase 3 of #1410 migrates this composition into the `gh-flow-skills` repo
-# as `gh-flow:issue`, while NF-1 keeps the dotfiles original alive (and the
-# automation in `gh_flow.sh` / `issue_watcher_cron.sh` still dispatches the
-# old `/gh-issue-flow`) until Phase 4. The guard must therefore recognize
-# BOTH namespaces at once. Every case below is an ADDITION — no existing
-# assertion above is modified (issue #1678, NF-4).
+# #1410 moved this composition into the `gh-flow-skills` plugin repo as
+# `gh-flow:issue`. Phase 4-1 (#1680) then deleted the dotfiles originals and
+# Phase 4-3 (#1682) switched `gh_flow.sh` / `issue_watcher_cron.sh` to the new
+# slash commands, so `gh-flow:issue` / `gh-flow-issue` is now the ONLY
+# namespace the guard answers to. These cases pin the surfaces that only the
+# plugin layout produces (installed base dirs, the `-relay` sibling).
 # ---------------------------------------------------------------------------
 
-# The same six chain slots as `_ALL_SIX_SUB_SKILLS`, addressed by their
-# post-migration names. Restated as literals for the same reason: the tests
-# drive the hook as a black box, so a silent drift in EXPECTED_CHAIN must
-# break them loudly.
-_ALL_SIX_SUB_SKILLS_NEW = [
+# The same six chain slots as `_ALL_SIX_SUB_SKILLS`, addressed by their COLON
+# form instead of their hyphen form. Restated as literals for the same reason:
+# the tests drive the hook as a black box, so a silent drift in EXPECTED_CHAIN
+# must break them loudly.
+_ALL_SIX_SUB_SKILLS_COLON = [
     "gh-issue:implement",
     "gh-pr:commit",
     "gh-pr:create",
@@ -2902,7 +2888,7 @@ def test_new_namespace_sub_skills_are_all_recognized(tmp_path: Path) -> None:
         tmp_path,
         [
             _user_text("/gh-flow:issue 1678"),
-            *(_assistant_skill(n) for n in _ALL_SIX_SUB_SKILLS_NEW),
+            *(_assistant_skill(n) for n in _ALL_SIX_SUB_SKILLS_COLON),
             _assistant_text("all done"),
         ],
     )
@@ -2912,13 +2898,13 @@ def test_new_namespace_sub_skills_are_all_recognized(tmp_path: Path) -> None:
     assert "6/6 sub-skills" in reason, reason
 
 
-def test_old_and_new_alias_of_one_slot_count_once(tmp_path: Path) -> None:
-    """`gh-commit` and `gh-pr:commit` are the same chain slot, not two."""
+def test_hyphen_and_colon_alias_of_one_slot_count_once(tmp_path: Path) -> None:
+    """`gh-pr-commit` and `gh-pr:commit` are the same chain slot, not two."""
     transcript = _write_transcript(
         tmp_path,
         [
-            _user_text("/gh-issue-flow 1678"),
-            _assistant_skill("gh-commit"),
+            _user_text("/gh-flow:issue 1678"),
+            _assistant_skill("gh-pr-commit"),
             _assistant_skill("gh-pr:commit"),
             _assistant_text("committed"),
         ],
@@ -2929,18 +2915,18 @@ def test_old_and_new_alias_of_one_slot_count_once(tmp_path: Path) -> None:
     assert "1/6 sub-skills" in reason, reason
 
 
-def test_mixed_old_and_new_names_complete_the_chain(tmp_path: Path) -> None:
-    """A chain half-invoked under each namespace still reaches 6/6.
+def test_mixed_hyphen_and_colon_names_complete_the_chain(tmp_path: Path) -> None:
+    """A chain invoked with a mix of hyphen and colon forms still reaches 6/6.
 
-    This is the transition-period shape D-12 exists for: the dotfiles copy
-    and the `gh-flow-skills` copy can both be installed at once.
+    Both forms address the same slot, so the per-slot canonicalization must
+    hold across a whole chain, not just the one-slot case above.
     """
     mixed = [
-        "gh:issue-implement",
+        "gh-issue:implement",
         "gh-pr:commit",
-        "gh-pr",
+        "gh-pr-create",
         "gh-verify:review-all",
-        "gh-pr-resolve-conflict",
+        "gh-resolve-conflict",
         "gh-resolve:outdated",
     ]
     transcript = _write_transcript(
@@ -2981,25 +2967,6 @@ def test_new_namespace_terminal_marker_allows_stop(tmp_path: Path, label: str, m
     assert result.stdout.strip() == "", f"{label}: expected allow, got {result.stdout!r}"
 
 
-def test_new_namespace_terminal_marker_via_bash_channel(tmp_path: Path) -> None:
-    """The #1270 Bash fallback channel accepts the new-name marker too."""
-    command = "printf 'gh-flow:issue complete (#1678)\\n'"
-    transcript = _write_transcript(
-        tmp_path,
-        [
-            _user_text("/gh-flow:issue 1678"),
-            _assistant_bash(command, block_id="toolu_report"),
-            _user_tool_result(
-                "gh-flow:issue complete (#1678)\n  PR URL: https://github.com/o/r/pull/1",
-                tool_use_id="toolu_report",
-            ),
-        ],
-    )
-    result = _run_hook(_hook_event(transcript))
-    assert result.returncode == 0
-    assert result.stdout.strip() == "", f"expected allow, got {result.stdout!r}"
-
-
 def test_new_namespace_relay_report_does_not_terminate_a_flow(tmp_path: Path) -> None:
     """`gh-flow:issue-relay complete (#N)` must not satisfy `gh-flow:issue`'s terminal.
 
@@ -3020,12 +2987,12 @@ def test_new_namespace_relay_report_does_not_terminate_a_flow(tmp_path: Path) ->
     assert json.loads(result.stdout)["decision"] == "block"
 
 
-def test_next_step_hint_names_both_namespaces(tmp_path: Path) -> None:
-    """A block's "next action" must be invocable under either namespace (#1678).
+def test_next_step_hint_names_both_forms_of_the_slot(tmp_path: Path) -> None:
+    """A block's "next action" quotes BOTH forms of the next slot (#1678).
 
-    A session running only the migrated `gh-flow-skills` plugin has no
-    `gh-commit` skill, so a hint naming that alone answers the block with an
-    instruction it cannot follow.
+    The canonical hyphen name comes first (existing substring assertions
+    depend on that), the colon alias follows in parentheses — that is the form
+    Claude Code's own slash-command surface uses.
     """
     transcript = _write_transcript(
         tmp_path,
@@ -3038,24 +3005,23 @@ def test_next_step_hint_names_both_namespaces(tmp_path: Path) -> None:
     result = _run_hook(_hook_event(transcript))
     assert result.returncode == 0
     reason = json.loads(result.stdout)["reason"]
-    assert "Skill(gh-commit)" in reason, reason
+    assert "Skill(gh-pr-commit)" in reason, reason
     assert "Skill(gh-pr:commit)" in reason, reason
 
 
-def test_terminal_hint_after_full_chain_names_both_report_forms(tmp_path: Path) -> None:
-    """The Step 3 nudge quotes the old and new terminal marker (#1678)."""
+def test_terminal_hint_after_full_chain_names_the_report_form(tmp_path: Path) -> None:
+    """The Step 3 nudge quotes the terminal marker the guard actually accepts."""
     transcript = _write_transcript(
         tmp_path,
         [
             _user_text("/gh-flow:issue 1678"),
-            *(_assistant_skill(n) for n in _ALL_SIX_SUB_SKILLS_NEW),
+            *(_assistant_skill(n) for n in _ALL_SIX_SUB_SKILLS_COLON),
             _assistant_text("all done"),
         ],
     )
     result = _run_hook(_hook_event(transcript))
     assert result.returncode == 0
     reason = json.loads(result.stdout)["reason"]
-    assert "gh:issue-flow complete (#N)" in reason, reason
     assert "gh-flow:issue complete (#N)" in reason, reason
 
 
@@ -3092,8 +3058,8 @@ def test_hint_alias_table_is_consistent_with_the_chain(tmp_path: Path) -> None:
     """
     checks = [
         ("gh-issue-implement", "Skill(gh-issue:implement)", []),
-        ("gh-commit", "Skill(gh-pr:commit)", ["gh-issue-implement"]),
-        ("gh-pr", "Skill(gh-pr:create)", ["gh-issue-implement", "gh-commit"]),
+        ("gh-pr-commit", "Skill(gh-pr:commit)", ["gh-issue-implement"]),
+        ("gh-pr-create", "Skill(gh-pr:create)", ["gh-issue-implement", "gh-pr-commit"]),
     ]
     for canonical, expected_hint, prefix in checks:
         transcript = _write_transcript(

--- a/tests/integration/test_gh_issue_flow_stop_guard.py
+++ b/tests/integration/test_gh_issue_flow_stop_guard.py
@@ -323,12 +323,7 @@ def test_completed_flow_allows_stop(tmp_path: Path) -> None:
         tmp_path,
         [
             _user_text("/gh-flow:issue 42"),
-            _assistant_skill("gh-issue-implement"),
-            _assistant_skill("gh-pr-commit"),
-            _assistant_skill("gh-pr-create"),
-            _assistant_skill("gh-verify-review-all"),
-            _assistant_skill("gh-resolve-conflict"),
-            _assistant_skill("gh-resolve-outdated"),
+            *(_assistant_skill(n) for n in _ALL_SIX_SUB_SKILLS),
             _assistant_text("gh-flow:issue complete (#42)\n  PR URL: https://github.com/example/repo/pull/99"),
         ],
     )
@@ -384,12 +379,7 @@ def test_mid_flow_after_all_6_blocks_for_step_3_report(tmp_path: Path) -> None:
         tmp_path,
         [
             _user_text("/gh-flow:issue 42"),
-            _assistant_skill("gh-issue-implement"),
-            _assistant_skill("gh-pr-commit"),
-            _assistant_skill("gh-pr-create"),
-            _assistant_skill("gh-verify-review-all"),
-            _assistant_skill("gh-resolve-conflict"),
-            _assistant_skill("gh-resolve-outdated"),
+            *(_assistant_skill(n) for n in _ALL_SIX_SUB_SKILLS),
             # No Step 3 report yet.
         ],
     )
@@ -660,12 +650,7 @@ def test_trace_on_emits_allow_reason_for_terminal_marker(tmp_path: Path) -> None
         tmp_path,
         [
             _user_text("/gh-flow:issue 42"),
-            _assistant_skill("gh-issue-implement"),
-            _assistant_skill("gh-pr-commit"),
-            _assistant_skill("gh-pr-create"),
-            _assistant_skill("gh-verify-review-all"),
-            _assistant_skill("gh-resolve-conflict"),
-            _assistant_skill("gh-resolve-outdated"),
+            *(_assistant_skill(n) for n in _ALL_SIX_SUB_SKILLS),
             _assistant_text("gh-flow:issue complete (#42)"),
         ],
     )
@@ -1136,12 +1121,7 @@ def test_real_terminal_marker_in_assistant_text_still_allows_stop(
                 "type": "user",
                 "message": {"role": "user", "content": boundary_with_template},
             },
-            _assistant_skill("gh-issue-implement"),
-            _assistant_skill("gh-pr-commit"),
-            _assistant_skill("gh-pr-create"),
-            _assistant_skill("gh-verify-review-all"),
-            _assistant_skill("gh-resolve-conflict"),
-            _assistant_skill("gh-resolve-outdated"),
+            *(_assistant_skill(n) for n in _ALL_SIX_SUB_SKILLS),
             # Real Step 3 success report — assistant role, real terminal marker.
             _assistant_text("gh-flow:issue complete (#608)\n  PR URL: https://x/pull/9"),
         ],
@@ -2817,30 +2797,6 @@ _ALL_SIX_SUB_SKILLS_COLON = [
 @pytest.mark.parametrize(
     ("label", "boundary"),
     [
-        ("colon-form", "/gh-flow:issue 1678"),
-        ("hyphen-form", "/gh-flow-issue 1678"),
-    ],
-)
-def test_new_namespace_slash_command_is_a_boundary(tmp_path: Path, label: str, boundary: str) -> None:
-    """`/gh-flow:issue` and `/gh-flow-issue` open a chain just like the old names."""
-    transcript = _write_transcript(
-        tmp_path,
-        [
-            _user_text(boundary),
-            _assistant_text("done!"),
-        ],
-    )
-    result = _run_hook(_hook_event(transcript))
-    assert result.returncode == 0
-    assert result.stdout.strip(), f"{label}: expected a block, got empty stdout"
-    assert json.loads(result.stdout)["decision"] == "block"
-
-
-@pytest.mark.parametrize(
-    ("label", "boundary"),
-    [
-        ("command-name-wrapper", "<command-name>/gh-flow:issue</command-name>"),
-        ("command-name-wrapper-hyphen", "<command-name>/gh-flow-issue</command-name>"),
         # The two real Claude Code install layouts, plus a flat dev checkout.
         (
             "skill-base-dir-marketplace",
@@ -2851,11 +2807,17 @@ def test_new_namespace_slash_command_is_a_boundary(tmp_path: Path, label: str, b
             "Base directory for this skill: /home/u/.claude/plugins/cache/gh-flow-skills/gh-flow/0.1.0/skills/issue",
         ),
         ("skill-base-dir-flat", "Base directory for this skill: /home/u/.claude/skills/gh-flow/skills/issue"),
-        ("skill-h1", "# gh-flow:issue — Issue → PR composition"),
     ],
 )
-def test_new_namespace_boundary_surfaces(tmp_path: Path, label: str, boundary: str) -> None:
-    """All four boundary surfaces have a new-namespace twin."""
+def test_installed_plugin_base_dirs_are_boundaries(tmp_path: Path, label: str, boundary: str) -> None:
+    """Surface (c) for the path-nested layouts an installed plugin produces.
+
+    `test_base_dir_marker_recognized_as_flow_start` covers only the
+    hyphen-joined `…/gh-flow-issue` shape; these three pin the `gh-flow…/issue`
+    layouts that a pattern fixed to one nesting depth silently misses. The
+    other three surfaces — raw slash command, `<command-name>` wrapper and
+    SKILL.md H1 — are covered with stronger assertions above.
+    """
     transcript = _write_transcript(tmp_path, [_user_text(boundary), _assistant_text("done!")])
     result = _run_hook(_hook_event(transcript))
     assert result.returncode == 0

--- a/tests/integration/test_skill_completion_guard.py
+++ b/tests/integration/test_skill_completion_guard.py
@@ -261,11 +261,17 @@ def test_raw_slash_command_boundary_detected(tmp_path: Path) -> None:
     assert "gh-issue-implement" in decision["reason"]
 
 
-def test_wrapped_command_boundary_detected(tmp_path: Path) -> None:
+@pytest.mark.parametrize("spelling", ["gh-pr-create", "gh-pr:create"])
+def test_wrapped_command_boundary_detected(tmp_path: Path, spelling: str) -> None:
+    """Surface (b), the `<command-name>` wrapper, in both live spellings.
+
+    The plugin-namespace form is the one the `gh-pr-skills` migration made
+    live (#1677); it has to reach the same catalog key as the hyphen form.
+    """
     transcript = _write_transcript(
         tmp_path,
         [
-            _user_slash_command("gh-pr-create", "42"),
+            _user_slash_command(spelling, "42"),
             _assistant_text("running"),
         ],
     )
@@ -333,6 +339,12 @@ def test_mid_sentence_command_does_not_match(tmp_path: Path) -> None:
         "/gh:pr:review --ai agy 123",
         "/gh:pr:reply 123",
         "/gh:pr:resolve-conflict 123",
+        # Plugin-namespace siblings: loosening the separator (#1677) must not
+        # resurrect the false-match class for the mixed spelling either.
+        "/gh-pr:review 99",
+        "/gh-pr:approve 99",
+        "/gh-pr:merge 51",
+        "/gh-pr:merge-train",
     ],
 )
 def test_hyphenated_sibling_command_not_matched_as_a_catalog_key(tmp_path: Path, sibling: str) -> None:
@@ -354,9 +366,26 @@ def test_hyphenated_sibling_command_not_matched_as_a_catalog_key(tmp_path: Path,
     assert result.stdout.strip() == "", f"{sibling} should not be a boundary"
 
 
-@pytest.mark.parametrize("cmd", ["/gh-pr-create", "/gh-pr-create 123", "/gh:pr:create", "/gh:pr:create 123"])
-def test_bare_command_still_matched(tmp_path: Path, cmd: str) -> None:
-    """The real `/gh-pr-create` (hyphen or colon form, bare or with args) must
+@pytest.mark.parametrize(
+    ("cmd", "key"),
+    [
+        ("/gh-pr-create", "gh-pr-create"),
+        ("/gh-pr-create 123", "gh-pr-create"),
+        ("/gh:pr:create", "gh-pr-create"),
+        ("/gh:pr:create 123", "gh-pr-create"),
+        # Plugin-namespace spelling (#1677): hyphen inside the namespace,
+        # colon before the skill. The regex used to offer only the two
+        # whole-string spellings above, so this mixture matched nothing and
+        # the guard failed open for every migrated skill. Separators are now
+        # independently `-` or `:`.
+        ("/gh-pr:create", "gh-pr-create"),
+        ("/gh-pr:create 1677 origin", "gh-pr-create"),
+        ("/gh-pr:commit", "gh-pr-commit"),
+        ("/gh-pr:commit 1677 origin", "gh-pr-commit"),
+    ],
+)
+def test_bare_command_still_matched(tmp_path: Path, cmd: str, key: str) -> None:
+    """A real catalog command (any separator mix, bare or with args) must
     still be detected (issue #1164 / PR #1169). Whitespace or EOL after the
     name passes the `(?![\\w:-])` lookahead."""
     transcript = _write_transcript(
@@ -370,7 +399,7 @@ def test_bare_command_still_matched(tmp_path: Path, cmd: str) -> None:
     assert result.returncode == 0
     decision = json.loads(result.stdout)
     assert decision["decision"] == "block", f"{cmd!r} should be a boundary"
-    assert "gh-pr-create" in decision["reason"]
+    assert key in decision["reason"]
 
 
 def test_tool_result_command_mention_not_boundary(tmp_path: Path) -> None:
@@ -1090,38 +1119,6 @@ def test_trace_reports_async_wait_reprieve(tmp_path: Path) -> None:
 
 
 @pytest.mark.parametrize(
-    "cmd",
-    [
-        "/gh-pr:create",
-        "/gh-pr:create 1677 origin",
-        "/gh-pr:commit",
-        "/gh-pr:commit 1677 origin",
-    ],
-)
-def test_plugin_namespace_command_is_a_boundary(tmp_path: Path, cmd: str) -> None:
-    """`/gh-pr:create` — hyphen inside the namespace, colon before the skill.
-
-    The `gh-pr-skills` migration (#1677) made this the live invocation form of
-    the `gh-pr-create` / `gh-pr-commit` catalog keys. The boundary regex used
-    to offer only two whole-string spellings per key — fully hyphenated
-    (`gh-pr-create`) or fully colonized (`gh:pr:create`) — so this mixture
-    matched nothing, no boundary was detected, and the guard failed open for
-    every migrated skill. Separators are now independently `-` or `:`.
-    """
-    transcript = _write_transcript(
-        tmp_path,
-        [
-            _user_text(cmd),
-            _assistant_text("running"),
-        ],
-    )
-    result = _run_hook(_hook_event(transcript))
-    assert result.returncode == 0
-    assert result.stdout.strip(), f"{cmd!r} must be detected as a boundary"
-    assert json.loads(result.stdout)["decision"] == "block"
-
-
-@pytest.mark.parametrize(
     ("cmd", "skill", "steps"),
     [
         ("/gh-pr:create", "gh-pr-create", ["push-and-create", "labels", "board-sync", "report"]),
@@ -1137,26 +1134,6 @@ def test_plugin_namespace_required_steps_satisfy(tmp_path: Path, cmd: str, skill
     result = _run_hook(_hook_event(transcript))
     assert result.returncode == 0
     assert result.stdout.strip() == "", f"stdout={result.stdout!r}"
-
-
-@pytest.mark.parametrize(
-    "sibling",
-    ["/gh-pr:review 99", "/gh-pr:approve 99", "/gh-pr:merge 51", "/gh-pr:merge-train"],
-)
-def test_plugin_namespace_sibling_not_matched_as_gh_pr(tmp_path: Path, sibling: str) -> None:
-    """Loosening the separator must not resurrect the #1164 false-match class.
-
-    `/gh-pr:review` is a real skill with no catalog entry; it must not be read
-    as the `gh-pr` entry. Surface (a)'s `(?![\\w:-])` lookahead is what keeps
-    that true, and it has to keep holding for the colon spelling too.
-    """
-    transcript = _write_transcript(
-        tmp_path,
-        [_user_text(sibling), _assistant_text("running")],
-    )
-    result = _run_hook(_hook_event(transcript))
-    assert result.returncode == 0
-    assert result.stdout.strip() == "", f"{sibling} must not be a boundary"
 
 
 # ---------------------------------------------------------------------------
@@ -1190,22 +1167,6 @@ def test_multi_hyphen_name_accepts_every_separator_mix(tmp_path: Path, spelling:
     assert decision["decision"] == "block", f"{spelling!r} must be a boundary"
     # Whatever spelling matched, the guard reports the canonical hyphen key.
     assert "gh-issue-implement" in decision["reason"]
-
-
-def test_plugin_namespace_wrapped_command_boundary(tmp_path: Path) -> None:
-    """Surface (b), the `<command-name>` wrapper, for a namespaced skill.
-
-    codex FOLLOW-UP on PR #1694: the first round covered only surface (a).
-    """
-    transcript = _write_transcript(
-        tmp_path,
-        [_user_slash_command("gh-pr:create", "1677"), _assistant_text("running")],
-    )
-    result = _run_hook(_hook_event(transcript))
-    assert result.returncode == 0
-    decision = json.loads(result.stdout)
-    assert decision["decision"] == "block"
-    assert "gh-pr-create" in decision["reason"]
 
 
 def test_plugin_namespace_skill_h1_boundary(tmp_path: Path) -> None:

--- a/tests/integration/test_skill_completion_guard.py
+++ b/tests/integration/test_skill_completion_guard.py
@@ -37,7 +37,7 @@ def _run_hook(
 
     final_env: dict[str, str] = _os.environ.copy()
     # Default: point the hook at the shipped catalog so the standard
-    # gh-issue-implement / gh-pr / gh-commit entries are in scope.
+    # gh-issue-implement / gh-pr-create / gh-pr-commit entries are in scope.
     final_env.setdefault("GH_SKILL_GUARD_CATALOG", str(CATALOG_PATH))
     if env is not None:
         final_env.update(env)
@@ -265,7 +265,7 @@ def test_wrapped_command_boundary_detected(tmp_path: Path) -> None:
     transcript = _write_transcript(
         tmp_path,
         [
-            _user_slash_command("gh-pr", "42"),
+            _user_slash_command("gh-pr-create", "42"),
             _assistant_text("running"),
         ],
     )
@@ -273,7 +273,7 @@ def test_wrapped_command_boundary_detected(tmp_path: Path) -> None:
     assert result.returncode == 0
     decision = json.loads(result.stdout)
     assert decision["decision"] == "block"
-    assert "gh-pr" in decision["reason"]
+    assert "gh-pr-create" in decision["reason"]
 
 
 def test_skill_tool_use_boundary_detected(tmp_path: Path) -> None:
@@ -281,7 +281,7 @@ def test_skill_tool_use_boundary_detected(tmp_path: Path) -> None:
     transcript = _write_transcript(
         tmp_path,
         [
-            _assistant_skill("gh-commit"),
+            _assistant_skill("gh-pr-commit"),
             _assistant_text("running"),
         ],
     )
@@ -289,7 +289,7 @@ def test_skill_tool_use_boundary_detected(tmp_path: Path) -> None:
     assert result.returncode == 0
     decision = json.loads(result.stdout)
     assert decision["decision"] == "block"
-    assert "gh-commit" in decision["reason"]
+    assert "gh-pr-commit" in decision["reason"]
 
 
 def test_colon_namespace_skill_tool_use_counted(tmp_path: Path) -> None:
@@ -308,11 +308,11 @@ def test_colon_namespace_skill_tool_use_counted(tmp_path: Path) -> None:
 
 
 def test_mid_sentence_command_does_not_match(tmp_path: Path) -> None:
-    """Mid-sentence mention of /gh-pr is not a boundary (PR #386 regression class)."""
+    """Mid-sentence mention of /gh-pr-create is not a boundary (PR #386 regression class)."""
     transcript = _write_transcript(
         tmp_path,
         [
-            _user_text("I was reading docs about /gh-pr and got confused"),
+            _user_text("I was reading docs about /gh-pr-create and got confused"),
             _assistant_text("sure"),
         ],
     )
@@ -335,13 +335,12 @@ def test_mid_sentence_command_does_not_match(tmp_path: Path) -> None:
         "/gh:pr:resolve-conflict 123",
     ],
 )
-def test_hyphenated_sibling_command_not_matched_as_gh_pr(tmp_path: Path, sibling: str) -> None:
-    """Line-start `/gh-pr-review` etc. must NOT be read as a `gh-pr` boundary (issue #1164).
+def test_hyphenated_sibling_command_not_matched_as_a_catalog_key(tmp_path: Path, sibling: str) -> None:
+    """Line-start `/gh-pr-review` etc. must NOT arm the guard (issue #1164).
 
-    Both `-` and `:` are non-word chars, so the old `\\b` after `gh-pr` in
-    surface (a) let `/gh-pr-review` (and, after the first fix, the colon
-    form `/gh:pr:review`) false-match the `gh-pr` catalog entry, wedging the
-    Stop hook into a permanent block. Surface (a) now uses `(?![\\w:-])`.
+    Both `-` and `:` are non-word chars, so a `\\b` at the end of surface (a)
+    let a longer sibling command false-match a shorter catalog key, wedging
+    the Stop hook into a permanent block. Surface (a) uses `(?![\\w:-])`.
     """
     transcript = _write_transcript(
         tmp_path,
@@ -352,14 +351,14 @@ def test_hyphenated_sibling_command_not_matched_as_gh_pr(tmp_path: Path, sibling
     )
     result = _run_hook(_hook_event(transcript))
     assert result.returncode == 0
-    assert result.stdout.strip() == "", f"{sibling} should not be a gh-pr boundary"
+    assert result.stdout.strip() == "", f"{sibling} should not be a boundary"
 
 
-@pytest.mark.parametrize("cmd", ["/gh-pr", "/gh-pr 123", "/gh:pr", "/gh:pr 123"])
-def test_bare_gh_pr_command_still_matched(tmp_path: Path, cmd: str) -> None:
-    """The real `/gh-pr` (hyphen or colon form, bare or with args) must still
-    be detected (issue #1164 / PR #1169). Whitespace or EOL after the name
-    passes the `(?![\\w:-])` lookahead."""
+@pytest.mark.parametrize("cmd", ["/gh-pr-create", "/gh-pr-create 123", "/gh:pr:create", "/gh:pr:create 123"])
+def test_bare_command_still_matched(tmp_path: Path, cmd: str) -> None:
+    """The real `/gh-pr-create` (hyphen or colon form, bare or with args) must
+    still be detected (issue #1164 / PR #1169). Whitespace or EOL after the
+    name passes the `(?![\\w:-])` lookahead."""
     transcript = _write_transcript(
         tmp_path,
         [
@@ -370,17 +369,17 @@ def test_bare_gh_pr_command_still_matched(tmp_path: Path, cmd: str) -> None:
     result = _run_hook(_hook_event(transcript))
     assert result.returncode == 0
     decision = json.loads(result.stdout)
-    assert decision["decision"] == "block", f"{cmd!r} should be a gh-pr boundary"
-    assert "gh-pr" in decision["reason"]
+    assert decision["decision"] == "block", f"{cmd!r} should be a boundary"
+    assert "gh-pr-create" in decision["reason"]
 
 
 def test_tool_result_command_mention_not_boundary(tmp_path: Path) -> None:
-    """A `/gh-pr` substring in a tool_result block is documentation, not a real boundary."""
+    """A `/gh-pr-create` substring in a tool_result block is documentation, not a real boundary."""
     transcript = _write_transcript(
         tmp_path,
         [
             _user_text("read the docs"),
-            _user_tool_result("Examples: run `/gh-pr` or `/gh-commit` or `/gh-issue-implement N`"),
+            _user_tool_result("Examples: run `/gh-pr-create` or `/gh-pr-commit` or `/gh-issue-implement N`"),
             _assistant_text("ok"),
         ],
     )
@@ -438,16 +437,16 @@ def test_missing_board_transition_step_blocks(tmp_path: Path) -> None:
     assert "gh-issue-implement" in decision["reason"]
 
 
-def test_missing_gh_pr_board_sync_step_blocks(tmp_path: Path) -> None:
-    """The other half of issue #753: gh-pr Step 7 board-sync skipped."""
+def test_missing_gh_pr_create_board_sync_step_blocks(tmp_path: Path) -> None:
+    """The other half of issue #753: gh-pr-create Step 7 board-sync skipped."""
     transcript = _write_transcript(
         tmp_path,
         [
-            _user_text("/gh-pr"),
-            _emit_marker("gh-pr", "push-and-create"),
-            _emit_marker("gh-pr", "labels"),
+            _user_text("/gh-pr-create"),
+            _emit_marker("gh-pr-create", "push-and-create"),
+            _emit_marker("gh-pr-create", "labels"),
             # board-sync deliberately omitted.
-            _emit_marker("gh-pr", "report"),
+            _emit_marker("gh-pr-create", "report"),
         ],
     )
     result = _run_hook(_hook_event(transcript))
@@ -455,7 +454,7 @@ def test_missing_gh_pr_board_sync_step_blocks(tmp_path: Path) -> None:
     decision = json.loads(result.stdout)
     assert decision["decision"] == "block"
     assert "board-sync" in decision["reason"]
-    assert "gh-pr" in decision["reason"]
+    assert "gh-pr-create" in decision["reason"]
 
 
 def test_markers_in_assistant_text_also_count(tmp_path: Path) -> None:
@@ -463,10 +462,10 @@ def test_markers_in_assistant_text_also_count(tmp_path: Path) -> None:
     transcript = _write_transcript(
         tmp_path,
         [
-            _user_text("/gh-commit"),
-            _assistant_text("[step:gh-commit/stage-commit] OK"),
-            _assistant_text("[step:gh-commit/metrics-board-sync] OK"),
-            _assistant_text("[step:gh-commit/report] OK"),
+            _user_text("/gh-pr-commit"),
+            _assistant_text("[step:gh-pr-commit/stage-commit] OK"),
+            _assistant_text("[step:gh-pr-commit/metrics-board-sync] OK"),
+            _assistant_text("[step:gh-pr-commit/report] OK"),
         ],
     )
     result = _run_hook(_hook_event(transcript))
@@ -475,14 +474,14 @@ def test_markers_in_assistant_text_also_count(tmp_path: Path) -> None:
 
 
 def test_colon_skill_markers_recognized(tmp_path: Path) -> None:
-    """Markers written as `gh:commit/<step>` (colon form) should also satisfy."""
+    """Markers written as `gh-pr:commit/<step>` (colon form) should also satisfy."""
     transcript = _write_transcript(
         tmp_path,
         [
-            _user_text("/gh-commit"),
-            _emit_marker("gh:commit", "stage-commit"),
-            _emit_marker("gh:commit", "metrics-board-sync"),
-            _emit_marker("gh:commit", "report"),
+            _user_text("/gh-pr-commit"),
+            _emit_marker("gh-pr:commit", "stage-commit"),
+            _emit_marker("gh-pr:commit", "metrics-board-sync"),
+            _emit_marker("gh-pr:commit", "report"),
         ],
     )
     result = _run_hook(_hook_event(transcript))
@@ -495,10 +494,10 @@ def test_partial_marker_without_ok_does_not_satisfy(tmp_path: Path) -> None:
     transcript = _write_transcript(
         tmp_path,
         [
-            _user_text("/gh-commit"),
-            _user_tool_result("[step:gh-commit/stage-commit]\n"),
-            _user_tool_result("[step:gh-commit/metrics-board-sync]\n"),
-            _user_tool_result("[step:gh-commit/report]\n"),
+            _user_text("/gh-pr-commit"),
+            _user_tool_result("[step:gh-pr-commit/stage-commit]\n"),
+            _user_tool_result("[step:gh-pr-commit/metrics-board-sync]\n"),
+            _user_tool_result("[step:gh-pr-commit/report]\n"),
         ],
     )
     result = _run_hook(_hook_event(transcript))
@@ -512,16 +511,16 @@ def test_unrelated_skill_markers_do_not_satisfy(tmp_path: Path) -> None:
     transcript = _write_transcript(
         tmp_path,
         [
-            _user_text("/gh-commit"),
-            _emit_marker("gh-pr", "push-and-create"),
-            _emit_marker("gh-pr", "labels"),
+            _user_text("/gh-pr-commit"),
+            _emit_marker("gh-pr-create", "push-and-create"),
+            _emit_marker("gh-pr-create", "labels"),
         ],
     )
     result = _run_hook(_hook_event(transcript))
     assert result.returncode == 0
     decision = json.loads(result.stdout)
     assert decision["decision"] == "block"
-    assert "gh-commit" in decision["reason"]
+    assert "gh-pr-commit" in decision["reason"]
 
 
 # ---------------------------------------------------------------------------
@@ -566,7 +565,7 @@ def test_unknown_skill_in_transcript_does_not_block(tmp_path: Path) -> None:
 
 
 # ---------------------------------------------------------------------------
-# Multi-boundary scenarios (gh-issue-flow chain compatibility)
+# Multi-boundary scenarios (gh-flow:issue chain compatibility)
 # ---------------------------------------------------------------------------
 
 
@@ -584,9 +583,9 @@ def test_most_recent_boundary_governs(tmp_path: Path) -> None:
             _emit_marker("gh-issue-implement", "board-transition"),
             _emit_marker("gh-issue-implement", "implement"),
             _emit_marker("gh-issue-implement", "report"),
-            # Now the model moves on to gh-commit but skips half the steps.
-            _assistant_skill("gh-commit"),
-            _emit_marker("gh-commit", "stage-commit"),
+            # Now the model moves on to gh-pr-commit but skips half the steps.
+            _assistant_skill("gh-pr-commit"),
+            _emit_marker("gh-pr-commit", "stage-commit"),
             # metrics-board-sync and report missing.
         ],
     )
@@ -594,34 +593,34 @@ def test_most_recent_boundary_governs(tmp_path: Path) -> None:
     assert result.returncode == 0
     decision = json.loads(result.stdout)
     assert decision["decision"] == "block"
-    assert "gh-commit" in decision["reason"]
+    assert "gh-pr-commit" in decision["reason"]
     assert "metrics-board-sync" in decision["reason"]
-    # The previous skill's report markers must NOT bleed into gh-commit.
+    # The previous skill's report markers must NOT bleed into gh-pr-commit.
     assert "fetch-issue" not in decision["reason"]
 
 
 def test_chain_of_catalog_skills_with_each_completing_allows_stop(tmp_path: Path) -> None:
-    """The gh-issue-flow happy path: each sub-skill emits all its required markers."""
+    """The gh-flow:issue happy path: each sub-skill emits all its required markers."""
     transcript = _write_transcript(
         tmp_path,
         [
-            _user_text("/gh-issue-flow 42"),
+            _user_text("/gh-flow:issue 42"),
             _assistant_skill("gh-issue-implement"),
             _emit_marker("gh-issue-implement", "fetch-issue"),
             _emit_marker("gh-issue-implement", "self-assign"),
             _emit_marker("gh-issue-implement", "board-transition"),
             _emit_marker("gh-issue-implement", "implement"),
             _emit_marker("gh-issue-implement", "report"),
-            _assistant_skill("gh-commit"),
-            _emit_marker("gh-commit", "stage-commit"),
-            _emit_marker("gh-commit", "metrics-board-sync"),
-            _emit_marker("gh-commit", "report"),
-            _assistant_skill("gh-pr"),
-            _emit_marker("gh-pr", "push-and-create"),
-            _emit_marker("gh-pr", "labels"),
-            _emit_marker("gh-pr", "board-sync"),
-            _emit_marker("gh-pr", "report"),
-            _assistant_text("gh:issue-flow complete (#42)"),
+            _assistant_skill("gh-pr-commit"),
+            _emit_marker("gh-pr-commit", "stage-commit"),
+            _emit_marker("gh-pr-commit", "metrics-board-sync"),
+            _emit_marker("gh-pr-commit", "report"),
+            _assistant_skill("gh-pr-create"),
+            _emit_marker("gh-pr-create", "push-and-create"),
+            _emit_marker("gh-pr-create", "labels"),
+            _emit_marker("gh-pr-create", "board-sync"),
+            _emit_marker("gh-pr-create", "report"),
+            _assistant_text("gh-flow:issue complete (#42)"),
         ],
     )
     result = _run_hook(_hook_event(transcript))
@@ -842,14 +841,14 @@ def test_colon_form_step_prefix_accepted(tmp_path: Path) -> None:
 
 
 def test_async_wait_marker_for_another_skill_does_not_reprieve(tmp_path: Path) -> None:
-    """Grace never crosses skills — a `gh-pr/report` marker cannot excuse
+    """Grace never crosses skills — a `gh-pr-create/report` marker cannot excuse
     `gh-issue-implement/report`."""
     transcript = _write_transcript(
         tmp_path,
         [
             *_partially_implemented(),
             _async_wait_text("gh-issue-implement/implement"),
-            _async_wait_text("gh-pr/report"),
+            _async_wait_text("gh-pr-create/report"),
         ],
     )
     result = _run_hook(_hook_event(transcript))


### PR DESCRIPTION
## Summary
- #1410 Phase 4-2: #1678 이 D-12 전환기 조치로 Stop hook 두 개에 넣은 "옛 이름 + 새 이름" dual-form 인식에서 옛 이름 절반을 제거한다.
- 선행 조건인 Phase 4-1(#1680, dotfiles `claude/skills/` 원본 삭제)과 Phase 4-3(#1682, 자동화 dispatch 문자열 전환)이 모두 CLOSED 이므로 옛 이름은 더 이상 어디서도 발생하지 않는다 (NF-1 충족).
- 죽은 매칭 코드와 "지금도 옛 이름이 쓰이나?" 라는 혼란을 함께 걷어낸다.

## Changes
- `claude/hooks/gh_issue_flow_stop_guard.py` (F-1~F-4): `EXPECTED_CHAIN` 을 신규 이름 `(hyphen, colon)` 2-form 으로 축소하고, 그에 따라 바뀌는 슬롯 canonical 이름과 `_SUB_SKILL_HINT_ALIAS` 키를 재정렬. `_USER_BOUNDARY_RE` 는 신규 네임스페이스 (a)~(d) 만 유지 — `gh-flow:issue-relay` 를 배제하는 `(?![\w-])` 종단과 설치 경로 2종을 모두 받는 (c) 의 유연한 경로 세그먼트는 그대로 둠. `FLOW_SKILL_NAMES` / `TERMINAL_PATTERNS` / `_TERMINAL_COMMAND_RE` 도 단일 네임스페이스로 축소.
- `claude/hooks/devx_autopilot_stop_guard.py` (F-5): `_STEP_MARKER_RE` / `TERMINAL_PATTERNS` / `_USER_BOUNDARY_RE` / `FLOW_SKILL_NAMES` 에서 `devx-autopilot` · `devx:autopilot` 매칭 제거. `_STEP_LABELS` 는 #1678 F-9 에서 이미 갱신돼 있어 재확인만.
- 두 hook 의 block reason 접두사(`... incomplete:`)를 신규 이름으로 이관: 이 문자열은 `_HARNESS_INJECTION_MARKERS` 가 자기 자신의 재주입 텍스트를 알아보는 근거라 한쪽만 바꾸면 마커가 매칭을 멈춘다. 같은 이유로 reason 본문이 지시하던 마커와 SKILL.md 경로도 갱신했다 — 예전 값은 새 `_STEP_MARKER_RE` 가 받지 못하는 마커와 #1680 에서 삭제된 경로를 가리키고 있었다.
- `claude/hooks/skill_step_catalog.yml` (F-7): 옛 키 `gh-pr` · `gh-commit` 삭제, #1677 이 추가한 `gh-pr-create` · `gh-pr-commit` 만 유지.
- `shell-common/functions/claude_stop_hook_install.sh` (F-8): 로그/주석 문자열만 신규 이름으로. `_csh_hook_command` 가 가리키는 실제 파일 경로와 hook 스크립트 파일명은 이슈 확정 사항대로 무변경.
- 테스트 3종 (F-6, F-7): 옛 이름 리터럴 전량 제거. #1678 F-11 이 이미 동등한 신규 이름 케이스를 추가해 둔 자리에서는 옛 케이스를 변환하지 않고 삭제해 중복을 막았다.

## Test plan
- [x] `pytest tests/integration/test_gh_issue_flow_stop_guard.py test_devx_autopilot_stop_guard.py test_skill_completion_guard.py` — 262 passed
- [x] 전체 pytest — 1557 passed, 1 failed (`test_command_docs.py::test_committed_docs_match_a_fresh_render`, HEAD 에서도 동일하게 실패하는 pre-existing)
- [x] 변경 파일을 실제로 다루는 bats 3종 (`claude_stop_hook_install.bats`, `session_start_settings_drift_hook.bats`, `test_no_backup_accumulation.bats`) — 30/30 pass
- [x] `mise run lint` — ruff check/format + mypy 통과, lint-docs errors=0
- [x] NF-2: `grep -n "gh-issue-flow\|devx-autopilot\b" tests/integration/test_*.py` 빈 결과
- [x] NF-1: 선행 이슈 #1680 · #1682 모두 CLOSED 확인 후 착수

## Related
Closes #1681

---
<details>
<summary>🤖 AI Metrics · 📊 ~44000 tokens · 👤 ~24 h · 🤖 ~0 min</summary>

<!-- ai-metrics:gh-pr -->
📊 ~44000 tokens · 👤 ~24 h · 🤖 ~0 min
<!-- /ai-metrics:gh-pr -->

</details>
