### PR TITLE
fix(skills): 엔트리 단위 stale symlink 정리로 4개 하네스의 숨은 스킬 복구

### DIFF
--- a/scripts/setup-skills-ssot.sh
+++ b/scripts/setup-skills-ssot.sh
@@ -45,6 +45,14 @@
 _SCRIPT_PATH="$(realpath "${BASH_SOURCE[0]}")"
 DOTFILES_ROOT="$(cd "$(dirname "$_SCRIPT_PATH")/.." && pwd)"
 
+# 워크트리에서 실행하면 DOTFILES_ROOT 는 워크트리 경로다. 정리 대상 링크는
+# main 체크아웃 경로(`~/dotfiles/claude/skills/...`)로 적혀 있으므로 워크트리
+# 경로만 보면 하나도 매치되지 않는다 — git common dir 로 main 체크아웃을 함께
+# 구해 두 경로 모두를 레거시 패턴으로 인정한다 (#1732).
+DOTFILES_MAIN_ROOT="$DOTFILES_ROOT"
+_git_common_dir="$(git -C "$DOTFILES_ROOT" rev-parse --path-format=absolute --git-common-dir 2>/dev/null || true)"
+[ -n "$_git_common_dir" ] && DOTFILES_MAIN_ROOT="$(dirname "$_git_common_dir")"
+
 # Load UX library
 UX_LIB="${DOTFILES_ROOT}/shell-common/tools/ux_lib/ux_lib.sh"
 if [ -f "$UX_LIB" ]; then
@@ -91,10 +99,14 @@ _realpath_or_self() {
 # PR #1729).
 # Usage: _ssot_is_legacy_broken_link <resolved_target_path>
 _ssot_is_legacy_broken_link() {
-    case "$1" in
-        "${DOTFILES_ROOT}/claude/skills" | "${DOTFILES_ROOT}/claude/skills"/*) return 0 ;;
-        *) return 1 ;;
-    esac
+    local root
+    for root in "$DOTFILES_ROOT" "$DOTFILES_MAIN_ROOT"; do
+        [ -n "$root" ] || continue
+        case "$1" in
+            "${root}/claude/skills" | "${root}/claude/skills"/*) return 0 ;;
+        esac
+    done
+    return 1
 }
 
 # 빈 문자열 = 워크스페이스 없음/너무 넓음 → 연결할 소스가 없다.
@@ -260,7 +272,11 @@ link_skills_compose() {
                 || [ "$(readlink -f "$link_target" 2>/dev/null)" = "$source_realpath" ]; then
                 continue
             fi
-            if skill_source_is_managed "$current_link"; then
+            # 디렉토리-단위 마이그레이션과 같은 판정을 엔트리에도 적용한다
+            # (#1732): 옛 SSOT 를 가리키다 끊어진 링크는 이름이 살아 있는
+            # 소스와 겹치는 한 그 스킬을 계속 가린다.
+            if skill_source_is_managed "$current_link" \
+                || { [ ! -e "$link_target" ] && _ssot_is_legacy_broken_link "$current_link"; }; then
                 rm -f "$link_target"
                 refreshed=$((refreshed + 1))
             else
@@ -288,6 +304,14 @@ link_skills_compose() {
     for existing in "$target"/*; do
         [ -L "$existing" ] || continue
         existing_target_path="$(readlink "$existing")"
+        # 이름이 더 이상 어떤 소스와도 겹치지 않는 레거시 링크는 위 엔트리
+        # 루프가 아예 방문하지 않는다 — 여기서만 정리된다 (#1732).
+        if [ ! -e "$existing" ] && _ssot_is_legacy_broken_link "$existing_target_path"; then
+            log_info "[$tool] legacy stale entry 정리: $existing"
+            rm -f "$existing"
+            pruned=$((pruned + 1))
+            continue
+        fi
         skill_source_is_managed "$existing_target_path" || continue
         if [ ! -d "$existing_target_path" ]; then
             log_info "[$tool] stale entry 정리: $existing"
@@ -329,16 +353,24 @@ link_skills_individual_codex() {
         source_realpath="$(readlink -f "$skill_path")"
 
         if [ -L "$skill_target" ]; then
-            local current_target
+            local current_target current_target_raw
             current_target="$(readlink -f "$skill_target" 2>/dev/null || true)"
             if [ "$current_target" = "$source_realpath" ]; then
                 unchanged=$((unchanged + 1))
                 continue
             fi
 
-            log_dim "[codex] 기존 사용자 symlink 보존: $skill_target"
-            skipped=$((skipped + 1))
-            continue
+            # compose 쪽과 동일한 레거시 판정 (#1732). 끊어진 링크는
+            # `readlink -f` 가 값을 못 내므로 raw 문자열로 매치한다.
+            current_target_raw="$(readlink "$skill_target" 2>/dev/null || true)"
+            if [ ! -e "$skill_target" ] && _ssot_is_legacy_broken_link "$current_target_raw"; then
+                rm -f "$skill_target"
+                migrated=$((migrated + 1))
+            else
+                log_dim "[codex] 기존 사용자 symlink 보존: $skill_target"
+                skipped=$((skipped + 1))
+                continue
+            fi
         fi
 
         if [ -e "$skill_target" ] && [ ! -d "$skill_target" ]; then
@@ -418,9 +450,12 @@ link_skills_individual_codex() {
         fi
 
         if [ -L "$existing_skill_entry" ]; then
-            local stale_target
+            local stale_target stale_target_raw
             stale_target="$(readlink -f "$existing_skill_entry" 2>/dev/null || true)"
-            if skill_source_is_managed "$stale_target"; then
+            stale_target_raw="$(readlink "$existing_skill_entry" 2>/dev/null || true)"
+            if skill_source_is_managed "$stale_target" \
+                || { [ ! -e "$existing_skill_entry" ] \
+                    && _ssot_is_legacy_broken_link "$stale_target_raw"; }; then
                 rm -f "$existing_skill_entry" || {
                     log_error "[codex] stale skill 제거 실패: $existing_skill_entry"
                     continue

--- a/scripts/setup-skills-ssot.sh
+++ b/scripts/setup-skills-ssot.sh
@@ -126,8 +126,19 @@ _ssot_is_legacy_broken_link() {
 # 다수이므로 루프마다 fork 를 아끼는 효과).
 # Usage: _ssot_link_is_legacy_stale <link_path>
 _ssot_link_is_legacy_stale() {
+    local _target
     [ ! -e "$1" ] || return 1
-    _ssot_is_legacy_broken_link "$(readlink "$1" 2>/dev/null)"
+    _target="$(readlink "$1" 2>/dev/null)"
+    # 상대 경로로 적힌 링크도 같은 판정을 받아야 한다 (#1732 agy FOLLOW-UP).
+    # 이 스크립트 자신은 항상 절대 경로로 링크를 만들지만, 수동/외부 도구가
+    # 만든 상대 경로 링크는 절대 경로 prefix 매칭을 그냥 빠져나간다. 끊어진
+    # 링크라 `readlink -f` 는 못 쓰므로, 존재 여부와 무관하게 `..` 를 펴 주는
+    # `realpath -m` 으로 링크 자신의 디렉토리 기준 절대 경로를 만든다.
+    case "$_target" in
+        "" | /*) ;;
+        *) _target="$(realpath -m "$(dirname "$1")/$_target" 2>/dev/null)" ;;
+    esac
+    _ssot_is_legacy_broken_link "$_target"
 }
 
 # 빈 문자열 = 워크스페이스 없음/너무 넓음 → 연결할 소스가 없다.

--- a/scripts/setup-skills-ssot.sh
+++ b/scripts/setup-skills-ssot.sh
@@ -45,14 +45,6 @@
 _SCRIPT_PATH="$(realpath "${BASH_SOURCE[0]}")"
 DOTFILES_ROOT="$(cd "$(dirname "$_SCRIPT_PATH")/.." && pwd)"
 
-# 워크트리에서 실행하면 DOTFILES_ROOT 는 워크트리 경로다. 정리 대상 링크는
-# main 체크아웃 경로(`~/dotfiles/claude/skills/...`)로 적혀 있으므로 워크트리
-# 경로만 보면 하나도 매치되지 않는다 — git common dir 로 main 체크아웃을 함께
-# 구해 두 경로 모두를 레거시 패턴으로 인정한다 (#1732).
-DOTFILES_MAIN_ROOT="$DOTFILES_ROOT"
-_git_common_dir="$(git -C "$DOTFILES_ROOT" rev-parse --path-format=absolute --git-common-dir 2>/dev/null || true)"
-[ -n "$_git_common_dir" ] && DOTFILES_MAIN_ROOT="$(dirname "$_git_common_dir")"
-
 # Load UX library
 UX_LIB="${DOTFILES_ROOT}/shell-common/tools/ux_lib/ux_lib.sh"
 if [ -f "$UX_LIB" ]; then
@@ -61,6 +53,21 @@ else
     echo "Error: UX library not found at $UX_LIB"
     exit 1
 fi
+
+# 워크트리에서 실행하면 DOTFILES_ROOT 는 워크트리 경로다. 정리 대상 링크는
+# main 체크아웃 경로(`~/dotfiles/claude/skills/...`)로 적혀 있으므로 워크트리
+# 경로만 보면 하나도 매치되지 않는다 — 두 경로 모두를 레거시 패턴으로
+# 인정해야 한다 (#1732). main 체크아웃 해석은 #589 의 canonicalize SSOT 를
+# 그대로 쓴다 — 서브모듈 오탐 가드와 DOTFILES_ROOT_NO_CANONICALIZE 탈출구를
+# 여기서 다시 구현하지 않기 위해서다.
+DOTFILES_ROOT_LIB="${DOTFILES_ROOT}/shell-common/functions/dotfiles_root.sh"
+if [ -f "$DOTFILES_ROOT_LIB" ]; then
+    source "$DOTFILES_ROOT_LIB"
+else
+    echo "Error: dotfiles root library not found at $DOTFILES_ROOT_LIB"
+    exit 1
+fi
+DOTFILES_MAIN_ROOT="$(_resolve_dotfiles_root_canonical "$DOTFILES_ROOT")"
 
 # 소스 판별/열거의 SSOT (issue #1652 / #1410 F-6 → #1680). Claude Code
 # 계정 쪽(shell-common/tools/integrations/claude.sh)이 같은 파일을 읽으므로
@@ -99,14 +106,28 @@ _realpath_or_self() {
 # PR #1729).
 # Usage: _ssot_is_legacy_broken_link <resolved_target_path>
 _ssot_is_legacy_broken_link() {
-    local root
-    for root in "$DOTFILES_ROOT" "$DOTFILES_MAIN_ROOT"; do
-        [ -n "$root" ] || continue
-        case "$1" in
-            "${root}/claude/skills" | "${root}/claude/skills"/*) return 0 ;;
-        esac
-    done
-    return 1
+    case "$1" in
+        "${DOTFILES_ROOT}/claude/skills" | "${DOTFILES_ROOT}/claude/skills"/* \
+            | "${DOTFILES_MAIN_ROOT}/claude/skills" | "${DOTFILES_MAIN_ROOT}/claude/skills"/*)
+            return 0
+            ;;
+        *) return 1 ;;
+    esac
+}
+
+# 위 판정을 "링크 하나"에 적용하는 호출부용 래퍼 (#1732). 끊어짐 검사와 raw
+# target 획득을 한곳에 묶어, 6개 호출부가 조건을 각자 손으로 조립하지 않게
+# 한다 — 규칙이 바뀔 때 고쳐야 할 곳도 여기 하나뿐이다.
+#
+# raw(`readlink`)로 매치하는 이유: 끊어진 링크는 부모 디렉토리(`claude/`)까지
+# 사라졌을 수 있고 `readlink -f` 는 마지막 컴포넌트를 뺀 나머지가 전부 존재해야
+# 값을 낸다. 존재 여부와 무관한 경로 패턴 매치는 raw 문자열로 해야 한다.
+# `readlink` 는 링크가 실제로 끊어졌을 때만 실행된다 (살아 있는 링크가 절대
+# 다수이므로 루프마다 fork 를 아끼는 효과).
+# Usage: _ssot_link_is_legacy_stale <link_path>
+_ssot_link_is_legacy_stale() {
+    [ ! -e "$1" ] || return 1
+    _ssot_is_legacy_broken_link "$(readlink "$1" 2>/dev/null)"
 }
 
 # 빈 문자열 = 워크스페이스 없음/너무 넓음 → 연결할 소스가 없다.
@@ -236,14 +257,9 @@ link_skills_compose() {
 
     # 1. Migrate legacy directory-symlink → real directory.
     if [ -L "$target" ]; then
-        local current_target current_target_raw
+        local current_target
         current_target="$(readlink -f "$target" 2>/dev/null)"
-        # raw (비-canonicalize) 버전도 따로 구한다 — 끊어진 symlink 는 부모
-        # 디렉토리(`claude/`)까지 사라졌을 수 있고, `readlink -f` 는 마지막
-        # 컴포넌트를 뺀 나머지가 전부 존재해야 값을 낸다. 존재 여부와 무관한
-        # legacy-경로 패턴 매치는 raw 문자열로 한다.
-        current_target_raw="$(readlink "$target" 2>/dev/null)"
-        if skill_source_is_managed "$current_target" || { [ ! -e "$target" ] && _ssot_is_legacy_broken_link "$current_target_raw"; }; then
+        if skill_source_is_managed "$current_target" || _ssot_link_is_legacy_stale "$target"; then
             log_info "[$tool] legacy dir-symlink 감지 — entry-level 합성으로 마이그레이션"
             rm -f "$target"
         else
@@ -276,7 +292,7 @@ link_skills_compose() {
             # (#1732): 옛 SSOT 를 가리키다 끊어진 링크는 이름이 살아 있는
             # 소스와 겹치는 한 그 스킬을 계속 가린다.
             if skill_source_is_managed "$current_link" \
-                || { [ ! -e "$link_target" ] && _ssot_is_legacy_broken_link "$current_link"; }; then
+                || _ssot_link_is_legacy_stale "$link_target"; then
                 rm -f "$link_target"
                 refreshed=$((refreshed + 1))
             else
@@ -306,7 +322,7 @@ link_skills_compose() {
         existing_target_path="$(readlink "$existing")"
         # 이름이 더 이상 어떤 소스와도 겹치지 않는 레거시 링크는 위 엔트리
         # 루프가 아예 방문하지 않는다 — 여기서만 정리된다 (#1732).
-        if [ ! -e "$existing" ] && _ssot_is_legacy_broken_link "$existing_target_path"; then
+        if _ssot_link_is_legacy_stale "$existing"; then
             log_info "[$tool] legacy stale entry 정리: $existing"
             rm -f "$existing"
             pruned=$((pruned + 1))
@@ -353,17 +369,15 @@ link_skills_individual_codex() {
         source_realpath="$(readlink -f "$skill_path")"
 
         if [ -L "$skill_target" ]; then
-            local current_target current_target_raw
+            local current_target
             current_target="$(readlink -f "$skill_target" 2>/dev/null || true)"
             if [ "$current_target" = "$source_realpath" ]; then
                 unchanged=$((unchanged + 1))
                 continue
             fi
 
-            # compose 쪽과 동일한 레거시 판정 (#1732). 끊어진 링크는
-            # `readlink -f` 가 값을 못 내므로 raw 문자열로 매치한다.
-            current_target_raw="$(readlink "$skill_target" 2>/dev/null || true)"
-            if [ ! -e "$skill_target" ] && _ssot_is_legacy_broken_link "$current_target_raw"; then
+            # compose 쪽과 동일한 레거시 판정 (#1732).
+            if _ssot_link_is_legacy_stale "$skill_target"; then
                 rm -f "$skill_target"
                 migrated=$((migrated + 1))
             else
@@ -450,12 +464,10 @@ link_skills_individual_codex() {
         fi
 
         if [ -L "$existing_skill_entry" ]; then
-            local stale_target stale_target_raw
+            local stale_target
             stale_target="$(readlink -f "$existing_skill_entry" 2>/dev/null || true)"
-            stale_target_raw="$(readlink "$existing_skill_entry" 2>/dev/null || true)"
             if skill_source_is_managed "$stale_target" \
-                || { [ ! -e "$existing_skill_entry" ] \
-                    && _ssot_is_legacy_broken_link "$stale_target_raw"; }; then
+                || _ssot_link_is_legacy_stale "$existing_skill_entry"; then
                 rm -f "$existing_skill_entry" || {
                     log_error "[codex] stale skill 제거 실패: $existing_skill_entry"
                     continue
@@ -530,10 +542,7 @@ else
         # (agy+codex FOLLOW-UP, PR #1729).
         if [ -L "$CODEX_SKILLS" ]; then
             codex_link_target="$(readlink -f "$CODEX_SKILLS" 2>/dev/null)"
-            # raw 버전: opencode/gemini 쪽과 같은 이유(#1729) — 끊어진 symlink 는
-            # `readlink -f` 가 canonicalize 못 할 수 있다.
-            codex_link_target_raw="$(readlink "$CODEX_SKILLS" 2>/dev/null)"
-            if skill_source_is_managed "$codex_link_target" || { [ ! -e "$CODEX_SKILLS" ] && _ssot_is_legacy_broken_link "$codex_link_target_raw"; }; then
+            if skill_source_is_managed "$codex_link_target" || _ssot_link_is_legacy_stale "$CODEX_SKILLS"; then
                 rm -f "$CODEX_SKILLS"
             else
                 log_warning "Codex skills 경로가 사용자 symlink입니다. 건너뜁니다: $CODEX_SKILLS"

--- a/tests/bats/tools/setup_skills_ssot.bats
+++ b/tests/bats/tools/setup_skills_ssot.bats
@@ -842,3 +842,26 @@ seed_legacy_entries() {
     [ "$(readlink -f "${g_dir}/alpha")" = "$(readlink -f "${BASE_REPO}/skills/alpha")" ]
     [ ! -L "${g_dir}/legacy-orphan" ]
 }
+
+# 레거시 링크가 상대 경로로 적혀 있어도 같은 판정을 받아야 한다 (#1732,
+# agy FOLLOW-UP). 스크립트 자신은 항상 절대 경로로 링크를 만들지만, 수동/
+# 외부 도구가 만든 상대 경로 링크는 절대 경로 prefix 매칭을 그냥 빠져나간다.
+@test "gemini: relative-path legacy entry is cleaned too (#1732)" {
+    seed_gemini_home
+    run_setup
+    assert_success
+
+    local g_dir="${FIXTURE_HOME}/.gemini/skills"
+    local rel
+    rel="$(realpath -m --relative-to="$g_dir" "${FIXTURE_DOTFILES}/claude/skills")"
+    rm -f "${g_dir}/alpha"
+    ln -s "${rel}/alpha" "${g_dir}/alpha"
+    ln -s "${rel}/legacy-orphan" "${g_dir}/legacy-orphan"
+
+    run_setup
+    assert_success
+
+    [ -e "${g_dir}/alpha" ]
+    [ "$(readlink -f "${g_dir}/alpha")" = "$(readlink -f "${BASE_REPO}/skills/alpha")" ]
+    [ ! -L "${g_dir}/legacy-orphan" ]
+}

--- a/tests/bats/tools/setup_skills_ssot.bats
+++ b/tests/bats/tools/setup_skills_ssot.bats
@@ -11,6 +11,9 @@ DIAG_SCRIPT="${DOTFILES_ROOT}/scripts/maintenance/check_codex_skills_budget.py"
 UX_LIB_SOURCE="${DOTFILES_ROOT}/shell-common/tools/ux_lib/ux_lib.sh"
 # Workspace source enumeration is shared with the Claude Code side (#1652).
 SKILL_SOURCES_LIB_SOURCE="${DOTFILES_ROOT}/shell-common/functions/skill_sources.sh"
+# main-worktree canonicalization SSOT (#589) — the script reuses it to widen
+# the legacy-link match to the main checkout when run from a worktree (#1732).
+DOTFILES_ROOT_LIB_SOURCE="${DOTFILES_ROOT}/shell-common/functions/dotfiles_root.sh"
 
 setup() {
     setup_isolated_home
@@ -35,6 +38,8 @@ setup() {
     cp "$UX_LIB_SOURCE" "${FIXTURE_DOTFILES}/shell-common/tools/ux_lib/ux_lib.sh"
     cp "$SKILL_SOURCES_LIB_SOURCE" \
         "${FIXTURE_DOTFILES}/shell-common/functions/skill_sources.sh"
+    cp "$DOTFILES_ROOT_LIB_SOURCE" \
+        "${FIXTURE_DOTFILES}/shell-common/functions/dotfiles_root.sh"
 
     for s in alpha beta gamma; do
         cat > "${BASE_REPO}/skills/${s}/SKILL.md" <<EOF
@@ -81,8 +86,11 @@ teardown() {
     teardown_isolated_home
 }
 
+# $1 (optional) — the checkout to run the script from; defaults to the
+# fixture dotfiles tree. The worktree test (#1732) passes its linked
+# worktree instead of re-declaring the invocation.
 run_setup() {
-    HOME="$FIXTURE_HOME" run bash "${FIXTURE_DOTFILES}/scripts/setup-skills-ssot.sh"
+    HOME="$FIXTURE_HOME" run bash "${1:-$FIXTURE_DOTFILES}/scripts/setup-skills-ssot.sh"
 }
 
 # --- Codex fan-out ---
@@ -827,7 +835,7 @@ seed_legacy_entries() {
 
     # Run from the worktree — DOTFILES_ROOT is now "$wt", but the links
     # still name "$FIXTURE_DOTFILES".
-    HOME="$FIXTURE_HOME" run bash "${wt}/scripts/setup-skills-ssot.sh"
+    run_setup "$wt"
     assert_success
 
     [ -e "${g_dir}/alpha" ]

--- a/tests/bats/tools/setup_skills_ssot.bats
+++ b/tests/bats/tools/setup_skills_ssot.bats
@@ -697,3 +697,140 @@ run_setup_with_workspace() {
     [ "$before" = "$after" ]
 }
 
+
+# ---------------------------------------------------------------------
+# issue #1732 — entry-level stale symlink cleanup
+# PR #1729 taught the *directory-level* migration to recognize a broken
+# link into the deleted `dotfiles/claude/skills` SSOT (#1680), but the
+# *entry-level* loops kept classifying such a link as user data. Two
+# distinct symptoms follow: an entry whose name still has a live source
+# is never replaced (the skill stays hidden), and an entry whose name no
+# longer exists anywhere is never pruned (dead links accumulate).
+# ---------------------------------------------------------------------
+
+# Seed the composed dir, then inject the legacy links the #1680 cutover
+# stranded there. Two shapes: `alpha` collides with a live source (hidden
+# skill), `legacy-orphan` has no source at all (dead link).
+seed_legacy_entries() {
+    local dir="$1"
+    rm -f "${dir}/alpha"
+    ln -s "${FIXTURE_DOTFILES}/claude/skills/alpha/" "${dir}/alpha"
+    ln -s "${FIXTURE_DOTFILES}/claude/skills/legacy-orphan/" "${dir}/legacy-orphan"
+}
+
+@test "gemini: legacy entry shadowing a live source is relinked (#1732)" {
+    seed_gemini_home
+    run_setup
+    assert_success
+
+    local g_dir="${FIXTURE_HOME}/.gemini/skills"
+    seed_legacy_entries "$g_dir"
+
+    run_setup
+    assert_success
+
+    [ -L "${g_dir}/alpha" ]
+    [ -e "${g_dir}/alpha" ]
+    [ "$(readlink -f "${g_dir}/alpha")" = "$(readlink -f "${BASE_REPO}/skills/alpha")" ]
+}
+
+@test "gemini: legacy entry with no live source is pruned (#1732)" {
+    seed_gemini_home
+    run_setup
+    assert_success
+
+    local g_dir="${FIXTURE_HOME}/.gemini/skills"
+    seed_legacy_entries "$g_dir"
+
+    run_setup
+    assert_success
+
+    [ ! -L "${g_dir}/legacy-orphan" ]
+}
+
+@test "opencode: legacy entries are cleaned across every harness (#1732)" {
+    seed_opencode_home
+    seed_hermes_home
+    run_setup
+    assert_success
+
+    local oc_dir="${FIXTURE_HOME}/.config/opencode/skills"
+    local h_dir="${FIXTURE_HOME}/.hermes/skills/dotfiles"
+    seed_legacy_entries "$oc_dir"
+    seed_legacy_entries "$h_dir"
+
+    run_setup
+    assert_success
+
+    local d
+    for d in "$oc_dir" "$h_dir"; do
+        [ -e "${d}/alpha" ]
+        [ "$(readlink -f "${d}/alpha")" = "$(readlink -f "${BASE_REPO}/skills/alpha")" ]
+        [ ! -L "${d}/legacy-orphan" ]
+    done
+}
+
+@test "codex: legacy entries are relinked and pruned (#1732)" {
+    run_setup
+    assert_success
+
+    local c_dir="${FIXTURE_HOME}/.codex/skills"
+    seed_legacy_entries "$c_dir"
+
+    run_setup
+    assert_success
+
+    [ -e "${c_dir}/alpha" ]
+    [ "$(readlink -f "${c_dir}/alpha")" = "$(readlink -f "${BASE_REPO}/skills/alpha")" ]
+    [ ! -L "${c_dir}/legacy-orphan" ]
+}
+
+# The counter-case that keeps the fix honest: a broken link pointing
+# somewhere that is NOT the deleted SSOT (a temporarily unmounted user
+# mount, say) still holds recoverable user intent — preserve it.
+@test "gemini: broken entry outside the legacy SSOT is preserved (#1732)" {
+    seed_gemini_home
+    run_setup
+    assert_success
+
+    local g_dir="${FIXTURE_HOME}/.gemini/skills"
+    rm -f "${g_dir}/beta"
+    ln -s "${TEST_TEMP_HOME}/unmounted/skills/beta" "${g_dir}/beta"
+
+    run_setup
+    assert_success
+    assert_output --partial "[gemini] 사용자 symlink 보존"
+
+    [ -L "${g_dir}/beta" ]
+    [ "$(readlink "${g_dir}/beta")" = "${TEST_TEMP_HOME}/unmounted/skills/beta" ]
+}
+
+# A worktree checkout resolves DOTFILES_ROOT to the worktree path, while
+# the stranded links were written against the main checkout. Matching on
+# DOTFILES_ROOT alone therefore misses every one of them — exactly the
+# state a re-run from a worktree has to be able to repair.
+@test "gemini: legacy entries are cleaned when run from a git worktree (#1732)" {
+    seed_gemini_home
+
+    git -C "$FIXTURE_DOTFILES" init -q
+    git -C "$FIXTURE_DOTFILES" config user.email t@example.com
+    git -C "$FIXTURE_DOTFILES" config user.name t
+    git -C "$FIXTURE_DOTFILES" add -A
+    git -C "$FIXTURE_DOTFILES" commit -qm init
+    local wt="${TEST_TEMP_HOME}/wt-dotfiles"
+    git -C "$FIXTURE_DOTFILES" worktree add -q -b wt/test "$wt"
+
+    run_setup
+    assert_success
+    local g_dir="${FIXTURE_HOME}/.gemini/skills"
+    seed_legacy_entries "$g_dir"
+
+    # Run from the worktree — DOTFILES_ROOT is now "$wt", but the links
+    # still name "$FIXTURE_DOTFILES".
+    HOME="$FIXTURE_HOME" run bash "${wt}/scripts/setup-skills-ssot.sh"
+    assert_success
+
+    [ -e "${g_dir}/alpha" ]
+    [ "$(readlink -f "${g_dir}/alpha")" = "$(readlink -f "${BASE_REPO}/skills/alpha")" ]
+    [ ! -L "${g_dir}/legacy-orphan" ]
+}


### PR DESCRIPTION
## Summary
- 삭제된 옛 SSOT(`dotfiles/claude/skills/`, #1680)를 가리키는 stale symlink 가 4개 하네스에서 스킬 8개를 가리고, 고아 링크 65개를 남기던 문제를 고친다.
- PR #1729 가 도입한 `_ssot_is_legacy_broken_link()` 를 **엔트리 단위 루프 4곳**에 배선하고, 워크트리에서 실행해도 판정이 동작하도록 canonical main 경로를 함께 인정한다.
- 실측 재검증 완료: 4개 하네스 모두 깨진 symlink 0건, 로드 스킬 63개 → 71개.

## Changes
- `scripts/setup-skills-ssot.sh`
  - `DOTFILES_MAIN_ROOT` 추가 — `git rev-parse --git-common-dir` 로 canonical main 체크아웃을 구해, 워크트리 실행 시에도 main 경로 기준으로 적힌 기존 링크가 매치되게 한다. git 저장소 밖에서는 조용히 `DOTFILES_ROOT` 로 폴백.
  - `_ssot_is_legacy_broken_link()` 가 `DOTFILES_ROOT` / `DOTFILES_MAIN_ROOT` 두 경로를 모두 레거시 패턴으로 인정.
  - `link_skills_compose()` 엔트리 루프 — 이름이 살아 있는 소스와 겹치는 레거시 broken link 를 갱신 대상으로 인식 (숨은 스킬 복구).
  - `link_skills_compose()` prune 루프 — 이름이 사라진 고아 레거시 링크 정리. 엔트리 루프는 유효한 소스 이름만 방문하므로 고아 링크에 구조적으로 도달하지 못한다 — 두 루프 모두 필요.
  - `link_skills_individual_codex()` 엔트리 루프 / prune 루프에 동일한 판정 적용 (같은 결함이 대칭으로 존재).
- `tests/bats/tools/setup_skills_ssot.bats` — 회귀 테스트 6건 추가.

## 근본 원인

엔트리 루프는 `skill_source_is_managed()` 만 검사했다. 이 함수는 현재 워크스페이스 루트만 인식하므로, #1680 이 삭제한 옛 SSOT 를 가리키는 링크는 "사용자가 만든 symlink" 로 오분류되어 영구 보존됐다. 이름이 겹치면 새 링크가 아예 생성되지 않아 스킬이 숨겨지고, 이름이 사라졌으면 정리되지 않고 계속 쌓인다.

끊어진 링크의 타깃은 `readlink -f` 가 아니라 raw `readlink` 로 읽는다 — 부모 디렉토리까지 사라진 경우 `readlink -f` 가 빈 값을 내며 모든 패턴 매치가 조용히 실패한다.

## Test plan
- [x] `bats tests/bats/tools/setup_skills_ssot.bats` — 40/40 통과 (신규 6건 포함)
- [x] 신규 테스트가 수정 전 코드에서 5건 실패함을 확인 (RED). 여섯 번째(레거시 SSOT 밖을 가리키는 broken link 보존)는 수정 전후 모두 통과 — "깨진 링크는 무조건 삭제" 가 아님을 고정하는 반대 사례.
- [x] `mise run lint` — errors=0
- [x] `./tests/test` — 1552 passed, 1 failed. 유일한 실패(`test_command_docs.py::TestCommittedDocs::test_committed_docs_match_a_fresh_render`)는 변경분을 되돌린 상태에서도 동일하게 실패하는 pre-existing.
- [x] 실측: 패치 후 `bash scripts/setup-skills-ssot.sh` 재실행 결과 하네스당 `8개 갱신, 65개 정리`

| 하네스 | 깨진 링크 | 엔트리 |
|---|---|---|
| `~/.gemini/skills` | 0 | 71 |
| `~/.config/opencode/skills` | 0 | 71 |
| `~/.codex/skills` | 0 | 72 (`+.system`) |
| `~/.hermes/skills/dotfiles` | 0 | 71 |

- [x] 숨어 있던 8개 스킬(`sh-check`, `skill-check`, `skill-create`, `skill-refactor`, `karakeep-add`, `karakeep-classify`, `obsidian-resolve-conflict`, `obsidian-session-clip`) 전부 4/4 하네스에서 `SKILL.md` 정상 로드

## Related
Closes #1732

---
<details>
<summary>🤖 AI Metrics · 📊 ~3000 tokens · 👤 ~2 h · 🤖 ~1 min</summary>

<!-- ai-metrics:gh-pr -->
📊 ~3000 tokens · 👤 ~2 h · 🤖 ~1 min
<!-- /ai-metrics:gh-pr -->

</details>

