### PR TITLE
fix(gh-project-status): projectItems 페이지네이션 + verify 대상 보드 상관

### DIFF
--- a/shell-common/functions/gh_project_status.sh
+++ b/shell-common/functions/gh_project_status.sh
@@ -480,13 +480,18 @@ _gh_project_status_query_current() {
         *) return 1 ;;
     esac
 
-    # Project pin (#1757), validated before anything is queried. GitHub node
-    # ids are base64url text; a value with anything else in it is a caller
-    # bug and must not be spliced into the jq program below.
+    # Project pin (#1757), validated before anything is queried. The guard
+    # exists so a caller-supplied id cannot break out of the jq string
+    # literal it is spliced into below — only `"` and `\` could do that, so
+    # the class stays permissive over the id alphabet itself and covers both
+    # base64 (`+`, `/`) and base64url (`-`, `_`) plus `=` padding. GraphQL
+    # node ids are opaque and GitHub guarantees neither variant (PR #1758,
+    # codex), so narrowing this to base64url would reject a legitimate id and
+    # turn a working verify into a silent "verify failed twice".
     local _proj_sel=''
     case "$_proj_arg" in
         '') ;;
-        *[!A-Za-z0-9_=-]*) return 1 ;;
+        *[!A-Za-z0-9_=+/-]*) return 1 ;;
         *) _proj_sel="| select(.project?.id == \"$_proj_arg\")" ;;
     esac
 

--- a/shell-common/functions/gh_project_status.sh
+++ b/shell-common/functions/gh_project_status.sh
@@ -266,14 +266,24 @@ _gh_project_status_sync() {
     #   project.id | item.id | field.id | target_option.id | current_status_name
     # The current_status_name is needed for --only-from gating.
     #
-    # Variables: $owner String!, $repo String!, $number Int!, $target String!
+    # Pagination (issue #1757): an item can belong to more than one board,
+    # and the jq select below keeps only the boards whose Status field
+    # actually offers $target. With a fixed `first: 10` an 11th-or-later
+    # membership was dropped before the filter ever saw it, so the sync
+    # degraded to a silent no-op indistinguishable from "not on any matching
+    # board". `--paginate` makes gh follow pageInfo.endCursor itself — that
+    # is why the query declares $endCursor and asks for pageInfo — and it
+    # re-runs the --jq filter per page, so $_records collects every match.
+    # Variables: $owner String!, $repo String!, $number Int!, $target String!,
+    #            $endCursor String
     local _records
-    _records=$(gh api graphql \
+    _records=$(gh api graphql --paginate \
         -f query="
-          query(\$owner: String!, \$repo: String!, \$number: Int!, \$target: String!) {
+          query(\$owner: String!, \$repo: String!, \$number: Int!, \$target: String!, \$endCursor: String) {
             repository(owner: \$owner, name: \$repo) {
               ${_q_field}(number: \$number) {
-                projectItems(first: 10) {
+                projectItems(first: 100, after: \$endCursor) {
+                  pageInfo { hasNextPage endCursor }
                   nodes {
                     id
                     fieldValueByName(name: \"Status\") {
@@ -377,7 +387,7 @@ _gh_project_status_set_and_verify() {
     local _attempt
     for _attempt in 1 2; do
         sleep "${_GH_PROJECT_STATUS_VERIFY_SLEEP-1}"
-        _actual=$(_gh_project_status_query_current "$_kind" "$_num" "$_repo_arg")
+        _actual=$(_gh_project_status_query_current "$_kind" "$_num" "$_repo_arg" "$_proj")
 
         if [ "$_actual" = "$_target" ]; then
             if [ "$_attempt" -eq 1 ]; then
@@ -408,12 +418,10 @@ _gh_project_status_set_and_verify() {
 }
 
 # Best-effort read of the current Status for an issue/PR. Returns the first
-# non-empty Status value found across the item's project memberships — for
-# multi-board items the verify pair only checks one board's value, but every
-# board runs the same builtin workflows so observing one race surface is
-# sufficient for the recovery contract.
+# non-empty Status value found across the item's project memberships, or —
+# when a project id is pinned — the value on exactly that one board.
 #
-# Args: kind num [owner/repo]
+# Args: kind num [owner/repo] [project-id]
 #   The optional third positional pins the repo (issue #1405). It is handed
 #   straight to _gh_project_status_resolve_owner_repo, so it accepts both
 #   "OWNER/REPO" and "HOST/OWNER/REPO" and, when omitted/empty, falls back to
@@ -421,6 +429,15 @@ _gh_project_status_set_and_verify() {
 #   explicit value is a resolution failure, reported as rc 1 below (the
 #   resolver's own rc 2 is folded in), never a silent fallback to
 #   auto-detect.
+#
+#   The optional fourth positional pins the project (issue #1757). Without
+#   it the read answers with whichever board GitHub lists first, which for a
+#   multi-board item need not be the board the caller just wrote to: the
+#   verify pair could then report a false revert, or "verified" off the
+#   wrong board. _gh_project_status_set_and_verify passes the project id it
+#   mutated; every other caller omits it and keeps the first-row behaviour.
+#   A value that is not a plain GitHub node id is a caller bug — rc 1, never
+#   a quietly unfiltered read.
 # Output (stdout): current Status name, or nothing.
 # Returns (four-way contract, issues #1354 and #1356):
 #   0 + non-empty stdout — query succeeded, item has a Status value.
@@ -447,7 +464,7 @@ _gh_project_status_set_and_verify() {
 # board attached", or a gate built on this helper would silently open
 # on its own misuse. Reviewer follow-up, PR #1355 (agy).
 _gh_project_status_query_current() {
-    local _kind="$1" _num="$2" _repo_arg="${3-}"
+    local _kind="$1" _num="$2" _repo_arg="${3-}" _proj_arg="${4-}"
     [ -z "$_kind" ] && return 1
     [ -z "$_num" ] && return 1
 
@@ -463,6 +480,17 @@ _gh_project_status_query_current() {
         *) return 1 ;;
     esac
 
+    # Project pin (#1757), validated before anything is queried. GitHub node
+    # ids are base64url text; a value with anything else in it is a caller
+    # bug and must not be spliced into the jq program below.
+    local _proj_sel=''
+    if [ -n "$_proj_arg" ]; then
+        case "$_proj_arg" in
+            *[!A-Za-z0-9_=-]*) return 1 ;;
+            *) _proj_sel="| select(.project?.id == \"$_proj_arg\")" ;;
+        esac
+    fi
+
     local _owner _repo _resolved
     # Resolution failure is a query failure, not "no board" (#1354). That
     # includes a malformed explicit repo argument (#1405) — callers gate on
@@ -474,13 +502,18 @@ _gh_project_status_query_current() {
     # Substitute gh's output into a variable, then filter it — a
     # `gh ... | head -n 1` pipeline would report head's exit status, not
     # gh's, and the POSIX Golden Rules rule out ${PIPESTATUS[0]} (#1354).
+    # `--paginate` + $endCursor is the same unbounded-membership fix the
+    # discovery query carries (#1757): a pinned board sitting past the first
+    # page must still be readable.
     local _raw _nl _gql_query _gql_jq _gql_err
     _gql_query="
-          query(\$owner: String!, \$repo: String!, \$number: Int!) {
+          query(\$owner: String!, \$repo: String!, \$number: Int!, \$endCursor: String) {
             repository(owner: \$owner, name: \$repo) {
               ${_q_field}(number: \$number) {
-                projectItems(first: 10) {
+                projectItems(first: 100, after: \$endCursor) {
+                  pageInfo { hasNextPage endCursor }
                   nodes {
+                    project { id }
                     fieldValueByName(name: \"Status\") {
                       ... on ProjectV2ItemFieldSingleSelectValue { name }
                     }
@@ -490,11 +523,12 @@ _gh_project_status_query_current() {
             }
           }"
     _gql_jq=".data.repository.${_q_field}.projectItems.nodes[]
+              ${_proj_sel}
               | .fieldValueByName?.name?
               | select(. != null and . != \"\")"
 
-    # Variables: $owner String!, $repo String!, $number Int!
-    if ! _raw=$(gh api graphql -f query="$_gql_query" \
+    # Variables: $owner String!, $repo String!, $number Int!, $endCursor String
+    if ! _raw=$(gh api graphql --paginate -f query="$_gql_query" \
         -f owner="$_owner" -f repo="$_repo" -F number="$_num" \
         --jq "$_gql_jq" \
         2>/dev/null); then
@@ -503,8 +537,8 @@ _gh_project_status_query_current() {
         # *successful* call, which would corrupt _raw on the happy path
         # (agy review, PR #1357). Re-run stderr-only, read-only, purely to
         # classify the failure — rc 2 vs rc 1, see the contract above (#1356).
-        # Variables: $owner String!, $repo String!, $number Int!
-        _gql_err=$(gh api graphql -f query="$_gql_query" \
+        # Variables: $owner String!, $repo String!, $number Int!, $endCursor String
+        _gql_err=$(gh api graphql --paginate -f query="$_gql_query" \
             -f owner="$_owner" -f repo="$_repo" -F number="$_num" \
             --jq "$_gql_jq" \
             2>&1 1>/dev/null)
@@ -515,8 +549,11 @@ _gh_project_status_query_current() {
     fi
 
     [ -z "$_raw" ] && return 0
-    # First line only — projectItems(first: 10) can yield multiple rows.
-    # Plain parameter expansion instead of `| head -n 1` to skip the fork.
+    # First line only — an unpinned read still spans every board the item
+    # sits on. With a $4 project pin the jq select above has already narrowed
+    # it to that board's single row (#1757); this stays the unpinned path's
+    # tie-break. Plain parameter expansion instead of `| head -n 1` to skip
+    # the fork.
     _nl='
 '
     printf '%s\n' "${_raw%%"$_nl"*}"

--- a/shell-common/functions/gh_project_status.sh
+++ b/shell-common/functions/gh_project_status.sh
@@ -484,12 +484,11 @@ _gh_project_status_query_current() {
     # ids are base64url text; a value with anything else in it is a caller
     # bug and must not be spliced into the jq program below.
     local _proj_sel=''
-    if [ -n "$_proj_arg" ]; then
-        case "$_proj_arg" in
-            *[!A-Za-z0-9_=-]*) return 1 ;;
-            *) _proj_sel="| select(.project?.id == \"$_proj_arg\")" ;;
-        esac
-    fi
+    case "$_proj_arg" in
+        '') ;;
+        *[!A-Za-z0-9_=-]*) return 1 ;;
+        *) _proj_sel="| select(.project?.id == \"$_proj_arg\")" ;;
+    esac
 
     local _owner _repo _resolved
     # Resolution failure is a query failure, not "no board" (#1354). That

--- a/tests/bats/functions/gh_project_status.bats
+++ b/tests/bats/functions/gh_project_status.bats
@@ -443,10 +443,14 @@ _run_resolve_bash() {
 #   3. `gh api graphql ... query: mutation(...)` → mutation. Outcome (ok/fail)
 #      driven by $FAKE_MUTATE_SEQUENCE (pipe-separated, defaults to all-ok).
 #   4. `gh api graphql ... query: query(...) options(names:` → discovery
-#      query; emits one synthetic record so the sync loop iterates once.
+#      query; emits one synthetic record so the sync loop iterates once,
+#      plus $FAKE_DISCOVER_PAGE2 when — and only when — the call opts into
+#      gh's own graphql pagination (#1757).
 #   5. `gh api graphql ... query: query(...) fieldValueByName` (no options)
 #      → verify-current query; emits the next entry of
-#      $FAKE_VERIFY_SEQUENCE (pipe-separated; missing entries → empty).
+#      $FAKE_VERIFY_SEQUENCE (pipe-separated; missing entries → empty), or
+#      $FAKE_VERIFY_OTHER_BOARD when the read does not name the board it is
+#      supposed to be verifying (#1757).
 #
 # All call shapes append a tag to $FAKE_GH_LOG for assertions.
 
@@ -512,6 +516,15 @@ case "$1 $2" in
             # joined with `|` to match the helper's --jq output shape:
             #   project.id | item.id | field.id | option.id | current_status
             echo "proj1|item1|field1|opt1|"
+            # #1757: a second page of memberships, reachable only when the
+            # caller opts into gh's graphql pagination — `--paginate` plus a
+            # declared `$endCursor` variable. An unpaginated query never
+            # learns this board exists, and the sync silently no-ops.
+            if [ -n "${FAKE_DISCOVER_PAGE2:-}" ] \
+                && [[ "$all_args" == *"--paginate"* ]] \
+                && [[ "$all_args" == *'$endCursor'* ]]; then
+                echo "$FAKE_DISCOVER_PAGE2"
+            fi
             exit 0
         elif [[ "$all_args" == *"fieldValueByName"* ]]; then
             echo "verify" >>"$LOG"
@@ -528,6 +541,14 @@ case "$1 $2" in
             # notices / proxy warnings on stderr even on a *successful*
             # (exit 0) call — see #1356 agy review, PR #1357.
             [ -n "${FAKE_VERIFY_STDERR_NOISE:-}" ] && echo "$FAKE_VERIFY_STDERR_NOISE" >&2
+            # #1757: a verify read that never names the board it is checking
+            # gets whichever row the API happened to list first — another
+            # board's value. Models the uncorrelated read the fix removes.
+            if [ -n "${FAKE_VERIFY_OTHER_BOARD:-}" ] \
+                && [[ "$all_args" != *"${FAKE_VERIFY_PROJECT:-proj1}"* ]]; then
+                echo "$FAKE_VERIFY_OTHER_BOARD"
+                exit 0
+            fi
             idx=$(cat "$FAKE_VERIFY_IDX")
             idx=$((idx + 1))
             echo "$idx" >"$FAKE_VERIFY_IDX"
@@ -570,6 +591,9 @@ _run_full_bash() {
         export FAKE_REVIEW_FAIL='${FAKE_REVIEW_FAIL:-0}'
         export FAKE_MUTATE_SEQUENCE='${FAKE_MUTATE_SEQUENCE:-}'
         export FAKE_VERIFY_SEQUENCE='${FAKE_VERIFY_SEQUENCE:-}'
+        export FAKE_DISCOVER_PAGE2='${FAKE_DISCOVER_PAGE2:-}'
+        export FAKE_VERIFY_OTHER_BOARD='${FAKE_VERIFY_OTHER_BOARD:-}'
+        export FAKE_VERIFY_PROJECT='${FAKE_VERIFY_PROJECT:-proj1}'
         export FAKE_REPO_VIEW_FAIL='${FAKE_REPO_VIEW_FAIL:-0}'
         export FAKE_VERIFY_FAIL='${FAKE_VERIFY_FAIL:-0}'
         export FAKE_VERIFY_FAIL_MSG='${FAKE_VERIFY_FAIL_MSG:-}'
@@ -768,6 +792,66 @@ _run_full_bash() {
     assert_success
     assert_output --partial "elapsed=0"
     [ "$(grep -c '^verify$' "$FAKE_GH_LOG")" -eq 1 ]
+}
+
+# ------- multi-board correctness (#1757) -----------------------------------
+#
+# Both defects need an item on more than one board, so neither shows up on
+# the happy path the cases above drive.
+
+@test "sync: a board past the first page of memberships still gets set" {
+    # Defect 1 — `projectItems(first: 10)` with no cursor follow. The board
+    # that owns the target Status can be the 11th membership; the jq select
+    # then finds nothing and the whole sync silently no-ops. The fake only
+    # hands over page 2 to a caller that paginates.
+    _setup_fake_gh_full
+    FAKE_DISCOVER_PAGE2="proj2|item2|field2|opt2|" \
+    FAKE_VERIFY_SEQUENCE="In review|In review" \
+        _run_full_bash '_gh_project_status_sync pr 42 "In review" 2>&1; echo "rc=$?"'
+    assert_success
+    assert_output --partial "rc=0"
+    refute_output --partial "not in any project"
+    # One mutate + one verify per board — the page-2 board included.
+    [ "$(grep -c '^mutate$' "$FAKE_GH_LOG")" -eq 2 ]
+    [ "$(grep -c '^verify$' "$FAKE_GH_LOG")" -eq 2 ]
+}
+
+@test "verify: reads the board it just wrote, not whichever row comes first" {
+    # Defect 2 — the verify read was uncorrelated with the project the
+    # mutation targeted. Here every read that fails to name proj1 answers
+    # with another board's "Done", which pre-fix reads as a revert and ends
+    # in "verify failed twice" on a write that actually landed.
+    _setup_fake_gh_full
+    FAKE_VERIFY_OTHER_BOARD="Done" \
+    FAKE_VERIFY_SEQUENCE="In review" \
+        _run_full_bash '_gh_project_status_sync pr 42 "In review" 2>&1; echo "rc=$?"'
+    assert_success
+    assert_output --partial '-> "In review" (verified)'
+    refute_output --partial 'reverted to "Done"'
+    refute_output --partial "ERROR"
+    [ "$(grep -c '^mutate$' "$FAKE_GH_LOG")" -eq 1 ]
+}
+
+@test "query_current: an explicit project pin narrows the read to that board" {
+    _setup_fake_gh_full
+    FAKE_VERIFY_OTHER_BOARD="Done" \
+    FAKE_VERIFY_SEQUENCE="In review" \
+        _run_full_bash 'out=$(_gh_project_status_query_current pr 42 "" "proj1"); echo "rc=$?"; echo "out=[$out]"'
+    assert_success
+    assert_output --partial "rc=0"
+    assert_output --partial "out=[In review]"
+}
+
+@test "query_current: a project pin that is not a node id returns rc=1 unqueried" {
+    # The pin is spliced into the jq program, so a value outside the
+    # base64url node-id alphabet is refused instead of being interpolated —
+    # and refused before any gh call goes out.
+    _setup_fake_gh_full
+    _run_full_bash 'out=$(_gh_project_status_query_current pr 42 "" "not a node id"); echo "rc=$?"; echo "out=[$out]"'
+    assert_success
+    assert_output --partial "rc=1"
+    assert_output --partial "out=[]"
+    [ ! -s "$FAKE_GH_LOG" ]
 }
 
 # ------- Approved fail-closed guard ----------------------------------------

--- a/tests/bats/functions/gh_project_status.bats
+++ b/tests/bats/functions/gh_project_status.bats
@@ -841,6 +841,19 @@ _run_full_bash() {
     assert_output --partial "out=[In review]"
 }
 
+@test "query_current: a standard-base64 node id is accepted, not refused" {
+    # PR #1758 (codex): GraphQL node ids are opaque. Narrowing the guard to
+    # the base64url alphabet would reject an id carrying `+` or `/` and turn a
+    # working verify into a silent "verify failed twice".
+    _setup_fake_gh_full
+    FAKE_VERIFY_OTHER_BOARD="Done" \
+    FAKE_VERIFY_SEQUENCE="In review" \
+        _run_full_bash 'out=$(_gh_project_status_query_current pr 42 "" "PVT_a+b/c="); echo "rc=$?"; echo "out=[$out]"'
+    assert_success
+    assert_output --partial "rc=0"
+    [ "$(grep -c '^verify$' "$FAKE_GH_LOG")" -eq 1 ]
+}
+
 @test "query_current: a project pin that is not a node id returns rc=1 unqueried" {
     # The pin is spliced into the jq program, so a value outside the
     # base64url node-id alphabet is refused instead of being interpolated —

--- a/tests/bats/functions/gh_project_status.bats
+++ b/tests/bats/functions/gh_project_status.bats
@@ -545,7 +545,7 @@ case "$1 $2" in
             # gets whichever row the API happened to list first — another
             # board's value. Models the uncorrelated read the fix removes.
             if [ -n "${FAKE_VERIFY_OTHER_BOARD:-}" ] \
-                && [[ "$all_args" != *"${FAKE_VERIFY_PROJECT:-proj1}"* ]]; then
+                && [[ "$all_args" != *proj1* ]]; then
                 echo "$FAKE_VERIFY_OTHER_BOARD"
                 exit 0
             fi
@@ -593,7 +593,6 @@ _run_full_bash() {
         export FAKE_VERIFY_SEQUENCE='${FAKE_VERIFY_SEQUENCE:-}'
         export FAKE_DISCOVER_PAGE2='${FAKE_DISCOVER_PAGE2:-}'
         export FAKE_VERIFY_OTHER_BOARD='${FAKE_VERIFY_OTHER_BOARD:-}'
-        export FAKE_VERIFY_PROJECT='${FAKE_VERIFY_PROJECT:-proj1}'
         export FAKE_REPO_VIEW_FAIL='${FAKE_REPO_VIEW_FAIL:-0}'
         export FAKE_VERIFY_FAIL='${FAKE_VERIFY_FAIL:-0}'
         export FAKE_VERIFY_FAIL_MSG='${FAKE_VERIFY_FAIL_MSG:-}'


### PR DESCRIPTION
## Summary
- `gh_project_status.sh` 의 다중 보드 결함 2건을 고친다 — 둘 다 이슈/PR 이 보드 한 개에만 붙어 있으면 드러나지 않아 그동안 잠복해 있었다.
- `projectItems` 를 페이지네이션해서 11번째 이후 보드가 조용히 사라지는 no-op 을 없애고, verify 재조회를 mutation 이 실제로 쓴 보드에 상관시킨다.
- 두 결함 모두 재현에 보드 10개 초과 / Status 를 가진 보드 2개가 필요하므로, 그 두 축을 모델링하는 회귀 테스트 4건을 함께 넣었다.

## Changes
- `shell-common/functions/gh_project_status.sh` — 결함 1: 탐색 쿼리(`_gh_project_status_sync`)와 읽기 쿼리(`_gh_project_status_query_current`) 양쪽에 `--paginate` + `$endCursor` + `pageInfo` 를 붙였다. gh 가 커서를 스스로 따라가고 페이지마다 `--jq` 를 다시 돌리므로 출력 형태는 그대로다. `first: 100` 으로 올려 흔한 경우는 여전히 요청 1회다.
- `shell-common/functions/gh_project_status.sh` — 결함 2: `_gh_project_status_query_current` 에 4번째 positional `[project-id]` 를 추가하고 `_gh_project_status_set_and_verify` 가 방금 쓴 `project.id` 를 넘긴다. jq `select(.project.id == ...)` 로 그 보드 한 줄로 좁힌다. 인자를 주지 않는 기존 호출자(`claude/hooks/post-gh-pr-create.sh` 등)는 종전 first-row 동작 그대로다. 노드 id 알파벳(base64url) 밖의 값은 jq 프로그램에 끼워 넣지 않고 조회 전에 rc 1 로 거절한다.
- `tests/bats/functions/gh_project_status.bats` — `_setup_fake_gh_full` 스텁에 `FAKE_DISCOVER_PAGE2`(페이지 2는 `--paginate` + `$endCursor` 를 선언한 호출에만 넘겨준다)와 `FAKE_VERIFY_OTHER_BOARD`(대상 보드를 지목하지 않는 verify 읽기에는 다른 보드 값을 준다) 노브를 추가하고, 회귀 테스트 4건을 붙였다.

## Test plan
- [x] `./tests/bats/lib/bats-core/bin/bats tests/bats/functions/gh_project_status.bats` — 103건 전부 통과(기존 99 + 신규 4).
- [x] 수정 전 소스로 되돌린 상태에서 신규 4건 전부 실패 확인 — 해피 패스로는 잡히지 않는 결함임을 고정.
- [x] `tests/bats/lint/gh_api_type_mapping.bats` + `tests/bats/init/project_board_sync_workflow.bats` 29건 통과 (`# Variables:` 주석에 `$endCursor` 반영).
- [x] `shellcheck shell-common/functions/gh_project_status.sh` clean · `bash -n` / `zsh -n` clean.
- [x] `_gh_project_status_sync issue 1757 "In progress"` 를 실제 보드에 실행해 동작 확인 (`(verified)`).

## Related
Closes #1757

---
<details>
<summary>🤖 AI Metrics · 📊 ~5000 tokens · 👤 ~2 h · 🤖 ~23 min</summary>

<!-- ai-metrics:gh-pr -->
📊 ~5000 tokens · 👤 ~2 h · 🤖 ~23 min
<!-- /ai-metrics:gh-pr -->

</details>
