### PR TITLE
fix(skills): setup-skills-ssot.sh 크로스-저장소 동명 스킬 은닉 해소

### DIFF
--- a/scripts/setup-skills-ssot.sh
+++ b/scripts/setup-skills-ssot.sh
@@ -151,32 +151,44 @@ WORKSPACE_ROOT_REAL=""
 [ -n "$WORKSPACE_ROOT_RESOLVED" ] \
     && WORKSPACE_ROOT_REAL="$(_realpath_or_self "$WORKSPACE_ROOT_RESOLVED")"
 
-# 모든 skill 소스 디렉토리를 한 줄에 하나씩 표준출력으로 낸다.
+# 모든 skill 소스를 `<소스 경로><TAB><합성 엔트리 이름>` 한 줄씩 표준출력으로 낸다.
 #
 # 소스는 워크스페이스 clone 한 곳뿐이다 (issue #1680):
 #   <root>/<repo>/skills/<skill>   (열거 규칙은 shell-common SSOT)
 #
-# 워크스페이스 repo 끼리 이름이 겹치면 정렬 순서상 앞선 repo 가 이긴다
-# (재현 가능한 결정). 진단 로그는 stdout 을 오염시키지 않도록 stderr 로 보낸다.
+# 이름이 겹치는 repo 끼리 서로를 가리지 않게 한다 (#1746). 예전에는 basename
+# 하나를 키로 dedupe 해서 gh-issue-skills/gh-pr-skills/packaging-skills 의
+# `create` 중 하나만 살아남았다. 이제 dedupe 키는 `<repo>/<skill>` 이고,
+# 정렬 순서상 앞선 repo 만 bare 이름을 갖고 나머지는 `<repo>__<skill>` 로
+# 합성된다 — 겹치지 않는 대다수 skill 의 이름은 그대로라 참조가 안 깨진다.
+# 구분자로 `__` 를 쓰는 이유: `-` `.` 는 repo/skill 이름에 이미 흔하다.
+# 진단 로그는 stdout 을 오염시키지 않도록 stderr 로 보낸다.
 collect_skill_sources() {
-    local seen="|"
-    local skill_path skill_name
+    local seen="|" used="|"
+    local skill_path skill_name repo entry_name
 
     [ -n "$WORKSPACE_ROOT_RESOLVED" ] || return 0
 
     while IFS= read -r skill_path; do
         [ -n "$skill_path" ] || continue
         skill_name="$(basename "$skill_path")"
+        repo="$(basename "$(dirname "$(dirname "$skill_path")")")"
 
         case "$seen" in
+            *"|${repo}/${skill_name}|"*) continue ;;
+        esac
+        seen="${seen}${repo}/${skill_name}|"
+
+        entry_name="$skill_name"
+        case "$used" in
             *"|${skill_name}|"*)
-                log_dim "[skills] 이름 충돌 — 먼저 발견된 소스 유지, 건너뜀: ${skill_path}" >&2
-                continue
+                entry_name="${repo}__${skill_name}"
+                log_dim "[skills] 이름 충돌 — 접두사 부여: ${entry_name} (원본: ${skill_path})" >&2
                 ;;
+            *) used="${used}${skill_name}|" ;;
         esac
 
-        seen="${seen}${skill_name}|"
-        printf "%s\n" "$skill_path"
+        printf "%s\t%s\n" "$skill_path" "$entry_name"
     done <<< "$(_skill_workspace_dirs "$WORKSPACE_ROOT_RESOLVED")"
 }
 
@@ -198,17 +210,19 @@ skill_source_is_managed() {
     return 1
 }
 
-# skill 이름으로 소스 경로를 되찾는다. 없으면 비어 있는 출력 + rc 1.
+# 합성 엔트리 이름으로 소스 경로를 되찾는다. 없으면 비어 있는 출력 + rc 1.
 # codex 의 stale prune 이 "이 이름이 아직 유효한 소스인가" 를 물을 때 쓴다.
+# 이름은 basename 재계산이 아니라 목록이 실어 보낸 엔트리 이름과 대조한다 —
+# `<repo>__<skill>` 로 합성된 엔트리도 되찾을 수 있어야 한다 (#1746).
 skill_source_path_for() {
     local name="$1"
-    local candidate
+    local candidate candidate_name
 
     [ -n "$name" ] || return 1
 
-    while IFS= read -r candidate; do
+    while IFS=$'\t' read -r candidate candidate_name; do
         [ -n "$candidate" ] || continue
-        if [ "$(basename "$candidate")" = "$name" ]; then
+        if [ "$candidate_name" = "$name" ]; then
             printf "%s\n" "$candidate"
             return 0
         fi
@@ -291,9 +305,8 @@ link_skills_compose() {
     local linked=0 refreshed=0 skipped=0 pruned=0
     local skill_path skill_name link_target source_realpath current_link existing_target_path
 
-    while IFS= read -r skill_path; do
+    while IFS=$'\t' read -r skill_path skill_name; do
         [ -n "$skill_path" ] || continue
-        skill_name="$(basename "$skill_path")"
         link_target="${target}/${skill_name}"
         source_realpath="$(readlink -f "$skill_path")"
 
@@ -370,11 +383,10 @@ link_skills_individual_codex() {
 
     mkdir -p "$target_dir"
 
-    while IFS= read -r skill_path; do
+    local skill_path skill_name
+    while IFS=$'\t' read -r skill_path skill_name; do
         [ -n "$skill_path" ] || continue
 
-        local skill_name
-        skill_name="$(basename "$skill_path")"
         if [ "$skill_name" = ".system" ]; then
             continue
         fi

--- a/scripts/setup-skills-ssot.sh
+++ b/scripts/setup-skills-ssot.sh
@@ -164,29 +164,31 @@ WORKSPACE_ROOT_REAL=""
 # 구분자로 `__` 를 쓰는 이유: `-` `.` 는 repo/skill 이름에 이미 흔하다.
 # 진단 로그는 stdout 을 오염시키지 않도록 stderr 로 보낸다.
 collect_skill_sources() {
-    local seen="|" used="|"
+    local seen="|"
     local skill_path skill_name repo entry_name
 
     [ -n "$WORKSPACE_ROOT_RESOLVED" ] || return 0
 
     while IFS= read -r skill_path; do
         [ -n "$skill_path" ] || continue
-        skill_name="$(basename "$skill_path")"
-        repo="$(basename "$(dirname "$(dirname "$skill_path")")")"
+        # 고정 레이아웃(<root>/<repo>/skills/<skill>)이라 basename/dirname
+        # 서브셸 없이 parameter expansion 만으로 뽑아낼 수 있다.
+        skill_name="${skill_path##*/}"
+        repo="${skill_path%/*/*}"
+        repo="${repo##*/}"
 
         case "$seen" in
             *"|${repo}/${skill_name}|"*) continue ;;
         esac
-        seen="${seen}${repo}/${skill_name}|"
 
         entry_name="$skill_name"
-        case "$used" in
-            *"|${skill_name}|"*)
+        case "$seen" in
+            *"/${skill_name}|"*)
                 entry_name="${repo}__${skill_name}"
                 log_dim "[skills] 이름 충돌 — 접두사 부여: ${entry_name} (원본: ${skill_path})" >&2
                 ;;
-            *) used="${used}${skill_name}|" ;;
         esac
+        seen="${seen}${repo}/${skill_name}|"
 
         printf "%s\t%s\n" "$skill_path" "$entry_name"
     done <<< "$(_skill_workspace_dirs "$WORKSPACE_ROOT_RESOLVED")"

--- a/scripts/setup-skills-ssot.sh
+++ b/scripts/setup-skills-ssot.sh
@@ -164,15 +164,17 @@ WORKSPACE_ROOT_REAL=""
 # 구분자로 `__` 를 쓰는 이유: `-` `.` 는 repo/skill 이름에 이미 흔하다.
 # 진단 로그는 stdout 을 오염시키지 않도록 stderr 로 보낸다.
 collect_skill_sources() {
-    local seen="|"
+    local seen="|" used_entries="|"
     local skill_path skill_name repo entry_name
 
     [ -n "$WORKSPACE_ROOT_RESOLVED" ] || return 0
 
     while IFS= read -r skill_path; do
         [ -n "$skill_path" ] || continue
-        # 고정 레이아웃(<root>/<repo>/skills/<skill>)이라 basename/dirname
-        # 서브셸 없이 parameter expansion 만으로 뽑아낼 수 있다.
+        # 고정 레이아웃(<root>/<repo>/skills/<skill>) 은 이 값의 유일한 생산자인
+        # _skill_workspace_dirs 가 `-mindepth 4 -maxdepth 4 -path */skills/*/SKILL.md`
+        # 로 강제하는 불변식이다 — 추정이 아니라 skill_sources.sh SSOT 가 보장한다.
+        # basename/dirname 서브셸 없이 parameter expansion 만으로 뽑아낸다.
         skill_name="${skill_path##*/}"
         repo="${skill_path%/*/*}"
         repo="${repo##*/}"
@@ -189,6 +191,20 @@ collect_skill_sources() {
                 ;;
         esac
         seen="${seen}${repo}/${skill_name}|"
+
+        # repo/skill 이름 자체에 `__` 가 들어 있으면 <repo>__<skill> 합성이
+        # 단사(injective)라는 보장이 없다 — 서로 다른 두 소스가 같은 최종
+        # entry_name 으로 수렴할 수 있다 (codex 리뷰, PR #1747 BLOCKER). 조용히
+        # 하나가 다른 하나를 덮어쓰게 두는 대신, 먼저 배정된 소스를 지키고 늦게
+        # 온 쪽을 건너뛰며 경고한다. 실사용 저장소/스킬 이름에는 `__` 가 없어
+        # 사실상 발동하지 않는 방어선이다.
+        case "$used_entries" in
+            *"|${entry_name}|"*)
+                log_warning "[skills] 합성 엔트리 이름 충돌 — 건너뜀: ${entry_name} (원본: ${skill_path})" >&2
+                continue
+                ;;
+        esac
+        used_entries="${used_entries}${entry_name}|"
 
         printf "%s\t%s\n" "$skill_path" "$entry_name"
     done <<< "$(_skill_workspace_dirs "$WORKSPACE_ROOT_RESOLVED")"

--- a/tests/bats/tools/setup_skills_ssot.bats
+++ b/tests/bats/tools/setup_skills_ssot.bats
@@ -569,7 +569,7 @@ run_setup_with_workspace() {
     [ ! -e "${FIXTURE_HOME}/.config/opencode/skills/_shared" ]
 }
 
-@test "workspace: name collision resolves by sorted repo order (#1652 NF-1)" {
+@test "workspace: name collision — bare name to first repo, others get qualified entries (#1652 NF-1, #1746)" {
     seed_opencode_home
     # `alpha` already comes from base-skills, which sorts first.
     seed_workspace_skill "$(default_workspace_root)" "packaging-skills" "alpha"
@@ -579,9 +579,13 @@ run_setup_with_workspace() {
 
     [ "$(readlink -f "${FIXTURE_HOME}/.config/opencode/skills/alpha")" \
         = "$(readlink -f "${BASE_REPO}/skills/alpha")" ]
+    # The loser is no longer dropped — it is composed under a repo-qualified
+    # entry name so both skills stay reachable (#1746).
+    [ "$(readlink -f "${FIXTURE_HOME}/.config/opencode/skills/packaging-skills__alpha")" \
+        = "$(readlink -f "$(default_workspace_root)/packaging-skills/skills/alpha")" ]
 }
 
-@test "workspace: two repos exposing the same skill — first wins, deterministically (#1652)" {
+@test "workspace: two repos exposing the same skill — both coexist, bare name to first repo (#1652, #1746)" {
     seed_opencode_home
     local ws
     ws="$(default_workspace_root)"
@@ -593,15 +597,39 @@ run_setup_with_workspace() {
     run_setup
     assert_success
 
-    # Glob order is sorted, so the alphabetically first repo wins — and
-    # the choice must not flip between runs.
+    # Glob order is sorted, so the alphabetically first repo keeps the bare
+    # name — and the choice must not flip between runs.
     [ "$(readlink -f "${FIXTURE_HOME}/.config/opencode/skills/delta")" \
         = "$(readlink -f "${ws}/aaa-skills/skills/delta")" ]
+    [ "$(readlink -f "${FIXTURE_HOME}/.config/opencode/skills/zzz-skills__delta")" \
+        = "$(readlink -f "${ws}/zzz-skills/skills/delta")" ]
 
     run_setup
     assert_success
     [ "$(readlink -f "${FIXTURE_HOME}/.config/opencode/skills/delta")" \
         = "$(readlink -f "${ws}/aaa-skills/skills/delta")" ]
+    [ "$(readlink -f "${FIXTURE_HOME}/.config/opencode/skills/zzz-skills__delta")" \
+        = "$(readlink -f "${ws}/zzz-skills/skills/delta")" ]
+}
+
+# The exact shape #1746 reports: three unrelated repos each shipping `create`.
+@test "workspace: a three-way name collision exposes all three skills (#1746)" {
+    seed_opencode_home
+    local ws
+    ws="$(default_workspace_root)"
+    seed_workspace_skill "$ws" "gh-issue-skills" "create"
+    seed_workspace_skill "$ws" "gh-pr-skills" "create"
+    seed_workspace_skill "$ws" "packaging-skills" "create"
+
+    run_setup
+    assert_success
+
+    [ "$(readlink -f "${FIXTURE_HOME}/.config/opencode/skills/create")" \
+        = "$(readlink -f "${ws}/gh-issue-skills/skills/create")" ]
+    [ "$(readlink -f "${FIXTURE_HOME}/.config/opencode/skills/gh-pr-skills__create")" \
+        = "$(readlink -f "${ws}/gh-pr-skills/skills/create")" ]
+    [ "$(readlink -f "${FIXTURE_HOME}/.config/opencode/skills/packaging-skills__create")" \
+        = "$(readlink -f "${ws}/packaging-skills/skills/create")" ]
 }
 
 @test "workspace: a linked git worktree never shadows its clone (#1652)" {
@@ -620,6 +648,9 @@ run_setup_with_workspace() {
 
     [ "$(readlink -f "${FIXTURE_HOME}/.config/opencode/skills/delta")" \
         = "$(readlink -f "${ws}/packaging-skills/skills/delta")" ]
+    # The worktree is filtered out upstream, so there is no real collision to
+    # qualify — no `<worktree>__delta` entry may appear (#1746).
+    [ ! -e "${FIXTURE_HOME}/.config/opencode/skills/packaging-skills-feat-1__delta" ]
 }
 
 @test "workspace: WORKSPACE_ROOT of \$HOME is refused as too broad (#1652 safety)" {
@@ -668,6 +699,28 @@ run_setup_with_workspace() {
     assert_success
     [ ! -e "${FIXTURE_HOME}/.codex/skills/delta" ]
     [ -L "${FIXTURE_HOME}/.codex/skills/alpha" ]
+}
+
+# The qualified name has to round-trip through skill_source_path_for, or
+# codex's stale prune would delete it on the very next run (#1746).
+@test "workspace: codex keeps a qualified entry, then prunes it with its repo (#1746)" {
+    local ws
+    ws="$(default_workspace_root)"
+    seed_workspace_skill "$ws" "aaa-skills" "delta"
+    seed_workspace_skill "$ws" "zzz-skills" "delta"
+
+    run_setup
+    assert_success
+    run_setup
+    assert_success
+    [ -L "${FIXTURE_HOME}/.codex/skills/zzz-skills__delta" ]
+
+    rm -rf "${ws}/zzz-skills"
+
+    run_setup
+    assert_success
+    [ ! -e "${FIXTURE_HOME}/.codex/skills/zzz-skills__delta" ]
+    [ -L "${FIXTURE_HOME}/.codex/skills/delta" ]
 }
 
 @test "workspace: SKILL.md edits are live through the composed link (#1652 NF-2)" {

--- a/tests/bats/tools/setup_skills_ssot.bats
+++ b/tests/bats/tools/setup_skills_ssot.bats
@@ -632,6 +632,38 @@ run_setup_with_workspace() {
         = "$(readlink -f "${ws}/packaging-skills/skills/create")" ]
 }
 
+# `__` inside a repo or skill name means <repo>__<skill> is not injective:
+# two unrelated sources can qualify to the exact same final entry name
+# (agy/codex review, PR #1747 BLOCKER). The later one must be dropped with a
+# warning, never silently overwrite the earlier one's symlink.
+@test "workspace: a literal '__' collision between qualified names is dropped, not overwritten (#1747)" {
+    seed_opencode_home
+    local ws
+    ws="$(default_workspace_root)"
+    # Claim the bare names "Z" and "Y__Z" first so the next two repos both
+    # get qualified — and qualify to the identical string "X__Y__Z".
+    seed_workspace_skill "$ws" "0-first" "Z"
+    seed_workspace_skill "$ws" "1-second" "Y__Z"
+    seed_workspace_skill "$ws" "X" "Y__Z"
+    seed_workspace_skill "$ws" "X__Y" "Z"
+
+    run_setup
+    assert_success
+    [[ "$output" == *"합성 엔트리 이름 충돌"* ]]
+
+    [ "$(readlink -f "${FIXTURE_HOME}/.config/opencode/skills/Z")" \
+        = "$(readlink -f "${ws}/0-first/skills/Z")" ]
+    [ "$(readlink -f "${FIXTURE_HOME}/.config/opencode/skills/Y__Z")" \
+        = "$(readlink -f "${ws}/1-second/skills/Y__Z")" ]
+    # "X" sorts before "X__Y", so X's Y__Z wins the collision.
+    [ "$(readlink -f "${FIXTURE_HOME}/.config/opencode/skills/X__Y__Z")" \
+        = "$(readlink -f "${ws}/X/skills/Y__Z")" ]
+    # X__Y's Z is dropped entirely — no entry, under any name, points to it.
+    # 3 from this fixture (Z, Y__Z, X__Y__Z) + the fixture's own base-skills
+    # alpha/beta/gamma (setup(), no collision) = 6, never 7.
+    [ "$(find "${FIXTURE_HOME}/.config/opencode/skills" -mindepth 1 -maxdepth 1 -type l | wc -l)" -eq 6 ]
+}
+
 @test "workspace: a linked git worktree never shadows its clone (#1652)" {
     seed_opencode_home
     local ws


### PR DESCRIPTION
## Summary
- `setup-skills-ssot.sh`가 workspace skill 을 합성할 때 basename 하나로만 dedupe 해, 서로 다른 저장소가 같은 skill 이름(예: `create`)을 쓰면 정렬상 앞선 저장소만 남고 나머지는 Codex/OpenCode/Gemini/Hermes/agy 에서 조용히 사라졌다.
- dedupe 키를 `<repo>/<skill>` 로 바꾸고, 정렬상 처음 발견된 저장소만 bare 이름을 유지하며 이후 저장소는 `<repo>__<skill>` 로 합성하도록 고쳤다.

## Changes
- `scripts/setup-skills-ssot.sh`: `collect_skill_sources()` 가 `<소스 경로><TAB><합성 엔트리 이름>` 두 필드를 내보내도록 변경. `link_skills_compose()` / `link_skills_individual_codex()` / `skill_source_path_for()` 모두 basename 재계산 대신 전달받은 엔트리 이름을 그대로 사용.
- `tests/bats/tools/setup_skills_ssot.bats`: 기존 "충돌 시 하나만 살아남는다" 테스트 2건을 "bare 이름은 첫 저장소, 나머지는 접두사 붙은 이름으로 둘 다 살아남는다"로 갱신. 실제 이슈 사례(3개 저장소가 동시에 `create` 를 노출)를 재현하는 회귀 테스트와, codex 쪽 qualified entry 의 stale prune 왕복 테스트를 추가.

## Test plan
- [x] `./tests/bats/lib/bats-core/bin/bats tests/bats/tools/setup_skills_ssot.bats` — 48/48 green
- [x] `shellcheck -s bash scripts/setup-skills-ssot.sh` — clean

## Related
Closes #1746

---
<details>
<summary>🤖 AI Metrics · 📊 ~2500 tokens · 👤 ~2 h · 🤖 ~31 min</summary>

<!-- ai-metrics:gh-pr -->
📊 ~2500 tokens · 👤 ~2 h · 🤖 ~31 min
<!-- /ai-metrics:gh-pr -->

</details>
