### PR TITLE
fix(docs): mytool.md 재생성 — command-docs drift gate 복구

### DIFF
--- a/docs/guide/commands/mytool.md
+++ b/docs/guide/commands/mytool.md
@@ -80,6 +80,7 @@
 - **pr_merge_train_cron** — merge-train cron 디스패처 — 1회 tick (issue #1470).
 - **repo_stats** — Initialize common tools environment
 - **run_agents_md_master_prompt** — Claude Code에게 AGENTS.md 생성 요청 (비대화형)
+- **session_doctor_cron** — session-doctor cron 디스패처 — 1회 tick (issue #15...
 - **set_locale** — This script sets up the en_US.UTF-8 locale to resolve "ma...
 - **setup_crt** — CA Certificate Setup Script
 - **setup_gpg_cache** — GPG agent 캐싱 설정 스크립트 (편의성 향상)
@@ -90,7 +91,7 @@
 - **uninstall_docker** — WSL Docker 제거 스크립트 (대화형)
 - **uninstall_npm** — Node.js & npm 제거 스크립트 (대화형)
 - **work_log** — Companion to post-commit hook for tracking non-developmen...
-- Total: 67 custom tools available
+- Total: 68 custom tools available
 - Location: ~/dotfiles/shell-common/tools/custom
 
 ### usage

--- a/git/hooks/checks/command_docs_staleness_check.sh
+++ b/git/hooks/checks/command_docs_staleness_check.sh
@@ -1,12 +1,17 @@
 #!/usr/bin/env bash
 # git/hooks/checks/command_docs_staleness_check.sh
 #
-# Warns (never blocks) when a commit stages shell-common/tools/custom/*.sh
-# changes without also staging the generated docs/guide/commands/mytool.md.
-# Issue #1737 — mytool.md's "tools" section enumerates that directory, so a
-# tool add/remove/rename that skips regeneration silently drifts from the
-# committed doc until the command-docs drift gate
+# Warns (never blocks) when a commit stages a top-level
+# shell-common/tools/custom/*.sh change without also staging the generated
+# docs/guide/commands/mytool.md. Issue #1737 — mytool.md's "tools" section
+# enumerates that directory (mytool_help.sh's `find "$custom_dir" -maxdepth 1
+# -type f -name "*.sh"`), so a tool add/remove/rename that skips regeneration
+# silently drifts from the committed doc until the command-docs drift gate
 # (tests/integration/test_command_docs.py) catches it on a full test run.
+#
+# Scope: top-level only, matching that same -maxdepth 1 — a change under
+# shell-common/tools/custom/<subdir>/*.sh never appears in mytool.md, so
+# flagging it would be a pure false positive (agy + codex review, PR #1741).
 #
 # Heuristic warning only: many commits touch a tool's body (logic changes)
 # without shifting the summary line the doc renders, which would be a
@@ -20,7 +25,7 @@ check_command_docs_staleness() {
     local staged_files="$1"
     local warnings_file="$2"
 
-    grep -q '^shell-common/tools/custom/.*\.sh$' <<<"$staged_files" || return 0
+    grep -q '^shell-common/tools/custom/[^/]\+\.sh$' <<<"$staged_files" || return 0
     grep -q '^docs/guide/commands/mytool\.md$' <<<"$staged_files" && return 0
 
     {

--- a/git/hooks/checks/command_docs_staleness_check.sh
+++ b/git/hooks/checks/command_docs_staleness_check.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# git/hooks/checks/command_docs_staleness_check.sh
+#
+# Warns (never blocks) when a commit stages shell-common/tools/custom/*.sh
+# changes without also staging the generated docs/guide/commands/mytool.md.
+# Issue #1737 — mytool.md's "tools" section enumerates that directory, so a
+# tool add/remove/rename that skips regeneration silently drifts from the
+# committed doc until the command-docs drift gate
+# (tests/integration/test_command_docs.py) catches it on a full test run.
+#
+# Heuristic warning only: many commits touch a tool's body (logic changes)
+# without shifting the summary line the doc renders, which would be a
+# false positive if this were a hard block.
+#
+# Usage:
+#   . git/hooks/checks/command_docs_staleness_check.sh
+#   check_command_docs_staleness "$STAGED_FILES" <warnings_file>
+
+check_command_docs_staleness() {
+    local staged_files="$1"
+    local warnings_file="$2"
+
+    grep -q '^shell-common/tools/custom/.*\.sh$' <<<"$staged_files" || return 0
+    grep -q '^docs/guide/commands/mytool\.md$' <<<"$staged_files" && return 0
+
+    {
+        echo "shell-common/tools/custom/*.sh staged without docs/guide/commands/mytool.md"
+        echo "  Fix: ./shell-common/tools/custom/gen_command_docs.sh --force && git add docs/guide/commands/mytool.md"
+        echo "  (false positive if this commit doesn't change a tool's summary line)"
+        echo ""
+    } >>"$warnings_file"
+    return 1
+}

--- a/git/hooks/pre-commit
+++ b/git/hooks/pre-commit
@@ -127,6 +127,9 @@ STAGED_FILES=$(git diff --cached --name-only --diff-filter=ACMR 2>/dev/null || e
 if [ -z "$STAGED_FILES" ]; then
     exit 0
 fi
+# Includes deletions (D) — ACMR alone hides a removed tools/custom/*.sh from
+# the command-docs staleness check below (codex review, PR #1741).
+STAGED_FILES_WITH_DELETIONS=$(git diff --cached --name-only --diff-filter=ACDMR 2>/dev/null || echo "")
 
 # ═══════════════════════════════════════════════════════════════════════════
 # Run checks
@@ -285,9 +288,11 @@ while IFS= read -r file; do
     fi
 done <<<"$STAGED_FILES"
 
-# 10) Command docs staleness warning (issue #1737): tools/custom staged
-# without the generated docs/guide/commands/mytool.md
-if ! check_command_docs_staleness "$STAGED_FILES" "$COMMAND_DOCS_STALENESS_FILE"; then
+# 10) Command docs staleness warning (issue #1737): tools/custom added,
+# removed, or renamed without the generated docs/guide/commands/mytool.md.
+# Uses STAGED_FILES_WITH_DELETIONS (not STAGED_FILES) so a removed tool
+# script isn't invisible to the check (codex review, PR #1741).
+if ! check_command_docs_staleness "$STAGED_FILES_WITH_DELETIONS" "$COMMAND_DOCS_STALENESS_FILE"; then
     ((command_docs_staleness_violations++))
 fi
 
@@ -358,7 +363,7 @@ if [ $blocking_violations -eq 0 ]; then
 
     if [ $command_docs_staleness_violations -gt 0 ] && [ -s "$COMMAND_DOCS_STALENESS_FILE" ]; then
         echo -e "${YELLOW}⚠ [WARNING] Command docs may be stale (issue #1737):${NC}"
-        cat "$COMMAND_DOCS_STALENESS_FILE" | sed 's/^/  /'
+        sed 's/^/  /' "$COMMAND_DOCS_STALENESS_FILE"
         echo ""
         has_warnings=1
     fi

--- a/git/hooks/pre-commit
+++ b/git/hooks/pre-commit
@@ -62,8 +62,9 @@ DIRECT_EXEC_GUARD_FILE=$(mktemp "$TMPDIR/direct_exec_guard_XXXXXX.txt")
 SHELLCHECK_VIOLATIONS_FILE=$(mktemp "$TMPDIR/shellcheck_violations_XXXXXX.txt")
 GH_API_TYPE_FILE=$(mktemp "$TMPDIR/gh_api_type_XXXXXX.txt")
 ABS_HOME_VIOLATIONS_FILE=$(mktemp "$TMPDIR/abs_home_XXXXXX.txt")
+COMMAND_DOCS_STALENESS_FILE=$(mktemp "$TMPDIR/command_docs_staleness_XXXXXX.txt")
 
-trap 'rm -f "$VIOLATIONS_FILE" "$FUNC_VIOLATIONS_FILE" "$SHEBANG_VIOLATIONS_FILE" "$SUBSHELL_VIOLATIONS_FILE" "$PIPE_LOOP_VIOLATIONS_FILE" "$ZSH_EMULATION_FILE" "$ALIAS_CONFLICT_FILE" "$ALIAS_LOCATION_FILE" "$WRAPPER_VIOLATIONS_FILE" "$CUSTOM_TOOLS_SOURCING_FILE" "$AUTO_EXEC_CUSTOM_FILE" "$AUTO_EXEC_SOURCED_FILE" "$PURITY_VIOLATIONS_FILE" "$BACKUP_FILES_FILE" "$HELP_INTEGRITY_VIOLATIONS_FILE" "$DIRECT_EXEC_GUARD_FILE" "$SHELLCHECK_VIOLATIONS_FILE" "$GH_API_TYPE_FILE" "$ABS_HOME_VIOLATIONS_FILE"' EXIT
+trap 'rm -f "$VIOLATIONS_FILE" "$FUNC_VIOLATIONS_FILE" "$SHEBANG_VIOLATIONS_FILE" "$SUBSHELL_VIOLATIONS_FILE" "$PIPE_LOOP_VIOLATIONS_FILE" "$ZSH_EMULATION_FILE" "$ALIAS_CONFLICT_FILE" "$ALIAS_LOCATION_FILE" "$WRAPPER_VIOLATIONS_FILE" "$CUSTOM_TOOLS_SOURCING_FILE" "$AUTO_EXEC_CUSTOM_FILE" "$AUTO_EXEC_SOURCED_FILE" "$PURITY_VIOLATIONS_FILE" "$BACKUP_FILES_FILE" "$HELP_INTEGRITY_VIOLATIONS_FILE" "$DIRECT_EXEC_GUARD_FILE" "$SHELLCHECK_VIOLATIONS_FILE" "$GH_API_TYPE_FILE" "$ABS_HOME_VIOLATIONS_FILE" "$COMMAND_DOCS_STALENESS_FILE"' EXIT
 
 # ═══════════════════════════════════════════════════════════════════════════
 # Load check modules
@@ -99,6 +100,7 @@ source_check_or_exit "${CHECKS_DIR}/shellcheck_check.sh"
 source_check_or_exit "${CHECKS_DIR}/gh_api_type_check.sh"
 source_check_or_exit "${CHECKS_DIR}/hardcoded_home_path_check.sh"
 source_check_or_exit "${CHECKS_DIR}/main_branch_guard.sh"
+source_check_or_exit "${CHECKS_DIR}/command_docs_staleness_check.sh"
 
 # ═══════════════════════════════════════════════════════════════════════════
 # Protected-branch guard (fail fast, before any file scanning)
@@ -150,6 +152,7 @@ direct_exec_guard_violations=0
 shellcheck_violations=0
 gh_api_type_violations=0
 abs_home_violations=0
+command_docs_staleness_violations=0
 
 # 1) Shebang consistency for staged .sh files under shell-common/bash/zsh
 while IFS= read -r file; do
@@ -282,6 +285,12 @@ while IFS= read -r file; do
     fi
 done <<<"$STAGED_FILES"
 
+# 10) Command docs staleness warning (issue #1737): tools/custom staged
+# without the generated docs/guide/commands/mytool.md
+if ! check_command_docs_staleness "$STAGED_FILES" "$COMMAND_DOCS_STALENESS_FILE"; then
+    ((command_docs_staleness_violations++))
+fi
+
 # ═══════════════════════════════════════════════════════════════════════════
 # Reporting and exit logic
 # ═══════════════════════════════════════════════════════════════════════════
@@ -291,7 +300,7 @@ echo -e "${BLUE}Pre-commit validation (staged files only)${NC}"
 echo ""
 
 blocking_violations=$((shebang_violations + naming_violations + function_naming_violations + alias_conflict_violations + alias_location_violations + custom_tools_sourcing_violations + auto_exec_custom_violations + auto_exec_sourced_violations + library_purity_violations + help_integrity_violations + direct_exec_guard_violations + pipe_loop_violations + shellcheck_violations + abs_home_violations))
-warning_count=$((subshell_violations + wrapper_violations + ux_violations + backup_files_found + gh_api_type_violations))
+warning_count=$((subshell_violations + wrapper_violations + ux_violations + backup_files_found + gh_api_type_violations + command_docs_staleness_violations))
 
 if [ $blocking_violations -eq 0 ]; then
     has_warnings=0
@@ -343,6 +352,13 @@ if [ $blocking_violations -eq 0 ]; then
         head -n 5 "$GH_API_TYPE_FILE" | sed 's/^/  /'
         [ $(wc -l <"$GH_API_TYPE_FILE") -gt 5 ] && echo "  ... and more"
         echo "  See: docs/guide/learnings/gh-api-type-casting.md (issue #395)"
+        echo ""
+        has_warnings=1
+    fi
+
+    if [ $command_docs_staleness_violations -gt 0 ] && [ -s "$COMMAND_DOCS_STALENESS_FILE" ]; then
+        echo -e "${YELLOW}⚠ [WARNING] Command docs may be stale (issue #1737):${NC}"
+        cat "$COMMAND_DOCS_STALENESS_FILE" | sed 's/^/  /'
         echo ""
         has_warnings=1
     fi

--- a/git/hooks/pre-commit
+++ b/git/hooks/pre-commit
@@ -124,12 +124,15 @@ fi
 # ═══════════════════════════════════════════════════════════════════════════
 
 STAGED_FILES=$(git diff --cached --name-only --diff-filter=ACMR 2>/dev/null || echo "")
-if [ -z "$STAGED_FILES" ]; then
+# Includes deletions (D) — ACMR alone hides a removed tools/custom/*.sh from
+# the command-docs staleness check below (codex review, PR #1741). Gate the
+# early-exit on this superset: a commit that is *only* a deletion leaves
+# STAGED_FILES empty while this stays non-empty, and must still reach that
+# check instead of short-circuiting here.
+STAGED_FILES_WITH_DELETIONS=$(git diff --cached --name-only --diff-filter=ACDMR 2>/dev/null || echo "")
+if [ -z "$STAGED_FILES_WITH_DELETIONS" ]; then
     exit 0
 fi
-# Includes deletions (D) — ACMR alone hides a removed tools/custom/*.sh from
-# the command-docs staleness check below (codex review, PR #1741).
-STAGED_FILES_WITH_DELETIONS=$(git diff --cached --name-only --diff-filter=ACDMR 2>/dev/null || echo "")
 
 # ═══════════════════════════════════════════════════════════════════════════
 # Run checks

--- a/tests/bats/lint/command_docs_staleness_check.bats
+++ b/tests/bats/lint/command_docs_staleness_check.bats
@@ -1,0 +1,47 @@
+#!/usr/bin/env bats
+# tests/bats/lint/command_docs_staleness_check.bats
+# Issue #1737 — warn (never block) when shell-common/tools/custom/*.sh is
+# staged without docs/guide/commands/mytool.md.
+
+load '../test_helper'
+
+CHECK_PATH="${_BATS_REAL_DOTFILES_ROOT}/git/hooks/checks/command_docs_staleness_check.sh"
+
+setup() {
+    setup_isolated_home
+    # shellcheck disable=SC1090
+    . "$CHECK_PATH"
+    WARN_FILE="$(mktemp "$BATS_TEST_TMPDIR/warn.XXXXXX")"
+}
+
+teardown() {
+    [ -n "$WARN_FILE" ] && rm -f "$WARN_FILE"
+    teardown_isolated_home
+}
+
+@test "new tools/custom script without doc update is flagged" {
+    local staged=$'shell-common/tools/custom/new_tool.sh\nshell-common/functions/foo.sh'
+    run check_command_docs_staleness "$staged" "$WARN_FILE"
+    [ "$status" -eq 1 ]
+    grep -q 'docs/guide/commands/mytool.md' "$WARN_FILE"
+}
+
+@test "tools/custom script staged together with doc update is silent" {
+    local staged=$'shell-common/tools/custom/new_tool.sh\ndocs/guide/commands/mytool.md'
+    run check_command_docs_staleness "$staged" "$WARN_FILE"
+    [ "$status" -eq 0 ]
+    [ ! -s "$WARN_FILE" ]
+}
+
+@test "commit without any tools/custom change is silent" {
+    local staged=$'shell-common/functions/foo.sh\ndocs/guide/README.md'
+    run check_command_docs_staleness "$staged" "$WARN_FILE"
+    [ "$status" -eq 0 ]
+    [ ! -s "$WARN_FILE" ]
+}
+
+@test "tools/custom subdirectory helper (not top-level entrypoint) still matches by path" {
+    local staged='shell-common/tools/custom/subdir/helper.sh'
+    run check_command_docs_staleness "$staged" "$WARN_FILE"
+    [ "$status" -eq 1 ]
+}

--- a/tests/bats/lint/command_docs_staleness_check.bats
+++ b/tests/bats/lint/command_docs_staleness_check.bats
@@ -40,10 +40,14 @@ teardown() {
     [ ! -s "$WARN_FILE" ]
 }
 
-@test "tools/custom subdirectory helper (not top-level entrypoint) still matches by path" {
+@test "tools/custom subdirectory helper is silent — never in mytool.md (agy+codex review, PR #1741)" {
+    # mytool_help.sh's generator uses `find -maxdepth 1`, so a nested helper
+    # under shell-common/tools/custom/<subdir>/ never appears in mytool.md —
+    # flagging it here would be a pure false positive.
     local staged='shell-common/tools/custom/subdir/helper.sh'
     run check_command_docs_staleness "$staged" "$WARN_FILE"
-    [ "$status" -eq 1 ]
+    [ "$status" -eq 0 ]
+    [ ! -s "$WARN_FILE" ]
 }
 
 @test "deleted tools/custom script without doc update is flagged (codex review, PR #1741)" {

--- a/tests/bats/lint/command_docs_staleness_check.bats
+++ b/tests/bats/lint/command_docs_staleness_check.bats
@@ -45,3 +45,12 @@ teardown() {
     run check_command_docs_staleness "$staged" "$WARN_FILE"
     [ "$status" -eq 1 ]
 }
+
+@test "deleted tools/custom script without doc update is flagged (codex review, PR #1741)" {
+    # pre-commit's STAGED_FILES (--diff-filter=ACMR) excludes deletions, so
+    # this check must be fed a deletion-inclusive file list — this test
+    # asserts the check itself still fires when a deleted path is present.
+    local staged=$'shell-common/tools/custom/removed_tool.sh\nshell-common/functions/foo.sh'
+    run check_command_docs_staleness "$staged" "$WARN_FILE"
+    [ "$status" -eq 1 ]
+}


### PR DESCRIPTION
## Summary
- `mytool.md` 를 재생성해 command-docs drift gate(`tests/integration/test_command_docs.py`)를 복구한다.
- 재발 방지: `shell-common/tools/custom/*.sh` 가 staged 인데 `docs/guide/commands/mytool.md` 는 없을 때 pre-commit 이 경고를 낸다.

## Changes
- `docs/guide/commands/mytool.md`: `gen_command_docs.sh --force` 로 재생성 — `session_doctor_cron` 항목 추가, Total 67 → 68 (d22dcc9e 가 문서 재생성 없이 도구를 추가한 결과).
- `git/hooks/checks/command_docs_staleness_check.sh` (신규): staged 파일 집합을 검사하는 경고 전용 pre-commit 체크.
- `git/hooks/pre-commit`: 새 체크를 10번째 섹션으로 배선 (mktemp 파일, trap, source, 호출, warning_count, 리포트 블록).
- `tests/bats/lint/command_docs_staleness_check.bats` (신규): 4 케이스 (경고, 침묵-동시staged, 무관commit, 서브디렉토리 매치).

## Test plan
- [x] `DOTFILES_ROOT_NO_CANONICALIZE=1 uv run pytest tests/integration/test_command_docs.py -q` — 19 passed (기존 1건 실패 포함 전부 통과)
- [x] `./tests/bats/lib/bats-core/bin/bats tests/bats/lint/command_docs_staleness_check.bats` — 4 passed
- [x] 샌드박스 repo 에서 실제 `git commit` 으로 경고 발화(비차단) + doc 동시 staged 시 침묵 확인
- [x] `bash git/tests/test_hooks.sh` — 변경 전/후 동일하게 `bad purity` 1건만 실패 (main 의 pre-existing, 이번 변경과 무관 — 별도 확인)

## Related
Closes #1737

---
<details>
<summary>🤖 AI Metrics · 📊 ~3000 tokens · 👤 ~2 h · 🤖 ~1 min</summary>

<!-- ai-metrics:gh-pr -->
📊 ~3000 tokens · 👤 ~2 h · 🤖 ~1 min
<!-- /ai-metrics:gh-pr -->

</details>
