### PR TITLE
fix(test): check_codex_skills_budget 정렬 폭 결합 단언 제거

### DIFF
--- a/tests/bats/tools/setup_skills_ssot.bats
+++ b/tests/bats/tools/setup_skills_ssot.bats
@@ -123,7 +123,7 @@ run_setup() {
         --skills-dir "${BASE_REPO}/skills" \
         --budget 1000
     assert_success
-    assert_output --partial "Skills:     3"
+    assert_output --regexp 'Skills: +3'
     assert_output --partial "Within budget"
 }
 


### PR DESCRIPTION
## Summary

- `check_codex_skills_budget` bats 단언이 `Skills:` 라벨 정렬 폭(공백 개수)에 결합돼 `2344ff03`(정렬 폭 확장) 이후 `main`에서 상시 `not ok`.
- 같은 파일 145행 선례(`--regexp 'Skills: +3'`)를 따라 공백에 둔감한 정규식 단언으로 교체. 스크립트는 무수정.

Closes #1738

## Test plan

- [x] `./tests/bats/lib/bats-core/bin/bats tests/bats/tools/setup_skills_ssot.bats` — 46/46 pass, not ok 0건
- [x] `git diff` — `scripts/maintenance/check_codex_skills_budget.py` 미포함 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D1dwCYvUuXaGreLQtzUk8L
