### PR TITLE
fix(gcp-scan): apply 루프의 cherry-pick conflict hint 중복 출력 제거

### DIFF
--- a/shell-common/functions/gcp_scan.sh
+++ b/shell-common/functions/gcp_scan.sh
@@ -246,6 +246,9 @@ _gcp_scan_report_conflict_stop() {
 }
 
 _gcp_scan_cherry_pick_quiet() {
+    #   $1  commit to pick
+    #   $2  the repo's git dir (the loop's $_gcp_git_dir) — scratch lives there
+    #
     # `git cherry-pick "$1"`, minus git's unactionable conflict-advice block
     # (issue #1753). On conflict git appends 5-6 `hint: ... --continue /
     # --skip / --abort` lines on STDERR, but the execution loop resolves the
@@ -255,22 +258,43 @@ _gcp_scan_cherry_pick_quiet() {
     # cannot act on, printed immediately above the loop's own `Deferred ...`
     # summary of the same event.
     #
-    # Filtering STDERR, not `-c advice.mergeConflict=false`: that key only
-    # gates this block from git 2.45 onwards and is silently ignored by older
-    # git (2.43 is what ships with Ubuntu 24.04), which prints the very same
-    # hints with no config gate at all — so the config-only fix is a no-op
-    # exactly where the bug was reported.
+    # Two git-side knobs plus one filter, because no single one covers every
+    # git (PR #1755 review, agy + codex FOLLOW-UP):
+    #
+    #   advice.mergeConflict=false — git >= 2.45 never emits the block at all,
+    #     so nothing has to be pattern-matched there (a translated `hint:`
+    #     prefix included). Silently ignored by older git, where `advise()` is
+    #     ungated — which is why the filter below still has to exist.
+    #   color.advice=false — makes the filter's `^hint: ` anchor unbreakable.
+    #     A user running `color.advice=always` gets each hint line prefixed
+    #     with an ANSI SGR escape, so the anchor misses and all six lines leak
+    #     (verified on git 2.43). `-c` on the command line outranks any
+    #     user config, so this cannot be turned back on from the outside.
+    #   grep -v '^hint: ' — the actual removal on git < 2.45.
+    #
+    # Residual, accepted: git < 2.45 with git's own translations installed AND
+    # a non-English locale would emit a translated prefix the filter misses.
+    # That combination degrades to today's behaviour (hints shown), never to a
+    # lost cherry-pick.
+    #
+    # Scratch file lives in the git dir under a fixed name, not `mktemp` in
+    # $TMPDIR: an interrupt mid-pick used to strand a `gcp_cp_err.*` file per
+    # commit (agy + codex FOLLOW-UP). A fixed path is truncated by the next
+    # `>` instead of accumulating, is scoped to the repo being picked into,
+    # and removes the `mktemp`-failure branch entirely.
     #
     # No information is lost: `Auto-merging` and `CONFLICT (content): ...` go
     # to STDOUT and are never touched, and `error: could not apply ...`
     # survives the filter because only `hint:` lines are dropped.
     local _err _rc
-    _err=$(mktemp "${TMPDIR:-/tmp}/gcp_cp_err.XXXXXX" 2>/dev/null) || {
-        # No temp file — never trade the cherry-pick itself for tidier output.
-        git cherry-pick "$1"
+    _err="${2:-}/gcp-scan-cp-stderr"
+    # Unwritable git dir (read-only checkout, odd permissions) — never trade
+    # the cherry-pick itself for tidier output.
+    if [ -z "${2:-}" ] || ! : >"$_err" 2>/dev/null; then
+        git -c advice.mergeConflict=false -c color.advice=false cherry-pick "$1"
         return $?
-    }
-    git cherry-pick "$1" 2>"$_err"
+    fi
+    git -c advice.mergeConflict=false -c color.advice=false cherry-pick "$1" 2>"$_err"
     _rc=$?
     grep -v '^hint: ' "$_err" >&2
     command rm -f "$_err"
@@ -1608,7 +1632,7 @@ $sha
         if type ux_info >/dev/null 2>&1; then
             ux_info "Cherry-picking $sha..."
         fi
-        if _gcp_scan_cherry_pick_quiet "$sha"; then
+        if _gcp_scan_cherry_pick_quiet "$sha" "$_gcp_git_dir"; then
             picked=$((picked + 1))
         else
             # Defensive: a commit that becomes empty against HEAD (no conflict)

--- a/shell-common/functions/gcp_scan.sh
+++ b/shell-common/functions/gcp_scan.sh
@@ -232,10 +232,49 @@ _gcp_scan_report_conflict_stop() {
     # Shared "Failed at $sha, resolve manually" message for the execution
     # loop's two abort-the-batch exits (--stop-on-conflict, and the rollback
     # itself failing to clear the sequencer) — issue #1647, defect B.
+    #
+    # Names `--abort` as well as `--continue` (issue #1753): the sequencer is
+    # left ACTIVE on both of these exits, and git's own hint block — which
+    # used to spell out the full menu right here — is now filtered out by
+    # `_gcp_scan_cherry_pick_quiet`. `_gcp_assert_no_cherry_pick` shows the
+    # same pair, but only on the NEXT gcp invocation.
     local sha="$1"
     if type ux_error >/dev/null 2>&1; then
         ux_error "Failed at $sha. Resolve and run: git cherry-pick --continue"
+        ux_error "  (or abandon it with: git cherry-pick --abort)"
     fi
+}
+
+_gcp_scan_cherry_pick_quiet() {
+    # `git cherry-pick "$1"`, minus git's unactionable conflict-advice block
+    # (issue #1753). On conflict git appends 5-6 `hint: ... --continue /
+    # --skip / --abort` lines on STDERR, but the execution loop resolves the
+    # sequencer itself — it rolls the single commit back and continues, and
+    # both abort-the-batch exits print their own recovery line via
+    # `_gcp_scan_report_conflict_stop`. So those hints are advice the user
+    # cannot act on, printed immediately above the loop's own `Deferred ...`
+    # summary of the same event.
+    #
+    # Filtering STDERR, not `-c advice.mergeConflict=false`: that key only
+    # gates this block from git 2.45 onwards and is silently ignored by older
+    # git (2.43 is what ships with Ubuntu 24.04), which prints the very same
+    # hints with no config gate at all — so the config-only fix is a no-op
+    # exactly where the bug was reported.
+    #
+    # No information is lost: `Auto-merging` and `CONFLICT (content): ...` go
+    # to STDOUT and are never touched, and `error: could not apply ...`
+    # survives the filter because only `hint:` lines are dropped.
+    local _err _rc
+    _err=$(mktemp "${TMPDIR:-/tmp}/gcp_cp_err.XXXXXX" 2>/dev/null) || {
+        # No temp file — never trade the cherry-pick itself for tidier output.
+        git cherry-pick "$1"
+        return $?
+    }
+    git cherry-pick "$1" 2>"$_err"
+    _rc=$?
+    grep -v '^hint: ' "$_err" >&2
+    command rm -f "$_err"
+    return "$_rc"
 }
 
 _gcp_scan_pick_list_prior() {
@@ -1569,7 +1608,7 @@ $sha
         if type ux_info >/dev/null 2>&1; then
             ux_info "Cherry-picking $sha..."
         fi
-        if git cherry-pick "$sha"; then
+        if _gcp_scan_cherry_pick_quiet "$sha"; then
             picked=$((picked + 1))
         else
             # Defensive: a commit that becomes empty against HEAD (no conflict)

--- a/shell-common/functions/gcp_scan.sh
+++ b/shell-common/functions/gcp_scan.sh
@@ -236,8 +236,8 @@ _gcp_scan_report_conflict_stop() {
     # Names `--abort` as well as `--continue` (issue #1753): the sequencer is
     # left ACTIVE on both of these exits, and git's own hint block — which
     # used to spell out the full menu right here — is now filtered out by
-    # `_gcp_scan_cherry_pick_quiet`. `_gcp_assert_no_cherry_pick` shows the
-    # same pair, but only on the NEXT gcp invocation.
+    # `_gcp_scan_cherry_pick_quiet`. Matches the same pair printed by this
+    # file's inline CHERRY_PICK_HEAD guard on the NEXT gcp scan.
     local sha="$1"
     if type ux_error >/dev/null 2>&1; then
         ux_error "Failed at $sha. Resolve and run: git cherry-pick --continue"
@@ -246,17 +246,13 @@ _gcp_scan_report_conflict_stop() {
 }
 
 _gcp_scan_cherry_pick_quiet() {
-    #   $1  commit to pick
-    #   $2  the repo's git dir (the loop's $_gcp_git_dir) — scratch lives there
-    #
     # `git cherry-pick "$1"`, minus git's unactionable conflict-advice block
     # (issue #1753). On conflict git appends 5-6 `hint: ... --continue /
     # --skip / --abort` lines on STDERR, but the execution loop resolves the
     # sequencer itself — it rolls the single commit back and continues, and
     # both abort-the-batch exits print their own recovery line via
     # `_gcp_scan_report_conflict_stop`. So those hints are advice the user
-    # cannot act on, printed immediately above the loop's own `Deferred ...`
-    # summary of the same event.
+    # cannot act on, printed right above the loop's own `Deferred ...` summary.
     #
     # Two git-side knobs plus one filter, because no single one covers every
     # git (PR #1755 review, agy + codex FOLLOW-UP):
@@ -265,39 +261,28 @@ _gcp_scan_cherry_pick_quiet() {
     #     so nothing has to be pattern-matched there (a translated `hint:`
     #     prefix included). Silently ignored by older git, where `advise()` is
     #     ungated — which is why the filter below still has to exist.
-    #   color.advice=false — makes the filter's `^hint: ` anchor unbreakable.
-    #     A user running `color.advice=always` gets each hint line prefixed
-    #     with an ANSI SGR escape, so the anchor misses and all six lines leak
-    #     (verified on git 2.43). `-c` on the command line outranks any
-    #     user config, so this cannot be turned back on from the outside.
+    #   color.advice=false — keeps the filter's `^hint: ` anchor unbreakable.
+    #     Under `color.advice=always` each hint line carries an ANSI SGR prefix,
+    #     so the anchor misses and all six leak (verified on git 2.43). `-c` on
+    #     the command line outranks user config, so this cannot be re-enabled
+    #     from the outside.
     #   grep -v '^hint: ' — the actual removal on git < 2.45.
     #
     # Residual, accepted: git < 2.45 with git's own translations installed AND
     # a non-English locale would emit a translated prefix the filter misses.
-    # That combination degrades to today's behaviour (hints shown), never to a
-    # lost cherry-pick.
+    # That degrades to today's behaviour (hints shown), never to a lost
+    # cherry-pick.
     #
-    # Scratch file lives in the git dir under a fixed name, not `mktemp` in
-    # $TMPDIR: an interrupt mid-pick used to strand a `gcp_cp_err.*` file per
-    # commit (agy + codex FOLLOW-UP). A fixed path is truncated by the next
-    # `>` instead of accumulating, is scoped to the repo being picked into,
-    # and removes the `mktemp`-failure branch entirely.
-    #
-    # No information is lost: `Auto-merging` and `CONFLICT (content): ...` go
-    # to STDOUT and are never touched, and `error: could not apply ...`
-    # survives the filter because only `hint:` lines are dropped.
+    # STDERR is captured through an fd swap, not a scratch file: `$(...)` sets
+    # `$?` from the command it ran, so git's exit status survives without the
+    # temp file a pipeline would force (`grep` would otherwise become `$?`, and
+    # PIPESTATUS is not POSIX). fd 3 carries STDOUT through untouched, so
+    # `Auto-merging` and `CONFLICT (content): ...` are never even captured;
+    # `error: could not apply ...` is, and survives the `hint:`-only filter.
     local _err _rc
-    _err="${2:-}/gcp-scan-cp-stderr"
-    # Unwritable git dir (read-only checkout, odd permissions) — never trade
-    # the cherry-pick itself for tidier output.
-    if [ -z "${2:-}" ] || ! : >"$_err" 2>/dev/null; then
-        git -c advice.mergeConflict=false -c color.advice=false cherry-pick "$1"
-        return $?
-    fi
-    git -c advice.mergeConflict=false -c color.advice=false cherry-pick "$1" 2>"$_err"
-    _rc=$?
-    grep -v '^hint: ' "$_err" >&2
-    command rm -f "$_err"
+    { _err=$(git -c advice.mergeConflict=false -c color.advice=false \
+        cherry-pick "$1" 2>&1 1>&3); _rc=$?; } 3>&1
+    [ -z "$_err" ] || printf '%s\n' "$_err" | grep -v '^hint: ' >&2
     return "$_rc"
 }
 
@@ -1632,7 +1617,7 @@ $sha
         if type ux_info >/dev/null 2>&1; then
             ux_info "Cherry-picking $sha..."
         fi
-        if _gcp_scan_cherry_pick_quiet "$sha" "$_gcp_git_dir"; then
+        if _gcp_scan_cherry_pick_quiet "$sha"; then
             picked=$((picked + 1))
         else
             # Defensive: a commit that becomes empty against HEAD (no conflict)

--- a/tests/bats/functions/gcp.bats
+++ b/tests/bats/functions/gcp.bats
@@ -2164,13 +2164,39 @@ FIXTURE
         git config advice.resolveConflict true
         printf 'y\n' | _gcp_scan main source --author=all
         echo \"scan_rc=\$?\"
+        ls .git/gcp-scan-cp-stderr >/dev/null 2>&1 && echo SCRATCH_LEFT || echo SCRATCH_CLEAN
     "
+    # The scratch file the filter writes through is cleaned up, and it lives in
+    # the git dir — never a per-commit mktemp in \$TMPDIR (PR #1755 review).
+    assert_output --partial "SCRATCH_CLEAN"
     # The noise is gone.
     refute_output --partial "hint:"
     # The informative body lines survive — no information loss.
     assert_output --partial "CONFLICT (content)"
     assert_output --partial "conf.txt"
     # The loop's own summary still reports the deferral.
+    assert_output --partial "rolled back, continuing with the rest"
+    assert_output --partial "1 deferred (conflict)"
+    assert_output --partial "scan_rc=1"
+}
+
+@test "scan #1753: hint filter survives color.advice=always (ANSI-prefixed hints)" {
+    # PR #1755 review (agy + codex FOLLOW-UP, generalized). With
+    # `color.advice=always` git prefixes every hint line with an ANSI SGR
+    # escape, so a bare `^hint: ` anchor misses and all six lines leak through
+    # — verified on git 2.43. The fix pins `-c color.advice=false` on the
+    # cherry-pick, and `-c` on the command line outranks repo config, so the
+    # setting below cannot defeat it.
+    run_in_bash "
+        $(_gcp1647_make_repo)
+        git config advice.mergeConflict true
+        git config color.advice always
+        git config color.ui always
+        printf 'y\n' | _gcp_scan main source --author=all
+        echo \"scan_rc=\$?\"
+    "
+    refute_output --partial "hint:"
+    assert_output --partial "CONFLICT (content)"
     assert_output --partial "rolled back, continuing with the rest"
     assert_output --partial "1 deferred (conflict)"
     assert_output --partial "scan_rc=1"

--- a/tests/bats/functions/gcp.bats
+++ b/tests/bats/functions/gcp.bats
@@ -2141,9 +2141,9 @@ FIXTURE
 }
 
 @test "bash: _gcp_scan_cherry_pick_quiet private function exists" {
-    run_in_bash 'type _gcp_scan_cherry_pick_quiet >/dev/null 2>&1 && echo EXISTS'
+    run_in_bash 'declare -f _gcp_scan_cherry_pick_quiet >/dev/null && echo ok'
     assert_success
-    assert_output --partial "EXISTS"
+    assert_output --partial "ok"
 }
 
 @test "scan #1753: git's cherry-pick advice hints are suppressed, CONFLICT line kept" {
@@ -2153,21 +2153,19 @@ FIXTURE
     # `Deferred ... rolled back, continuing with the rest.` summary. Both
     # abort-the-batch exits print their own recovery line via
     # `_gcp_scan_report_conflict_stop`, so nothing actionable is lost.
-    # Both advice keys are forced ON in the fixture repo so the test cannot
-    # pass vacuously on a machine that disabled them globally. Note that on
-    # git < 2.45 neither key gates this block at all — which is why the fix
-    # filters `hint:` off the cherry-pick's stderr instead of setting them.
+    # advice.mergeConflict is forced ON in the fixture repo so the test cannot
+    # pass vacuously on a machine that disabled it globally. Note that on
+    # git < 2.45 that key does not gate this block at all — which is why the
+    # fix filters `hint:` off the cherry-pick's stderr as well as setting it.
     run_in_bash "
         $(_gcp1647_make_repo)
         git config advice.mergeConflict true
-        git config advice.skippedCherryPicks true
-        git config advice.resolveConflict true
         printf 'y\n' | _gcp_scan main source --author=all
         echo \"scan_rc=\$?\"
         ls .git/gcp-scan-cp-stderr >/dev/null 2>&1 && echo SCRATCH_LEFT || echo SCRATCH_CLEAN
     "
-    # The scratch file the filter writes through is cleaned up, and it lives in
-    # the git dir — never a per-commit mktemp in \$TMPDIR (PR #1755 review).
+    # No scratch file is created at all: stderr is captured through an fd swap,
+    # so there is nothing to leak on an interrupt mid-pick (PR #1755 review).
     assert_output --partial "SCRATCH_CLEAN"
     # The noise is gone.
     refute_output --partial "hint:"

--- a/tests/bats/functions/gcp.bats
+++ b/tests/bats/functions/gcp.bats
@@ -2140,6 +2140,42 @@ FIXTURE
     refute_output --partial "B10"
 }
 
+@test "bash: _gcp_scan_cherry_pick_quiet private function exists" {
+    run_in_bash 'type _gcp_scan_cherry_pick_quiet >/dev/null 2>&1 && echo EXISTS'
+    assert_success
+    assert_output --partial "EXISTS"
+}
+
+@test "scan #1753: git's cherry-pick advice hints are suppressed, CONFLICT line kept" {
+    # Issue #1753. The apply loop rolls a deferred conflict back itself, so git's
+    # 5-line "hint: ... run git cherry-pick --continue/--skip/--abort" block is
+    # advice the user cannot act on, duplicated right above the loop's own
+    # `Deferred ... rolled back, continuing with the rest.` summary. Both
+    # abort-the-batch exits print their own recovery line via
+    # `_gcp_scan_report_conflict_stop`, so nothing actionable is lost.
+    # Both advice keys are forced ON in the fixture repo so the test cannot
+    # pass vacuously on a machine that disabled them globally. Note that on
+    # git < 2.45 neither key gates this block at all — which is why the fix
+    # filters `hint:` off the cherry-pick's stderr instead of setting them.
+    run_in_bash "
+        $(_gcp1647_make_repo)
+        git config advice.mergeConflict true
+        git config advice.skippedCherryPicks true
+        git config advice.resolveConflict true
+        printf 'y\n' | _gcp_scan main source --author=all
+        echo \"scan_rc=\$?\"
+    "
+    # The noise is gone.
+    refute_output --partial "hint:"
+    # The informative body lines survive — no information loss.
+    assert_output --partial "CONFLICT (content)"
+    assert_output --partial "conf.txt"
+    # The loop's own summary still reports the deferral.
+    assert_output --partial "rolled back, continuing with the rest"
+    assert_output --partial "1 deferred (conflict)"
+    assert_output --partial "scan_rc=1"
+}
+
 @test "scan #1647: --stop-on-conflict restores the legacy all-or-nothing abort" {
     # Defect B opt-out. With the flag the first unpredicted conflict aborts the
     # whole remaining batch exactly as before: the sequencer stays ACTIVE for the
@@ -2152,6 +2188,10 @@ FIXTURE
         [ -f \"\$repo/.git/CHERRY_PICK_HEAD\" ] && echo CPH_PRESENT || echo CPH_MISSING
     "
     assert_output --partial "Resolve and run"
+    # #1753: git's hint block is filtered out now, so the sequencer is left
+    # ACTIVE with only this message to recover from — it must name --abort too.
+    assert_output --partial "git cherry-pick --abort"
+    refute_output --partial "hint:"
     assert_output --partial "scan_rc=1"
     assert_output --partial "CPH_PRESENT"
     # Legacy behavior: the batch stopped, so the later candidate never applied.


### PR DESCRIPTION
## Summary
- `gcp scan` apply 루프에서 git 이 붙이는 cherry-pick conflict advice hint 5줄을 제거했다 — 스크립트가 스스로 롤백하므로 사용자가 따라 할 수 없는 지침이고, 바로 아래 `Deferred ...` 요약과 중복된다.
- 이슈가 제안한 `-c advice.mergeConflict=false` 는 이 환경에서 무효라 stderr 필터 방식으로 구현했다 (git 2.43 vs 2.45 차이).
- hint 블록이 사라지면서 `--stop-on-conflict` 경로가 잃게 되는 `--abort` 안내를 스크립트 자체 메시지에 보강했다.

## Changes
- `shell-common/functions/gcp_scan.sh`: `_gcp_scan_cherry_pick_quiet()` 추가 — cherry-pick 을 감싸 stderr 에서 `hint:` 줄만 걸러낸다. apply 루프(구 `git cherry-pick "$sha"`)가 이 헬퍼를 호출한다. `mktemp` 실패 시에는 필터 없이 그냥 cherry-pick 을 실행해, 출력 정리 때문에 apply 자체를 잃지 않는다.
- `shell-common/functions/gcp_scan.sh`: `_gcp_scan_report_conflict_stop()` 이 `--continue` 와 함께 `--abort` 도 안내한다. 이 경로는 sequencer 를 살아 있는 채로 남기는데, git 의 hint 메뉴가 걸러지므로 전체 복구 수단을 스크립트가 직접 알려야 한다.
- `tests/bats/functions/gcp.bats`: 회귀 테스트 2건 추가 (`_gcp_scan_cherry_pick_quiet` 존재 확인, #1753 hint 억제 + `CONFLICT (content)` 보존). `--stop-on-conflict` 테스트에도 `--abort` 안내와 `hint:` 부재 단언을 추가했다.

## 왜 `-c advice.mergeConflict=false` 가 아닌가
이슈 본문의 수정안은 이 저장소가 도는 git 에서 동작하지 않는다. `advice.mergeConflict` 키는 git 2.45 에서 도입됐고, 여기 git 은 2.43 이라 `sequencer.c` 의 `print_advice()` 가 게이트 없는 `advise()` 로 같은 hint 를 출력한다. `advice.resolveConflict` / `advice.skippedCherryPicks` 도 동일하게 무효임을 실측 확인했다. 반면 stderr 필터는 git 버전과 무관하게 동작한다.

정보 손실은 없다 — `Auto-merging` / `CONFLICT (content): ...` 은 **stdout** 이라 손대지 않고, stderr 의 `error: could not apply ...` 도 `hint:` 가 아니므로 그대로 남는다.

## 범위 판단
`shell-common/functions/gcp.sh` 의 `gcp pick` / `gcp theirs` 도 `git cherry-pick` 을 부르지만 손대지 않았다. 그쪽은 sequencer 를 사용자에게 넘긴 채 끝나므로 git 의 hint 가 **실제로 따라 할 수 있는 안내**다. 같은 증상처럼 보여도 같은 결함이 아니다.

## Test plan
- [x] `tests/bats/functions/gcp.bats` 121/121 통과 (신규 2건 포함)
- [x] 수정 전 신규 테스트가 RED — `hint:` 6줄이 실제로 재현됨을 확인
- [x] pytest 1553 통과
- [x] `mise run lint-sh` 통과
- [x] `bash -n` / `zsh -n` 문법 검사 통과
- [ ] 리뷰어: conflict 가 나는 실제 `gcp scan` 실행에서 `hint:` 부재 + `CONFLICT` 유지 육안 확인

## Related
Closes #1753

---
<details>
<summary>🤖 AI Metrics · 📊 ~2500 tokens · 👤 ~2 h · 🤖 ~0 min</summary>

<!-- ai-metrics:gh-pr -->
📊 ~2500 tokens · 👤 ~2 h · 🤖 ~0 min
<!-- /ai-metrics:gh-pr -->

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015CHxoSgh1MntvZric8BFdm
