### PR TITLE
fix(gcp-scan): clean-apply 중복 append 를 no-op 으로 흡수

### DIFF
--- a/docs/guide/learnings/gcp-scan-phantom-commits.md
+++ b/docs/guide/learnings/gcp-scan-phantom-commits.md
@@ -73,6 +73,7 @@ git reset --hard HEAD
 | 충돌 해결 후 `--continue` 거부 | net-zero (빈 커밋) | `git cherry-pick --skip` |
 | scan fix가 적용 안 됨 | phantom이 fix 앞에 있어서 | 위 수동 우회 절차 실행 |
 | `git cherry` 출력에 `+` | 내용이 달라서 중복 미인식 | preflight probe로 no-op 확인 |
+| 같은 커밋이 매 scan 마다 clean apply, 항상 `N insertions(+)` | HEAD 가 그 블록을 **다른 위치**에 이미 갖고 있어 머지가 충돌 없이 또 붙임 (#1759) | `_gcp_scan_staged_is_duplicate_append` 가 흡수. 안 잡히면 블록 최소 길이 `GCP_SCAN_DUP_BLOCK_MIN_LINES` 확인 |
 
 ## When to use
 
@@ -85,5 +86,6 @@ git reset --hard HEAD
 ## Related
 
 - `shell-common/functions/gcp_scan.sh` — `_gcp_scan_preflight_is_noop` (line ~40)
+- `shell-common/functions/gcp_scan.sh` — `_gcp_scan_staged_is_duplicate_append` (#1759: clean-apply 중복 append 흡수)
 - Discussion #927 (원본 전체 분석·로그 포함)
 - #913 (preflight probe 구현 PR)

--- a/shell-common/functions/gcp_scan.sh
+++ b/shell-common/functions/gcp_scan.sh
@@ -65,6 +65,7 @@ _gcp_scan_preflight_is_noop() {
         return 1
     fi
     local sha="$1" result=1 had_stash=0 conflicted f real_content_conflict=0
+    local _dup_files="" _dup_short=""
     if ! git diff --quiet || ! git diff --cached --quiet; then
         git stash push -q --include-untracked -m "gcp_preflight_probe" && had_stash=1
         # Data-loss guard (PR #916 review): a failed stash leaves the tree
@@ -166,7 +167,23 @@ _gcp_scan_preflight_is_noop() {
         command cp -f "$_gcfg2_bak" "$_gcfg2" 2>/dev/null
     fi
     if [ "$_gcp_cp_rc" -eq 0 ]; then
-        git diff --cached --quiet && result=0
+        if git diff --cached --quiet; then
+            result=0
+        elif _gcp_scan_staged_is_duplicate_append; then
+            # A clean apply whose whole payload HEAD already holds, just
+            # elsewhere in the file (issue #1759). Announced, never silent: this
+            # is the one verdict that drops a commit the staged diff still shows
+            # as real work, so a wrong call has to be auditable from the scan
+            # output alone.
+            _dup_files=$(git diff --cached --name-only 2>/dev/null | tr '\n' ' ')
+            _dup_short=$(git rev-parse --short "$sha" 2>/dev/null)
+            if type ux_warning >/dev/null 2>&1; then
+                ux_warning "Absorbing ${_dup_short} — its added block is already in HEAD (duplicate append): ${_dup_files}"
+            else
+                echo "[gcp-scan] Absorbing ${_dup_short} — its added block is already in HEAD (duplicate append): ${_dup_files}" >&2
+            fi
+            result=0
+        fi
     else
         conflicted=$(git diff --name-only --diff-filter=U)
         # Only a real merge conflict is eligible for the context-drift no-op
@@ -530,6 +547,111 @@ _gcp_scan_conflict_adds_new_content() {
     fi
     command rm -rf "$td"
     return 1
+}
+
+_gcp_scan_staged_is_duplicate_append() {
+    # True (0) when the CURRENTLY STAGED tree (a `cherry-pick -n` that applied
+    # CLEANLY) differs from HEAD only by re-inserting blocks HEAD's own copy of
+    # the same file already contains — issue #1759.
+    #
+    # Why the clean path needed its own discriminator: Stage-2's two verdicts
+    # both ask "does the staged tree still differ from HEAD?". That is the right
+    # question when the payload landed identically (empty staged diff) or
+    # collided (conflict -> `_gcp_scan_conflict_adds_new_content` decides). It is
+    # the WRONG question when HEAD holds the payload at a DIFFERENT position
+    # than the commit puts it: the two insertions do not overlap, so git's merge
+    # has nothing to resolve, appends the block a SECOND time, and leaves a
+    # non-empty staged diff that reads as real work. The commit is then
+    # re-recommended and re-applied on every scan, one more copy each time
+    # (`1 file changed, 54 insertions(+)`, six copies deep in the report).
+    # A cross-repo cherry-pick produces that shape whenever the base-side copy
+    # of a block landed somewhere other than where the source commit put it.
+    #
+    # THREE preconditions, all of them narrowing toward "this cannot be new
+    # work", because a wrong verdict here drops a commit silently — the #1177
+    # data-loss direction:
+    #
+    #   1. Every staged path is a plain modification (`M`). An add, delete,
+    #      rename or typechange is never a re-application of content HEAD
+    #      already holds.
+    #   2. Every hunk is addition-only. One deleted line means the commit
+    #      changes what HEAD has, not merely repeats it — and a pure MOVE
+    #      (delete here, add there) lands in exactly that shape, so this is
+    #      what keeps a reordering commit visible.
+    #   3. Every added block appears verbatim and CONTIGUOUSLY in HEAD's copy
+    #      of that same file, and is at least GCP_SCAN_DUP_BLOCK_MIN_LINES
+    #      long.
+    #
+    # Contiguity is the deliberate difference from the set-membership test
+    # `_gcp_scan_conflict_adds_new_content` uses: a set test accepts a commit
+    # whose every added line happens to exist SOMEWHERE in the file, which for
+    # boilerplate (`    return 0`, a lone `}`, a blank line) is coincidence
+    # rather than duplication. Requiring the whole hunk to match as one run
+    # rules that out for anything but the shortest blocks, and the line floor
+    # covers those. Default 3: long enough that an accidental verbatim run is
+    # implausible, short enough to catch a real appended stanza.
+    #
+    # Reads the index and HEAD blobs only — no checkout, no mutation. The
+    # caller's `git reset --hard HEAD` is what clears the probe.
+    local floor="${GCP_SCAN_DUP_BLOCK_MIN_LINES:-3}"
+    local files f td rc=0
+    # Precondition 1. `grep -v` answers 0 as soon as ONE staged path is not a
+    # plain modification.
+    if git diff --cached --name-status 2>/dev/null | grep -qv '^M'; then
+        return 1
+    fi
+    files=$(git diff --cached --name-only 2>/dev/null)
+    [ -n "$files" ] || return 1
+    td=$(mktemp -d "${TMPDIR:-/tmp}/gcp_dup.XXXXXX" 2>/dev/null) || return 1
+    while IFS= read -r f; do
+        [ -z "$f" ] && continue
+        if ! git cat-file -p "HEAD:${f}" >"${td}/head" 2>/dev/null; then
+            rc=1
+            break
+        fi
+        # `-U0`: no context lines, so every `+`/`-` line inside a hunk is real
+        # payload and the hunk headers alone delimit the blocks.
+        if ! git diff --cached -U0 -- "$f" >"${td}/diff" 2>/dev/null; then
+            rc=1
+            break
+        fi
+        # `seen` skips the per-file diff header, whose `--- a/x` / `+++ b/x`
+        # lines would otherwise read as payload; anchoring on those two
+        # prefixes instead would mis-skip a deleted line that starts with
+        # `-- `. A bare `exit` on a hit is deliberate — `exit 0` would still
+        # run END, whose own exit would override the verdict.
+        if ! awk -v min="$floor" -v HF="${td}/head" '
+            function block_ok(   i, j, ok) {
+                if (bn == 0) { return 1 }
+                if (bn < min) { return 0 }
+                for (i = 1; i + bn - 1 <= n; i++) {
+                    ok = 1
+                    for (j = 1; j <= bn; j++) {
+                        if (h[i + j - 1] != b[j]) { ok = 0; break }
+                    }
+                    if (ok) { nblocks++; return 1 }
+                }
+                return 0
+            }
+            FILENAME == HF { h[++n] = $0; next }
+            /^@@/ { if (!block_ok()) { bad = 1; exit } bn = 0; seen = 1; next }
+            !seen { next }
+            /^-/ { bad = 1; exit }
+            /^\+/ { b[++bn] = substr($0, 2); next }
+            { next }
+            # nblocks == 0 means nothing was actually matched — a mode-only
+            # or binary change has a non-empty staged diff but no hunks at
+            # all, and "every block matched" is vacuously true for it.
+            END { if (!bad && !block_ok()) { bad = 1 } exit((bad || nblocks == 0) ? 1 : 0) }
+        ' "${td}/head" "${td}/diff"; then
+            rc=1
+            break
+        fi
+    done <<EOF
+$files
+EOF
+    command rm -rf "$td"
+    return $rc
 }
 
 _gcp_scan_predict_content_conflict() {

--- a/shell-common/functions/gcp_scan.sh
+++ b/shell-common/functions/gcp_scan.sh
@@ -65,7 +65,6 @@ _gcp_scan_preflight_is_noop() {
         return 1
     fi
     local sha="$1" result=1 had_stash=0 conflicted f real_content_conflict=0
-    local _dup_files="" _dup_short=""
     if ! git diff --quiet || ! git diff --cached --quiet; then
         git stash push -q --include-untracked -m "gcp_preflight_probe" && had_stash=1
         # Data-loss guard (PR #916 review): a failed stash leaves the tree
@@ -175,6 +174,7 @@ _gcp_scan_preflight_is_noop() {
             # is the one verdict that drops a commit the staged diff still shows
             # as real work, so a wrong call has to be auditable from the scan
             # output alone.
+            local _dup_files _dup_short
             _dup_files=$(git diff --cached --name-only 2>/dev/null | tr '\n' ' ')
             _dup_short=$(git rev-parse --short "$sha" 2>/dev/null)
             if type ux_warning >/dev/null 2>&1; then
@@ -605,22 +605,16 @@ _gcp_scan_staged_is_duplicate_append() {
     td=$(mktemp -d "${TMPDIR:-/tmp}/gcp_dup.XXXXXX" 2>/dev/null) || return 1
     while IFS= read -r f; do
         [ -z "$f" ] && continue
-        if ! git cat-file -p "HEAD:${f}" >"${td}/head" 2>/dev/null; then
-            rc=1
-            break
-        fi
+        git cat-file -p "HEAD:${f}" >"${td}/head" 2>/dev/null || { rc=1; break; }
         # `-U0`: no context lines, so every `+`/`-` line inside a hunk is real
         # payload and the hunk headers alone delimit the blocks.
-        if ! git diff --cached -U0 -- "$f" >"${td}/diff" 2>/dev/null; then
-            rc=1
-            break
-        fi
+        git diff --cached -U0 -- "$f" >"${td}/diff" 2>/dev/null || { rc=1; break; }
         # `seen` skips the per-file diff header, whose `--- a/x` / `+++ b/x`
         # lines would otherwise read as payload; anchoring on those two
         # prefixes instead would mis-skip a deleted line that starts with
         # `-- `. A bare `exit` on a hit is deliberate — `exit 0` would still
         # run END, whose own exit would override the verdict.
-        if ! awk -v min="$floor" -v HF="${td}/head" '
+        awk -v min="$floor" -v HF="${td}/head" '
             function block_ok(   i, j, ok) {
                 if (bn == 0) { return 1 }
                 if (bn < min) { return 0 }
@@ -638,15 +632,11 @@ _gcp_scan_staged_is_duplicate_append() {
             !seen { next }
             /^-/ { bad = 1; exit }
             /^\+/ { b[++bn] = substr($0, 2); next }
-            { next }
             # nblocks == 0 means nothing was actually matched — a mode-only
             # or binary change has a non-empty staged diff but no hunks at
             # all, and "every block matched" is vacuously true for it.
             END { if (!bad && !block_ok()) { bad = 1 } exit((bad || nblocks == 0) ? 1 : 0) }
-        ' "${td}/head" "${td}/diff"; then
-            rc=1
-            break
-        fi
+        ' "${td}/head" "${td}/diff" || { rc=1; break; }
     done <<EOF
 $files
 EOF

--- a/shell-common/functions/gcp_scan.sh
+++ b/shell-common/functions/gcp_scan.sh
@@ -168,7 +168,7 @@ _gcp_scan_preflight_is_noop() {
     if [ "$_gcp_cp_rc" -eq 0 ]; then
         if git diff --cached --quiet; then
             result=0
-        elif _gcp_scan_staged_is_duplicate_append; then
+        elif _gcp_scan_staged_is_duplicate_append "$sha"; then
             # A clean apply whose whole payload HEAD already holds, just
             # elsewhere in the file (issue #1759). Announced, never silent: this
             # is the one verdict that drops a commit the staged diff still shows
@@ -593,8 +593,9 @@ _gcp_scan_staged_is_duplicate_append() {
     #
     # Reads the index and HEAD blobs only — no checkout, no mutation. The
     # caller's `git reset --hard HEAD` is what clears the probe.
+    local sha="$1"
     local floor="${GCP_SCAN_DUP_BLOCK_MIN_LINES:-3}"
-    local files f td rc=0
+    local files f td rc=0 subject="" subject_seen=0
     # Precondition 1. `grep -v` answers 0 as soon as ONE staged path is not a
     # plain modification.
     if git diff --cached --name-status 2>/dev/null | grep -qv '^M'; then
@@ -615,6 +616,13 @@ _gcp_scan_staged_is_duplicate_append() {
         # `-- `. A bare `exit` on a hit is deliberate — `exit 0` would still
         # run END, whose own exit would override the verdict.
         awk -v min="$floor" -v HF="${td}/head" '
+            # O(n*m) sliding window: n = HEAD line count, m = block length.
+            # Bounded in practice by when this runs at all — only on a clean
+            # apply whose staged diff is non-empty, at most once per staged
+            # file. `b[1..bn]` is the whole block: entries left over from a
+            # LONGER previous hunk sit past bn and are never read, so bn = 0
+            # is a complete reset and `delete b` would be dead code (PR #1760
+            # review, agy; pinned by the multi-hunk bats cases).
             function block_ok(   i, j, ok) {
                 if (bn == 0) { return 1 }
                 if (bn < min) { return 0 }
@@ -641,7 +649,46 @@ _gcp_scan_staged_is_duplicate_append() {
 $files
 EOF
     command rm -rf "$td"
-    return $rc
+    [ "$rc" -eq 0 ] || return 1
+    # Precondition 4 — corroborating evidence that THIS commit was already
+    # applied (PR #1760 review, agy + codex BLOCKER, independently).
+    #
+    # Preconditions 1-3 establish that the payload is a verbatim repeat of
+    # content HEAD holds. They cannot, on their own, distinguish that from a
+    # commit deliberately adding a second copy of an existing stanza —
+    # repeated boilerplate, a config block, another table row. Absorbing one
+    # of those is the #1177 data-loss direction, and no threshold on block
+    # length fixes it: the repeat is verbatim in both cases.
+    #
+    # What separates them is not the diff, it is the history. A duplicate
+    # RE-application carries the subject of the commit that already landed —
+    # a cherry-pick copies the message — so HEAD's own log for the touched
+    # files already contains that exact subject. A commit legitimately adding
+    # a repeated stanza is new work with a subject of its own, which HEAD has
+    # never seen, so it stays visible. That is the same signal #1136 uses as
+    # its duplicate CANDIDATE filter, here as the corroborating half of a
+    # verdict the payload comparison has already narrowed to one commit.
+    #
+    # ANY touched file matching is enough: the reported case touched four
+    # files but only one carried the duplicated block, the other three having
+    # been absorbed silently by the 3-way merge.
+    #
+    # Deliberately last: it is the only precondition that walks history, and
+    # by here the candidate set is already down to "payload is a verbatim
+    # repeat", which is rare.
+    subject=$(git log -1 --format=%s "$sha" 2>/dev/null)
+    [ -n "$subject" ] || return 1
+    while IFS= read -r f; do
+        [ -z "$f" ] && continue
+        if git log --format=%s HEAD -- "$f" 2>/dev/null | grep -Fxq "$subject"; then
+            subject_seen=1
+            break
+        fi
+    done <<EOF
+$files
+EOF
+    [ "$subject_seen" -eq 1 ] || return 1
+    return 0
 }
 
 _gcp_scan_predict_content_conflict() {

--- a/tests/bats/functions/gcp.bats
+++ b/tests/bats/functions/gcp.bats
@@ -2535,3 +2535,199 @@ FIXTURE
     run bash -c "grep 'range_str' '${src}' | grep -vE 'local range_str=|ux_bullet|ux_info|echo '"
     assert_failure 1
 }
+
+# ---------------------------------------------------------------------------
+# Issue #1759 — a duplicate block re-applied as a CLEAN append
+#
+# Both of Stage-2's verdict paths ask a textual question: "does the staged tree
+# still differ from HEAD?" That is the right question when the commit's payload
+# either landed identically (empty staged diff -> no-op) or collided (conflict
+# -> the drift discriminator decides). It is the WRONG question when the payload
+# already sits in HEAD at a DIFFERENT position: the merge then has no overlap to
+# resolve, applies the hunk cleanly a second time, and leaves a non-empty staged
+# diff that reads as real work.
+#
+# That shape is not hypothetical — it is what a cross-repo cherry-pick produces
+# whenever the base-side copy of a block landed somewhere other than where the
+# source commit put it. The reported case appended 54 lines to a bats file on
+# every single scan (`1 file changed, 54 insertions(+)`), six copies deep,
+# because the block was in HEAD but not where the commit expected it.
+#
+# `_gcp_scan_staged_is_duplicate_append` closes that path. It fires only on the
+# narrowest shape that can BE a re-application — every staged path a plain
+# modification, every hunk addition-only, and every added block already present
+# verbatim and contiguously in HEAD's copy of that same file — so a commit that
+# adds anything HEAD lacks, deletes anything, or adds a file keeps its "real
+# work" verdict untouched. Contiguity (not the set membership #1177/#1688 use)
+# is what keeps a coincidental line repeat out of the verdict, and the
+# GCP_SCAN_DUP_BLOCK_MIN_LINES floor covers the rest.
+# ---------------------------------------------------------------------------
+
+_gcp1759_make_dup_append_repo() {
+    # `source` appends block B to the END of the file. `main` already carries
+    # that identical block, landed MID-file by an earlier cross-repo pick, so
+    # the two insertions do not overlap: the cherry-pick applies cleanly and
+    # appends a SECOND copy of B. Repeat the scan and it appends a third.
+    cat <<'FIXTURE'
+        repo="$(mktemp -d "${TMPDIR:-/tmp}/gcp1759.XXXXXX")"
+        trap "rm -rf $repo" EXIT
+        cd "$repo" || exit 1
+        export GIT_EDITOR=true GIT_AUTHOR_NAME="Test" GIT_AUTHOR_EMAIL="t@t" \
+               GIT_COMMITTER_NAME="Test" GIT_COMMITTER_EMAIL="t@t"
+        git init -q -b main
+        seq 1 12 | sed 's/^/L/' > f.txt && git add f.txt && git commit -qm "init"
+        git checkout -q -b source
+        printf 'B1\nB2\nB3\nB4\n' >> f.txt && git add f.txt && git commit -qm "append block B"
+        src=$(git rev-parse HEAD)
+        git checkout -q main
+        { head -6 f.txt; printf 'B1\nB2\nB3\nB4\n'; tail -6 f.txt; } > n.txt && mv n.txt f.txt
+        git add f.txt && git commit -qm "same block, landed mid-file"
+FIXTURE
+}
+
+@test "bash: _gcp_scan_staged_is_duplicate_append private function exists" {
+    run_in_bash 'declare -f _gcp_scan_staged_is_duplicate_append >/dev/null && echo ok'
+    assert_success
+    assert_output --partial "ok"
+}
+
+@test "preflight #1759: the reported shape really is a CLEAN apply, not a conflict" {
+    # Pins the premise the fix rests on. If a future git resolved this as a
+    # conflict instead, the clean-apply guard below would be dead code and the
+    # drift discriminator (#1177/#1688) would own the case again.
+    run_in_bash "
+        $(_gcp1759_make_dup_append_repo)
+        git cherry-pick -n \"\$src\" >/dev/null 2>&1; echo \"cp_rc=\$?\"
+        git diff --cached --quiet && echo STAGED_EMPTY || echo STAGED_DIRTY
+        git diff --cached --shortstat
+        git reset --hard -q HEAD
+    "
+    assert_success
+    assert_output --partial "cp_rc=0"
+    assert_output --partial "STAGED_DIRTY"
+    assert_output --partial "4 insertions(+)"
+}
+
+@test "preflight #1759: a cleanly re-applied duplicate block is absorbed as a no-op (0), non-destructive" {
+    run_in_bash "
+        $(_gcp1759_make_dup_append_repo)
+        orig=\$(git rev-parse HEAD)
+        echo localedit > untracked_note.txt
+        _gcp_scan_preflight_is_noop \"\$src\"; echo \"rc=\$?\"
+        grep -q localedit untracked_note.txt 2>/dev/null && echo EDIT_KEPT || echo EDIT_LOST
+        [ \"\$(git rev-parse HEAD)\" = \"\$orig\" ] && echo HEAD_SAME || echo HEAD_MOVED
+        git rev-parse -q --verify CHERRY_PICK_HEAD >/dev/null 2>&1 && echo PICK_ACTIVE || echo PICK_CLEAR
+    "
+    assert_success
+    assert_output --partial "rc=0"
+    assert_output --partial "EDIT_KEPT"
+    assert_output --partial "HEAD_SAME"
+    assert_output --partial "PICK_CLEAR"
+}
+
+@test "preflight #1759: absorbing a duplicate append is announced, never silent" {
+    # The #1177 direction: a commit dropped from the candidate list must leave
+    # a trace naming the sha, so a wrong verdict is auditable rather than
+    # invisible.
+    run_in_bash "
+        $(_gcp1759_make_dup_append_repo)
+        _gcp_scan_preflight_is_noop \"\$src\"
+    "
+    assert_success
+    assert_output --partial "duplicate append"
+    assert_output --partial "f.txt"
+}
+
+@test "dup #1759: a genuinely new block is NOT a duplicate append (1)" {
+    run_in_bash "
+        $(_gcp903_make_repo)
+        seq 1 12 | sed 's/^/L/' > f.txt && git add f.txt && git commit -qm 'seed'
+        git checkout -q -b source
+        printf 'N1\nN2\nN3\nN4\n' >> f.txt && git add f.txt && git commit -qm 'append new block'
+        src=\$(git rev-parse HEAD)
+        git checkout -q main
+        _gcp_scan_preflight_is_noop \"\$src\"; echo \"rc=\$?\"
+    "
+    assert_success
+    assert_output --partial "rc=1"
+}
+
+@test "dup #1759: a commit that also DELETES is never absorbed (1)" {
+    # Deletion is the #1177 data-loss direction — an addition-only staged diff
+    # is a precondition, not a detail.
+    run_in_bash "
+        $(_gcp903_make_repo)
+        seq 1 12 | sed 's/^/L/' > f.txt && git add f.txt && git commit -qm 'seed'
+        git checkout -q -b source
+        printf 'B1\nB2\nB3\nB4\n' >> f.txt
+        sed -i '3d' f.txt
+        git add f.txt && git commit -qm 'append B and drop L3'
+        src=\$(git rev-parse HEAD)
+        git checkout -q main
+        { head -6 f.txt; printf 'B1\nB2\nB3\nB4\n'; tail -6 f.txt; } > n.txt && mv n.txt f.txt
+        git add f.txt && git commit -qm 'same block, landed mid-file'
+        _gcp_scan_preflight_is_noop \"\$src\"; echo \"rc=\$?\"
+    "
+    assert_success
+    assert_output --partial "rc=1"
+}
+
+@test "dup #1759: a block under the line floor is a coincidence, not a duplicate (1)" {
+    # A one-line addition that happens to repeat an existing line is the
+    # commonest false positive a contiguity test alone would accept. Routed
+    # through the CLEAN apply path on purpose — main's edit sits at the head of
+    # the file, far from the appended line, so nothing conflicts and the new
+    # discriminator (not #1177's conflict-path one) owns the verdict.
+    run_in_bash "
+        $(_gcp903_make_repo)
+        printf 'alpha\nbeta\n    return 0\ngamma\n' > f.txt && git add f.txt && git commit -qm 'seed'
+        git checkout -q -b source
+        printf '    return 0\n' >> f.txt && git add f.txt && git commit -qm 'append a lone return'
+        src=\$(git rev-parse HEAD)
+        git checkout -q main
+        sed -i '1s/.*/alpha-edited/' f.txt && git add f.txt && git commit -qm 'unrelated head work'
+        _gcp_scan_preflight_is_noop \"\$src\"; echo \"rc=\$?\"
+    "
+    assert_success
+    assert_output --partial "rc=1"
+}
+
+@test "dup #1759: a commit that ADDS a file is never a duplicate append (1)" {
+    run_in_bash "
+        $(_gcp903_make_repo)
+        seq 1 12 | sed 's/^/L/' > f.txt && git add f.txt && git commit -qm 'seed'
+        git checkout -q -b source
+        printf 'B1\nB2\nB3\nB4\n' > new.txt && git add new.txt && git commit -qm 'add new file'
+        src=\$(git rev-parse HEAD)
+        git checkout -q main
+        printf 'B1\nB2\nB3\nB4\n' >> f.txt && git add f.txt && git commit -qm 'same lines, other file'
+        _gcp_scan_preflight_is_noop \"\$src\"; echo \"rc=\$?\"
+    "
+    assert_success
+    assert_output --partial "rc=1"
+}
+
+@test "dup #1759: a mode-only change has no hunks and is never absorbed (1)" {
+    # A non-empty staged diff with zero hunks would make "every added block is
+    # already in HEAD" vacuously true.
+    run_in_bash "
+        $(_gcp903_make_repo)
+        printf 'echo hi\n' > s.sh && git add s.sh && git commit -qm 'add script'
+        git checkout -q -b source
+        chmod +x s.sh && git add s.sh && git commit -qm 'make it executable'
+        src=\$(git rev-parse HEAD)
+        git checkout -q main
+        _gcp_scan_preflight_is_noop \"\$src\"; echo \"rc=\$?\"
+    "
+    assert_success
+    assert_output --partial "rc=1"
+}
+
+@test "scan #1759: the re-application loop terminates — the dup is filtered in Analysis" {
+    run_in_bash "
+        $(_gcp1759_make_dup_append_repo)
+        printf 'y\n' | _gcp_scan main source --author=all
+    "
+    assert_success
+    assert_output --partial "Already in HEAD (no-op):"
+}

--- a/tests/bats/functions/gcp.bats
+++ b/tests/bats/functions/gcp.bats
@@ -2678,7 +2678,7 @@ FIXTURE
     # through the CLEAN apply path on purpose — main's edit sits at the head of
     # the file, far from the appended line, so nothing conflicts and the new
     # discriminator (not #1177's conflict-path one) owns the verdict.
-    run_in_bash "
+    local fixture="
         $(_gcp903_make_repo)
         printf 'alpha\nbeta\n    return 0\ngamma\n' > f.txt && git add f.txt && git commit -qm 'seed'
         git checkout -q -b source
@@ -2686,10 +2686,24 @@ FIXTURE
         src=\$(git rev-parse HEAD)
         git checkout -q main
         sed -i '1s/.*/alpha-edited/' f.txt && git add f.txt && git commit -qm 'unrelated head work'
+    "
+    run_in_bash "$fixture
         _gcp_scan_preflight_is_noop \"\$src\"; echo \"rc=\$?\"
     "
     assert_success
     assert_output --partial "rc=1"
+
+    # ...and it is the FLOOR that rejects it, not one of the other two
+    # preconditions: the same fixture IS absorbed once the floor drops to 1.
+    # Pins GCP_SCAN_DUP_BLOCK_MIN_LINES as a live knob — the phantom-commit
+    # runbook sends users to it, so a default-only test would leave the
+    # documented escape hatch unproven.
+    run_in_bash "$fixture
+        GCP_SCAN_DUP_BLOCK_MIN_LINES=1
+        _gcp_scan_preflight_is_noop \"\$src\"; echo \"rc=\$?\"
+    "
+    assert_success
+    assert_output --partial "rc=0"
 }
 
 @test "dup #1759: a commit that ADDS a file is never a duplicate append (1)" {

--- a/tests/bats/functions/gcp.bats
+++ b/tests/bats/functions/gcp.bats
@@ -2568,6 +2568,10 @@ _gcp1759_make_dup_append_repo() {
     # that identical block, landed MID-file by an earlier cross-repo pick, so
     # the two insertions do not overlap: the cherry-pick applies cleanly and
     # appends a SECOND copy of B. Repeat the scan and it appends a third.
+    #
+    # main's landing commit reuses the source commit's SUBJECT — that is what
+    # a cherry-pick does, and precondition 4 reads it as the evidence that
+    # this payload already landed once.
     cat <<'FIXTURE'
         repo="$(mktemp -d "${TMPDIR:-/tmp}/gcp1759.XXXXXX")"
         trap "rm -rf $repo" EXIT
@@ -2581,7 +2585,7 @@ _gcp1759_make_dup_append_repo() {
         src=$(git rev-parse HEAD)
         git checkout -q main
         { head -6 f.txt; printf 'B1\nB2\nB3\nB4\n'; tail -6 f.txt; } > n.txt && mv n.txt f.txt
-        git add f.txt && git commit -qm "same block, landed mid-file"
+        git add f.txt && git commit -qm "append block B"
 FIXTURE
 }
 
@@ -2665,7 +2669,7 @@ FIXTURE
         src=\$(git rev-parse HEAD)
         git checkout -q main
         { head -6 f.txt; printf 'B1\nB2\nB3\nB4\n'; tail -6 f.txt; } > n.txt && mv n.txt f.txt
-        git add f.txt && git commit -qm 'same block, landed mid-file'
+        git add f.txt && git commit -qm 'append B and drop L3'
         _gcp_scan_preflight_is_noop \"\$src\"; echo \"rc=\$?\"
     "
     assert_success
@@ -2680,12 +2684,13 @@ FIXTURE
     # discriminator (not #1177's conflict-path one) owns the verdict.
     local fixture="
         $(_gcp903_make_repo)
-        printf 'alpha\nbeta\n    return 0\ngamma\n' > f.txt && git add f.txt && git commit -qm 'seed'
+        printf 'alpha\nbeta\ngamma\n' > f.txt && git add f.txt && git commit -qm 'seed'
         git checkout -q -b source
         printf '    return 0\n' >> f.txt && git add f.txt && git commit -qm 'append a lone return'
         src=\$(git rev-parse HEAD)
         git checkout -q main
-        sed -i '1s/.*/alpha-edited/' f.txt && git add f.txt && git commit -qm 'unrelated head work'
+        printf 'alpha\nbeta\n    return 0\ngamma\n' > f.txt
+        git add f.txt && git commit -qm 'append a lone return'
     "
     run_in_bash "$fixture
         _gcp_scan_preflight_is_noop \"\$src\"; echo \"rc=\$?\"
@@ -2731,6 +2736,71 @@ FIXTURE
         chmod +x s.sh && git add s.sh && git commit -qm 'make it executable'
         src=\$(git rev-parse HEAD)
         git checkout -q main
+        _gcp_scan_preflight_is_noop \"\$src\"; echo \"rc=\$?\"
+    "
+    assert_success
+    assert_output --partial "rc=1"
+}
+
+@test "dup #1759: an intentional repeat of an existing stanza is NOT absorbed (1)" {
+    # PR #1760 review, codex BLOCKER + agy Assumption, independently: the
+    # payload comparison alone cannot tell a duplicate RE-application from a
+    # commit deliberately adding a second copy of an existing stanza, and
+    # absorbing the latter is the #1177 data-loss direction. The diff shape
+    # here is identical to the absorbed case above — only the SUBJECT differs,
+    # which is exactly the signal precondition 4 reads.
+    run_in_bash "
+        $(_gcp903_make_repo)
+        seq 1 12 | sed 's/^/L/' > f.txt && git add f.txt && git commit -qm 'seed'
+        git checkout -q -b source
+        printf 'B1\nB2\nB3\nB4\n' >> f.txt
+        git add f.txt && git commit -qm 'add a SECOND copy of the B stanza on purpose'
+        src=\$(git rev-parse HEAD)
+        git checkout -q main
+        { head -6 f.txt; printf 'B1\nB2\nB3\nB4\n'; tail -6 f.txt; } > n.txt && mv n.txt f.txt
+        git add f.txt && git commit -qm 'introduce the B stanza'
+        _gcp_scan_preflight_is_noop \"\$src\"; echo \"rc=\$?\"
+    "
+    assert_success
+    assert_output --partial "rc=1"
+}
+
+@test "dup #1759: multi-hunk — a SHORT hunk after a LONG one is judged on its own lines (0)" {
+    # PR #1760 review, agy BLOCKER: claimed the awk leaves stale tail entries
+    # in `b` when a hunk is shorter than its predecessor. It does leave them —
+    # past `bn`, where block_ok never reads. This case and the next pin that
+    # both verdicts come out right, so the claim stays disproved rather than
+    # merely argued.
+    run_in_bash "
+        $(_gcp903_make_repo)
+        seq 1 30 | sed 's/^/L/' > f.txt && git add f.txt && git commit -qm 'seed'
+        git checkout -q -b source
+        { head -5 f.txt; printf 'P1\nP2\nP3\nP4\nP5\nP6\n'; tail -25 f.txt; printf 'Q1\nQ2\nQ3\n'; } > n.txt && mv n.txt f.txt
+        git add f.txt && git commit -qm 'two blocks'
+        src=\$(git rev-parse HEAD)
+        git checkout -q main
+        { head -20 f.txt; printf 'P1\nP2\nP3\nP4\nP5\nP6\nQ1\nQ2\nQ3\n'; tail -10 f.txt; } > n.txt && mv n.txt f.txt
+        git add f.txt && git commit -qm 'two blocks'
+        _gcp_scan_preflight_is_noop \"\$src\"; echo \"rc=\$?\"
+    "
+    assert_success
+    assert_output --partial "rc=0"
+}
+
+@test "dup #1759: multi-hunk — one NEW short hunk keeps the whole commit visible (1)" {
+    # The other half of the stale-array disproof: were the leftover tail of the
+    # LONG first block still being compared, this short second hunk could match
+    # on those stale lines and the commit would be wrongly absorbed.
+    run_in_bash "
+        $(_gcp903_make_repo)
+        seq 1 30 | sed 's/^/L/' > f.txt && git add f.txt && git commit -qm 'seed'
+        git checkout -q -b source
+        { head -5 f.txt; printf 'P1\nP2\nP3\nP4\nP5\nP6\n'; tail -25 f.txt; printf 'Z1\nZ2\nZ3\n'; } > n.txt && mv n.txt f.txt
+        git add f.txt && git commit -qm 'two blocks'
+        src=\$(git rev-parse HEAD)
+        git checkout -q main
+        { head -20 f.txt; printf 'P1\nP2\nP3\nP4\nP5\nP6\n'; tail -10 f.txt; } > n.txt && mv n.txt f.txt
+        git add f.txt && git commit -qm 'two blocks'
         _gcp_scan_preflight_is_noop \"\$src\"; echo \"rc=\$?\"
     "
     assert_success


### PR DESCRIPTION
## Summary
- `gcp scan` 이 이미 적용된 커밋을 스캔마다 다시 추천하고, 승인하면 매번 clean cherry-pick 되어 같은 블록을 한 벌씩 더 붙이는 무한 루프를 막는다 (보고 사례: `1 file changed, 54 insertions(+)` 가 6벌 누적).
- Stage-2 no-op 판정의 **clean-apply 경로**에 중복 append 판별기를 추가한다. 충돌 경로(#1177/#1688)는 손대지 않는다.
- 흡수 시 sha·파일명을 경고로 남겨, 커밋을 후보에서 떨어뜨리는 유일한 판정이 스캔 출력만으로 추적 가능하게 한다.

## Changes
- `shell-common/functions/gcp_scan.sh`: `_gcp_scan_staged_is_duplicate_append` 신규. `_gcp_scan_preflight_is_noop` 의 clean-apply 분기에서 staged diff 가 비어 있지 않을 때 호출한다.
- `tests/bats/functions/gcp.bats`: #1759 회귀 10건 추가 (재현 형태 고정 1 + 흡수 2 + 오탐 방어 5 + 루프 종료 e2e 1 + 함수 존재 1).
- `docs/guide/learnings/gcp-scan-phantom-commits.md`: cheat sheet 행 + Related 포인터.

## 근본원인

이슈의 가설("파일 끝 컨텍스트만 맞으면 git 이 또 append 한다")은 실측과 달랐다 — `cherry-pick` 은 patch apply 가 아니라 3-way merge 라서, 같은 위치의 중복 append 는 조용한 no-op 이거나 충돌이 된다. 실제 루프가 성립하는 형태는 다음이다:

**HEAD 가 그 블록을 커밋이 넣으려는 위치와 다른 곳에 이미 갖고 있을 때.** 두 삽입이 겹치지 않아 머지가 해결할 것이 없고, 블록을 두 번째로 그냥 덧붙인 뒤 non-empty staged diff 를 남긴다 — 이것이 "실제 작업" 으로 읽힌다. base 쪽 사본이 source 커밋과 다른 위치에 안착한 크로스-레포 cherry-pick 이면 언제든 나온다. `preflight #1759: the reported shape really is a CLEAN apply, not a conflict` 테스트가 이 전제를 고정한다.

기존 방어가 놓친 이유: `_gcp_scan_conflict_adds_new_content`(#1177/#1688)는 **충돌 분기에서만** 돈다. clean 분기의 유일한 검사는 `git diff --cached --quiet` 였다.

## 판별기 설계

잘못된 판정은 커밋을 조용히 떨어뜨리는 #1177 데이터 손실 방향이므로, 세 조건을 모두 만족할 때만 발동한다:

1. staged 경로가 전부 순수 수정(`M`) — 추가/삭제/rename/typechange 는 재적용일 수 없다.
2. 모든 hunk 가 추가 전용 — 삭제 한 줄이라도 있으면 제외. 순수 **이동** 커밋이 정확히 이 형태이므로, 이것이 재정렬 커밋을 계속 보이게 만드는 장치다.
3. 추가된 블록이 HEAD 사본에 **연속으로** 그대로 존재하고, `GCP_SCAN_DUP_BLOCK_MIN_LINES`(기본 3) 이상일 것.

연속성은 #1177/#1688 이 쓰는 집합 비교와 의도적으로 다르다. 집합 비교는 추가된 모든 줄이 파일 어딘가에 있기만 하면 통과시키는데, 셸 보일러플레이트(`    return 0`, 단독 `}`)에서는 그것이 중복이 아니라 우연이다. hunk 전체가 한 덩어리로 일치할 것을 요구하면 짧은 블록 말고는 우연이 배제되고, 나머지는 최소 길이 하한이 막는다.

hunk 가 아예 없는 staged 변경(mode-only, binary)은 "모든 블록이 일치" 가 공허하게 참이 되므로 `nblocks == 0` 으로 별도 차단한다.

## Test plan
- [x] `tests/bats/functions/gcp.bats` 132/132 통과 (base 122 → +10)
- [x] `mise run lint-sh` 통과 (shellcheck + shfmt)
- [x] `mise run lint-docs` errors=0
- [x] `mise run test`: pytest 1553 passed / 0 failed. bats 13/147 파일 실패는 전부 base 에도 있는 pre-existing (plugin_sync, claude_accounts, statusline_ime, dotfiles_root, gh_pr_review, browser_env, setup_skills_ssot, issue_watcher_cron) — gcp 계열 무관
- [x] bash + zsh 양쪽에서 `_gcp_scan_preflight_is_noop` 이 재현 형태를 rc=0 으로 흡수하는지 수동 확인
- [x] 실제 저장소의 `9e4680fa` 재적용 케이스가 판정 불변(rc=1)인지 확인 — 그 커밋은 이후 리팩터로 HEAD 에서 블록이 바뀌어 verbatim 중복이 아니다 (범위 밖, 동작 변화 없음)

## Related
Closes #1759

---
<details>
<summary>🤖 AI Metrics · 📊 ~10000 tokens · 👤 ~2 h · 🤖 ~0 min</summary>

<!-- ai-metrics:gh-pr -->
📊 ~10000 tokens · 👤 ~2 h · 🤖 ~0 min
<!-- /ai-metrics:gh-pr -->

</details>
