### PR TITLE
fix(devx): devx_pr_verify_live_parse가 `#N` PR 인자를 remote로 삼키는 결함 해소

### DIFF
--- a/shell-common/functions/devx_pr_verify_live.sh
+++ b/shell-common/functions/devx_pr_verify_live.sh
@@ -66,6 +66,7 @@ devx_pr_verify_live_parse() {
     local post_comment=1
     local _remote_set=0
     local _pos_seen=0
+    local _hash_prefixed=0
     local _url_set=0
     local _api_url_set=0
     local _start_set=0
@@ -187,6 +188,7 @@ devx_pr_verify_live_parse() {
                     ;;
                 '#'*)
                     pr="${1#\#}"
+                    _hash_prefixed=1
                     ;;
                 *)
                     remote="$1"
@@ -205,7 +207,11 @@ devx_pr_verify_live_parse() {
         esac
     done
 
-    if [ -n "$pr" ]; then
+    # A bare `#` with no digits (`_hash_prefixed=1`, `pr=""`) must still hit
+    # this check — otherwise it silently falls back to PR auto-detection
+    # instead of being rejected like any other malformed PR# (#1748 codex
+    # review, PR #1749).
+    if [ -n "$pr" ] || [ "$_hash_prefixed" -eq 1 ]; then
         if ! _devx_pr_verify_live_pos_int "$pr"; then
             echo "PR# must be a positive integer: '$pr'" >&2
             return 2

--- a/shell-common/functions/devx_pr_verify_live.sh
+++ b/shell-common/functions/devx_pr_verify_live.sh
@@ -66,7 +66,7 @@ devx_pr_verify_live_parse() {
     local post_comment=1
     local _remote_set=0
     local _pos_seen=0
-    local _hash_prefixed=0
+    local _pr_set=0
     local _url_set=0
     local _api_url_set=0
     local _start_set=0
@@ -183,12 +183,11 @@ devx_pr_verify_live_parse() {
             if [ "$_pos_seen" -eq 0 ]; then
                 _pos_seen=1
                 case "$1" in
-                [0-9]*)
-                    pr="$1"
-                    ;;
-                '#'*)
+                [0-9]* | '#'*)
+                    # Stripping `#` is a no-op on a bare digit string, so
+                    # one arm covers `123` and `#123` alike.
                     pr="${1#\#}"
-                    _hash_prefixed=1
+                    _pr_set=1
                     ;;
                 *)
                     remote="$1"
@@ -207,11 +206,11 @@ devx_pr_verify_live_parse() {
         esac
     done
 
-    # A bare `#` with no digits (`_hash_prefixed=1`, `pr=""`) must still hit
-    # this check — otherwise it silently falls back to PR auto-detection
-    # instead of being rejected like any other malformed PR# (#1748 codex
+    # Gate on "a PR# positional was given", not on `pr` being non-empty: a
+    # bare `#` strips to an empty PR# and must still be rejected here
+    # instead of silently falling back to PR auto-detection (#1748 codex
     # review, PR #1749).
-    if [ -n "$pr" ] || [ "$_hash_prefixed" -eq 1 ]; then
+    if [ "$_pr_set" -eq 1 ]; then
         if ! _devx_pr_verify_live_pos_int "$pr"; then
             echo "PR# must be a positive integer: '$pr'" >&2
             return 2

--- a/shell-common/functions/devx_pr_verify_live.sh
+++ b/shell-common/functions/devx_pr_verify_live.sh
@@ -174,15 +174,19 @@ devx_pr_verify_live_parse() {
             ;;
         *)
             # `[pr-number] [remote]` with an optional PR#. Discriminator:
-            # PR numbers start with a digit, git remote names conventionally
+            # PR numbers start with a digit (optionally `#`-prefixed, the
+            # common GitHub PR notation), git remote names conventionally
             # do not. A leading digit therefore always means "this is the
-            # PR#" — `12a` stays a loud PR# error instead of silently
-            # becoming a remote name.
+            # PR#" — `12a` / `#12a` stay a loud PR# error instead of
+            # silently becoming a remote name.
             if [ "$_pos_seen" -eq 0 ]; then
                 _pos_seen=1
                 case "$1" in
                 [0-9]*)
                     pr="$1"
+                    ;;
+                '#'*)
+                    pr="${1#\#}"
                     ;;
                 *)
                     remote="$1"

--- a/tests/bats/functions/devx_pr_verify_live.bats
+++ b/tests/bats/functions/devx_pr_verify_live.bats
@@ -334,6 +334,14 @@ setup() {
     assert_output --partial "PR# must be a positive integer: '12a'"
 }
 
+# codex review on PR #1749: a bare "#" strips to an empty pr, which must not
+# silently bypass validation and fall back to PR auto-detection.
+@test "bare hash with no digits -> exit 2, not silent auto-detect fallback" {
+    run devx_pr_verify_live_parse "#"
+    assert_failure 2
+    assert_output --partial "PR# must be a positive integer: ''"
+}
+
 @test "remote-only + extra positional -> exit 2" {
     run devx_pr_verify_live_parse upstream extra
     assert_failure 2

--- a/tests/bats/functions/devx_pr_verify_live.bats
+++ b/tests/bats/functions/devx_pr_verify_live.bats
@@ -319,6 +319,21 @@ setup() {
     assert_output --partial "PR# must be a positive integer: '12a'"
 }
 
+# #1748: `#N` is the common GitHub PR notation and must classify as a PR#,
+# not fall through to the remote-name branch.
+@test "hash-prefixed PR# -> pr stripped of '#', remote defaults to origin" {
+    run devx_pr_verify_live_parse "#1745"
+    assert_success
+    assert_line "pr=1745"
+    assert_line "remote=origin"
+}
+
+@test "hash-prefixed digit-leading typo stays a PR# error, not a remote" {
+    run devx_pr_verify_live_parse "#12a"
+    assert_failure 2
+    assert_output --partial "PR# must be a positive integer: '12a'"
+}
+
 @test "remote-only + extra positional -> exit 2" {
     run devx_pr_verify_live_parse upstream extra
     assert_failure 2


### PR DESCRIPTION
## Summary
- `devx_pr_verify_live_parse`가 `#N` 형태의 PR 인자를 remote로 잘못 삼키던 결함을 수정했다.

## Changes
- fix(devx): 첫 positional 분류에 `'#'*)` 분기를 추가해 선행 `#`을 벗겨낸 뒤 기존 양의 정수 검증(`_devx_pr_verify_live_pos_int`)에 그대로 태움 (`shell-common/functions/devx_pr_verify_live.sh`)
- test: `#1745`(정상 분류) / `#12a`(오타 거부) 회귀 케이스 2건 추가 (`tests/bats/functions/devx_pr_verify_live.bats`)

## Test plan
- [x] `./tests/bats/lib/bats-core/bin/bats tests/bats/functions/devx_pr_verify_live.bats` — 62/62 통과
- [x] `shellcheck shell-common/functions/devx_pr_verify_live.sh` — clean

## Related
Closes #1748

---
<details>
<summary>🤖 AI Metrics · 📊 ~1000 tokens · 👤 ~2 h · 🤖 ~0 min</summary>

<!-- ai-metrics:gh-pr -->
📊 ~1000 tokens · 👤 ~2 h · 🤖 ~0 min
<!-- /ai-metrics:gh-pr -->

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CswQgLGiTfYWNrzbCeLmka
