### PR TITLE
Fix: origin 원장에 추적 이슈 4번째 필드 추가 — 에스컬레이션된 BLOCKER 가독성

### DIFF
--- a/shell-common/functions/gh_pr_reply_targeted_review.sh
+++ b/shell-common/functions/gh_pr_reply_targeted_review.sh
@@ -99,13 +99,46 @@ _gh_pr_reply_reviewer_is_bot() {
     return 1
 }
 
+# The optional 4th ledger field: where a declined BLOCKER was escalated to
+# (#1762, upstream half of dEitY719/gh-pr-skills#21).
+#
+# rc 0 when <ref> is exactly one `owner/repo#N`. Every field is checked against
+# a positive character class rather than a blacklist, which buys three things
+# at once: the ref can never smuggle in the `:` that delimits the ledger line,
+# a second `/` or `#` (`a/b/c#1`, `a/b#1#2`) is rejected rather than silently
+# reinterpreted, and a typo is caught at the WRITE boundary where a caller can
+# still be told about it.
+#
+# Deliberately NOT case-normalized by its caller: `owner/repo` is
+# case-sensitive on GitHub, so the reviewer/verdict folding must not reach it.
+_gh_pr_reply_tracking_ref_is_valid() {
+    local _ref="${1-}" _owner _rest _repo _num
+
+    case "$_ref" in
+    */*"#"*) ;;
+    *) return 1 ;;
+    esac
+
+    _owner="${_ref%%/*}"
+    _rest="${_ref#*/}"
+    _repo="${_rest%%#*}"
+    _num="${_rest#*#}"
+
+    case "$_owner" in "" | *[!A-Za-z0-9._-]*) return 1 ;; esac
+    case "$_repo" in "" | *[!A-Za-z0-9._-]*) return 1 ;; esac
+    case "$_num" in "" | *[!0-9]*) return 1 ;; esac
+    return 0
+}
+
 _gh_pr_reply_origin_line() {
-    local _reviewer _severity _verdict
+    local _reviewer _severity _verdict _ref
     _reviewer=$(printf '%s' "${1-}" | tr '[:upper:]' '[:lower:]')
     # Reviewers tag findings as `[BLOCKER]` / `[FOLLOW-UP]`; the brackets are
     # rendering, not data.
     _severity=$(printf '%s' "${2-}" | tr -d '[]' | tr '[:lower:]' '[:upper:]')
     _verdict=$(printf '%s' "${3-}" | tr '[:lower:]' '[:upper:]')
+    # Case preserved on purpose — see _gh_pr_reply_tracking_ref_is_valid.
+    _ref="${4-}"
 
     # Either set is accepted; anything in neither is still exit 2, and the
     # message names both so a caller can tell which list it missed.
@@ -139,6 +172,19 @@ _gh_pr_reply_origin_line() {
         return 2
         ;;
     esac
+
+    # The 4th field is OPTIONAL and its absence is the pre-#1762 line, byte for
+    # byte: the ledger is durable state already posted on live PRs, so this is
+    # a strict superset, never a migration.
+    if [ -n "$_ref" ]; then
+        if ! _gh_pr_reply_tracking_ref_is_valid "$_ref"; then
+            printf '[gh-pr-reply] malformed tracking ref: %s (want <owner>/<repo>#<N>, e.g. dEitY719/harness-skills#22)\n' \
+                "$_ref" >&2
+            return 2
+        fi
+        printf '%s:%s:%s:%s\n' "$_reviewer" "$_severity" "$_verdict" "$_ref"
+        return 0
+    fi
 
     printf '%s:%s:%s\n' "$_reviewer" "$_severity" "$_verdict"
 }
@@ -201,7 +247,17 @@ _gh_pr_reply_origin_tally() {
 #   <!-- pr-reply-origins:<head-sha> -->
 #   codex:BLOCKER:DECLINE
 #   agy:FOLLOW-UP:ACCEPT
+#   agy:BLOCKER:DECLINE:dEitY719/harness-skills#22
 #   <!-- /pr-reply-origins:<head-sha> -->
+#
+# The 4th field is optional (#1762): it names the issue a declined BLOCKER was
+# escalated to, so `review-blocked` stops meaning two different things at once
+# ("nobody acted on it" vs "triaged, out of scope here, filed where it
+# belongs"). It changes nothing about the DECISION — the gate still holds — only
+# about what the report can say. Written by `_gh_pr_reply_origin_line`,
+# validated by `_gh_pr_reply_tracking_ref_is_valid`, and read back by the gate;
+# every other reader here globs on `*:*:*` or takes `${line%%:*}` and is
+# indifferent to it.
 
 # Origin lines on stdin -> the wrapped ledger block on stdout.
 #
@@ -225,7 +281,7 @@ _gh_pr_reply_origins_block() {
         case "$_line" in
         *:*:*) ;;
         *)
-            printf '[gh-pr-reply] malformed origin line (want <reviewer>:<severity>:<verdict>): %s\n' \
+            printf '[gh-pr-reply] malformed origin line (want <reviewer>:<severity>:<verdict>[:<owner>/<repo>#<N>]): %s\n' \
                 "$_line" >&2
             return 2
             ;;
@@ -465,7 +521,7 @@ _gh_pr_reply_origins_merge() {
         case "$_line" in
         *:*:*) ;;
         *)
-            printf '[gh-pr-reply] malformed origin line (want <reviewer>:<severity>:<verdict>): %s\n' \
+            printf '[gh-pr-reply] malformed origin line (want <reviewer>:<severity>:<verdict>[:<owner>/<repo>#<N>]): %s\n' \
                 "$_line" >&2
             return 2
             ;;
@@ -486,7 +542,7 @@ EOF
         case "$_line" in
         *:*:*) ;;
         *)
-            printf '[gh-pr-reply] malformed origin line (want <reviewer>:<severity>:<verdict>): %s\n' \
+            printf '[gh-pr-reply] malformed origin line (want <reviewer>:<severity>:<verdict>[:<owner>/<repo>#<N>]): %s\n' \
                 "$_line" >&2
             return 2
             ;;
@@ -565,6 +621,8 @@ _gh_pr_reply_post_origins_ledger() {
 #   pass=no-blocker              no BLOCKER-severity item was raised at all
 #   pass=blockers-resolved:<n>   all <n> BLOCKER items are ACCEPT/ACCEPT-PARTIAL
 #   hold=unresolved-blocker:<r>  <r> has a BLOCKER that is not resolved
+#   hold=unresolved-blocker-tracked:<r>:<ref>
+#                                same, but the item was escalated to <ref>
 #   hold=no-external-review      no external reviewer ever looked at this PR
 #
 # The origin stream is expected to be the MERGED one (this pass's lines plus
@@ -604,7 +662,7 @@ _gh_pr_reply_post_origins_ledger() {
 # the safe direction for a gate that authorizes `review-passed`.
 _gh_pr_reply_review_passed_gate() {
     local _evidence="${1-}"
-    local _origins _line _rev _rest _sev _verd _blocking=0
+    local _origins _line _rev _rest _sev _tail _verd _ref _blocking=0
 
     # Read stdin whole before deciding: an early `return` mid-loop would leave
     # a piped producer facing EPIPE.
@@ -615,7 +673,7 @@ _gh_pr_reply_review_passed_gate() {
         case "$_line" in
         *:*:*) ;;
         *)
-            printf '[gh-pr-reply] malformed origin line (want <reviewer>:<severity>:<verdict>): %s\n' \
+            printf '[gh-pr-reply] malformed origin line (want <reviewer>:<severity>:<verdict>[:<owner>/<repo>#<N>]): %s\n' \
                 "$_line" >&2
             return 2
             ;;
@@ -623,14 +681,33 @@ _gh_pr_reply_review_passed_gate() {
         _rev="${_line%%:*}"
         _rest="${_line#*:}"
         _sev="${_rest%%:*}"
-        _verd=$(printf '%s' "${_rest#*:}" | tr '[:lower:]' '[:upper:]')
+        _tail="${_rest#*:}"
+        _verd=$(printf '%s' "${_tail%%:*}" | tr '[:lower:]' '[:upper:]')
+        # #1762: everything after the verdict is the optional tracking ref. A
+        # 3-field line leaves `_tail` colon-free and `_ref` empty, so this
+        # parses the old shape unchanged. An UNPARSEABLE ref degrades to empty
+        # rather than failing: the ledger lives in an ordinary PR comment and
+        # `_gh_pr_reply_history_origins` already drops garbage silently for
+        # exactly that reason — reporting a ref nobody can follow would be
+        # worse than reporting none, and the hold is identical either way.
+        _ref=""
+        case "$_tail" in
+        *:*) _ref="${_tail#*:}" ;;
+        esac
+        _gh_pr_reply_tracking_ref_is_valid "$_ref" || _ref=""
 
         _gh_pr_reply_severity_is_blocking "$_sev" || continue
         _blocking=$((_blocking + 1))
         case "$_verd" in
         ACCEPT | ACCEPT-PARTIAL) ;;
         *)
-            printf 'hold=unresolved-blocker:%s\n' "$_rev"
+            # Escalation is NOT resolution: both branches are a hold and both
+            # leave the PR unlabelled. Only the report line differs (#1762).
+            if [ -n "$_ref" ]; then
+                printf 'hold=unresolved-blocker-tracked:%s:%s\n' "$_rev" "$_ref"
+            else
+                printf 'hold=unresolved-blocker:%s\n' "$_rev"
+            fi
             return 0
             ;;
         esac
@@ -662,7 +739,7 @@ EOF
 # label is written by `_gh_pr_reply_apply_review_passed` below, which prints
 # this line only once the write actually succeeded.
 _gh_pr_reply_review_passed_report() {
-    local _token="${1-}" _who
+    local _token="${1-}" _who _rest _ref
     case "$_token" in
     pass=no-blocker)
         printf '[OK] 미해결 BLOCKER 없음(BLOCKER 항목 자체가 없음) — review-passed 적용 (외부 재검토 없음, #1636)\n'
@@ -670,6 +747,17 @@ _gh_pr_reply_review_passed_report() {
     pass=blockers-resolved:*)
         printf '[OK] BLOCKER %s건 전부 해소 — review-blocked 해제, review-passed 적용 (외부 재검토 없음, #1636)\n' \
             "${_token#pass=blockers-resolved:}"
+        ;;
+    hold=unresolved-blocker-tracked:*)
+        # Matched BEFORE the bare form. The two patterns cannot actually
+        # collide — `hold=unresolved-blocker:` requires the colon that
+        # `-tracked` displaces — but ordering them this way keeps that
+        # non-collision from being load-bearing.
+        _rest="${_token#hold=unresolved-blocker-tracked:}"
+        _who="${_rest%%:*}"
+        _ref="${_rest#*:}"
+        printf '[BLOCKED] %s 의 블로커가 미해결 — %s 로 에스컬레이션(추적 중, 해소 아님), review-passed 미부여, review-blocked 유지\n' \
+            "$_who" "$_ref"
         ;;
     hold=unresolved-blocker:*)
         _who="${_token#hold=unresolved-blocker:}"
@@ -753,6 +841,7 @@ _gh_pr_reply_apply_review_passed() {
 # fall back to the old global rule.
 for _gprtr_selfcheck_fn in \
     _gh_pr_reply_origin_line \
+    _gh_pr_reply_tracking_ref_is_valid \
     _gh_pr_reply_reviewer_is_bot \
     _gh_pr_reply_severity_is_blocking \
     _gh_pr_reply_origin_tally \

--- a/shell-common/functions/gh_pr_reply_targeted_review.sh
+++ b/shell-common/functions/gh_pr_reply_targeted_review.sh
@@ -109,8 +109,12 @@ _gh_pr_reply_reviewer_is_bot() {
 # reinterpreted, and a typo is caught at the WRITE boundary where a caller can
 # still be told about it.
 #
-# Deliberately NOT case-normalized by its caller: `owner/repo` is
-# case-sensitive on GitHub, so the reviewer/verdict folding must not reach it.
+# Deliberately NOT case-normalized by its caller. GitHub resolves `owner/repo`
+# case-INSENSITIVELY, so folding would still find the repo — the reason is that
+# this field is reproduced verbatim in a report a human reads, and echoing back
+# what the author actually typed is what makes it recognisable. Reviewer and
+# verdict are folded because they are compared against closed enums; this field
+# is compared against nothing (PR #1764 review, codex FOLLOW-UP).
 _gh_pr_reply_tracking_ref_is_valid() {
     local _ref="${1-}" _owner _rest _repo _num
 
@@ -126,8 +130,29 @@ _gh_pr_reply_tracking_ref_is_valid() {
 
     case "$_owner" in "" | *[!A-Za-z0-9._-]*) return 1 ;; esac
     case "$_repo" in "" | *[!A-Za-z0-9._-]*) return 1 ;; esac
-    case "$_num" in "" | *[!0-9]*) return 1 ;; esac
+    # `0*` rejects `#0` and any zero-padded number (`#022`): GitHub issue
+    # numbers start at 1 and are never padded, so both name a target no reader
+    # can open — exactly the failure this validator exists to prevent
+    # (PR #1764 review, codex BLOCKER).
+    case "$_num" in "" | *[!0-9]* | 0*) return 1 ;; esac
     return 0
+}
+
+# The optional 4th field of an origin line, or "" when the line has only three
+# (#1762).
+#
+# Guarded on the 4-field shape, because the same expansion applied to a 3-field
+# line hands back the VERDICT. That trap is why the readers below go through
+# here instead of each re-deriving it inline (PR #1764 review, codex BLOCKER).
+_gh_pr_reply_origin_ref() {
+    local _line="${1-}" _ref
+    case "$_line" in
+    *:*:*:*) ;;
+    *) return 0 ;;
+    esac
+    _ref="${_line#*:}"
+    _ref="${_ref#*:}"
+    printf '%s' "${_ref#*:}"
 }
 
 # One stderr line for every reader that rejects a ledger line without the
@@ -275,7 +300,7 @@ _gh_pr_reply_origin_tally() {
 # <head-sha> may be empty, in which case the unsuffixed marker form is emitted
 # — the same fallback `_gh_pr_review_build_comment_body`'s 8th argument makes.
 _gh_pr_reply_origins_block() {
-    local _sha="${1-}" _marker _origins _line _out=""
+    local _sha="${1-}" _marker _origins _line _ref _out=""
 
     _origins=$(cat)
     _marker="pr-reply-origins"
@@ -290,6 +315,19 @@ _gh_pr_reply_origins_block() {
             return 2
             ;;
         esac
+        # The 4th field is re-checked HERE, not only in
+        # `_gh_pr_reply_origin_line` (PR #1764 review, codex BLOCKER). This
+        # function is THE ledger write, and the contract in its header is that
+        # garbage never gets persisted in the first place. A caller that hand-
+        # builds a line, bypassing the builder, must not be able to leave a ref
+        # in the ledger that every later reader silently drops.
+        _ref=$(_gh_pr_reply_origin_ref "$_line")
+        if [ -n "$_ref" ] &&
+            ! _gh_pr_reply_tracking_ref_is_valid "$_ref"; then
+            printf '[gh-pr-reply] malformed tracking ref in origin line (want <owner>/<repo>#<N>): %s\n' \
+                "$_line" >&2
+            return 2
+        fi
         _out="${_out}${_line}
 "
     done <<EOF
@@ -373,7 +411,7 @@ _gh_pr_reply_login_bodies() {
 # comment, and a human replying inside it (or GitHub reflowing it) must not be
 # able to turn the next pass's gate into a hard error.
 _gh_pr_reply_history_origins() {
-    local _line
+    local _line _ref _rest _tail
     _gh_pr_reply_login_bodies "${1-}" |
     awk '
         # "\001" is the "marker absent on this line" sentinel: unlike
@@ -428,8 +466,27 @@ _gh_pr_reply_history_origins() {
         END { printf "%s", last }
     ' | while IFS= read -r _line || [ -n "$_line" ]; do
         case "$_line" in
-        *:*:*) printf '%s\n' "$_line" ;;
+        *:*:*) ;;
+        *) continue ;;
         esac
+        # An unusable 4th field is STRIPPED, never dropped with its line
+        # (PR #1764 review, codex BLOCKER). Dropping would take the BLOCKER's
+        # VERDICT with it and let the gate certify a PR whose blocker still
+        # stands — the fail-OPEN direction, and the very hole this ledger
+        # exists to close. Stripping keeps the verdict and loses only the ref
+        # nobody could have followed. It also means the sanitized stream can be
+        # handed straight back to the now-strict `_gh_pr_reply_origins_block`
+        # without one human typo inside the PR comment permanently breaking the
+        # ledger write.
+        _ref=$(_gh_pr_reply_origin_ref "$_line")
+        if [ -n "$_ref" ] &&
+            ! _gh_pr_reply_tracking_ref_is_valid "$_ref"; then
+            _rest="${_line#*:}"
+            _tail="${_rest#*:}"
+            printf '%s:%s:%s\n' "${_line%%:*}" "${_rest%%:*}" "${_tail%%:*}"
+            continue
+        fi
+        printf '%s\n' "$_line"
     done
 }
 
@@ -696,10 +753,7 @@ _gh_pr_reply_review_passed_gate() {
         # `_gh_pr_reply_history_origins` already drops garbage silently for
         # exactly that reason — reporting a ref nobody can follow would be
         # worse than reporting none, and the hold is identical either way.
-        _ref=""
-        case "$_tail" in
-        *:*) _ref="${_tail#*:}" ;;
-        esac
+        _ref=$(_gh_pr_reply_origin_ref "$_line")
         _gh_pr_reply_tracking_ref_is_valid "$_ref" || _ref=""
 
         case "$_verd" in
@@ -846,6 +900,7 @@ _gh_pr_reply_apply_review_passed() {
 for _gprtr_selfcheck_fn in \
     _gh_pr_reply_origin_line \
     _gh_pr_reply_tracking_ref_is_valid \
+    _gh_pr_reply_origin_ref \
     _gh_pr_reply_reviewer_is_bot \
     _gh_pr_reply_severity_is_blocking \
     _gh_pr_reply_origin_tally \

--- a/shell-common/functions/gh_pr_reply_targeted_review.sh
+++ b/shell-common/functions/gh_pr_reply_targeted_review.sh
@@ -130,6 +130,13 @@ _gh_pr_reply_tracking_ref_is_valid() {
     return 0
 }
 
+# One stderr line for every reader that rejects a ledger line without the
+# minimum three fields. Callers still `return 2` themselves.
+_gh_pr_reply_malformed_origin_line() {
+    printf '[gh-pr-reply] malformed origin line (want <reviewer>:<severity>:<verdict>[:<owner>/<repo>#<N>]): %s\n' \
+        "${1-}" >&2
+}
+
 _gh_pr_reply_origin_line() {
     local _reviewer _severity _verdict _ref
     _reviewer=$(printf '%s' "${1-}" | tr '[:upper:]' '[:lower:]')
@@ -175,18 +182,16 @@ _gh_pr_reply_origin_line() {
 
     # The 4th field is OPTIONAL and its absence is the pre-#1762 line, byte for
     # byte: the ledger is durable state already posted on live PRs, so this is
-    # a strict superset, never a migration.
-    if [ -n "$_ref" ]; then
-        if ! _gh_pr_reply_tracking_ref_is_valid "$_ref"; then
-            printf '[gh-pr-reply] malformed tracking ref: %s (want <owner>/<repo>#<N>, e.g. dEitY719/harness-skills#22)\n' \
-                "$_ref" >&2
-            return 2
-        fi
-        printf '%s:%s:%s:%s\n' "$_reviewer" "$_severity" "$_verdict" "$_ref"
-        return 0
+    # a strict superset, never a migration. `${_ref:+:$_ref}` is empty when
+    # `_ref` is, so one printf covers both shapes.
+    if [ -n "$_ref" ] &&
+        ! _gh_pr_reply_tracking_ref_is_valid "$_ref"; then
+        printf '[gh-pr-reply] malformed tracking ref: %s (want <owner>/<repo>#<N>, e.g. dEitY719/harness-skills#22)\n' \
+            "$_ref" >&2
+        return 2
     fi
 
-    printf '%s:%s:%s\n' "$_reviewer" "$_severity" "$_verdict"
+    printf '%s:%s:%s%s\n' "$_reviewer" "$_severity" "$_verdict" "${_ref:+:$_ref}"
 }
 
 # Blocking severity = the tag that made `review-blocked` happen. Everything
@@ -281,8 +286,7 @@ _gh_pr_reply_origins_block() {
         case "$_line" in
         *:*:*) ;;
         *)
-            printf '[gh-pr-reply] malformed origin line (want <reviewer>:<severity>:<verdict>[:<owner>/<repo>#<N>]): %s\n' \
-                "$_line" >&2
+            _gh_pr_reply_malformed_origin_line "$_line"
             return 2
             ;;
         esac
@@ -521,8 +525,7 @@ _gh_pr_reply_origins_merge() {
         case "$_line" in
         *:*:*) ;;
         *)
-            printf '[gh-pr-reply] malformed origin line (want <reviewer>:<severity>:<verdict>[:<owner>/<repo>#<N>]): %s\n' \
-                "$_line" >&2
+            _gh_pr_reply_malformed_origin_line "$_line"
             return 2
             ;;
         esac
@@ -542,8 +545,7 @@ EOF
         case "$_line" in
         *:*:*) ;;
         *)
-            printf '[gh-pr-reply] malformed origin line (want <reviewer>:<severity>:<verdict>[:<owner>/<repo>#<N>]): %s\n' \
-                "$_line" >&2
+            _gh_pr_reply_malformed_origin_line "$_line"
             return 2
             ;;
         esac
@@ -673,14 +675,18 @@ _gh_pr_reply_review_passed_gate() {
         case "$_line" in
         *:*:*) ;;
         *)
-            printf '[gh-pr-reply] malformed origin line (want <reviewer>:<severity>:<verdict>[:<owner>/<repo>#<N>]): %s\n' \
-                "$_line" >&2
+            _gh_pr_reply_malformed_origin_line "$_line"
             return 2
             ;;
         esac
         _rev="${_line%%:*}"
         _rest="${_line#*:}"
         _sev="${_rest%%:*}"
+        # Filter on severity BEFORE parsing the rest: only a blocking line's
+        # verdict and ref are ever read, and `_verd` costs a fork per line.
+        _gh_pr_reply_severity_is_blocking "$_sev" || continue
+        _blocking=$((_blocking + 1))
+
         _tail="${_rest#*:}"
         _verd=$(printf '%s' "${_tail%%:*}" | tr '[:lower:]' '[:upper:]')
         # #1762: everything after the verdict is the optional tracking ref. A
@@ -696,8 +702,6 @@ _gh_pr_reply_review_passed_gate() {
         esac
         _gh_pr_reply_tracking_ref_is_valid "$_ref" || _ref=""
 
-        _gh_pr_reply_severity_is_blocking "$_sev" || continue
-        _blocking=$((_blocking + 1))
         case "$_verd" in
         ACCEPT | ACCEPT-PARTIAL) ;;
         *)

--- a/shell-common/functions/gh_pr_reply_targeted_review.sh
+++ b/shell-common/functions/gh_pr_reply_targeted_review.sh
@@ -102,6 +102,18 @@ _gh_pr_reply_reviewer_is_bot() {
 # The optional 4th ledger field: where a declined BLOCKER was escalated to
 # (#1762, upstream half of dEitY719/gh-pr-skills#21).
 #
+# ADVISORY PROVENANCE, not a verdict — and the writer therefore accepts it on
+# ANY severity/verdict, not only `BLOCKER`+`DECLINE` (PR #1764 review, codex
+# FOLLOW-UP: the prose used to imply an invariant the code does not enforce).
+# The narrowing is on the READ side, where it is enforceable: only
+# `_gh_pr_reply_review_passed_gate`'s blocking-and-held branch ever looks at
+# the field, so a ref on an ACCEPT or a FOLLOW-UP line changes no decision and
+# reaches no report — see the "4th field on a NON-blocking line" and "tracked
+# ACCEPT is still a pass" cases in the bats file. Constraining the writer would
+# buy nothing real either: the ledger is a plain PR comment any collaborator
+# can hand-edit, so the readers must stay tolerant of an off-contract line no
+# matter what the builder allows.
+#
 # rc 0 when <ref> is exactly one `owner/repo#N`. Every field is checked against
 # a positive character class rather than a blacklist, which buys three things
 # at once: the ref can never smuggle in the `:` that delimits the ledger line,
@@ -109,12 +121,15 @@ _gh_pr_reply_reviewer_is_bot() {
 # reinterpreted, and a typo is caught at the WRITE boundary where a caller can
 # still be told about it.
 #
-# Deliberately NOT case-normalized by its caller. GitHub resolves `owner/repo`
-# case-INSENSITIVELY, so folding would still find the repo — the reason is that
-# this field is reproduced verbatim in a report a human reads, and echoing back
-# what the author actually typed is what makes it recognisable. Reviewer and
-# verdict are folded because they are compared against closed enums; this field
-# is compared against nothing (PR #1764 review, codex FOLLOW-UP).
+# Deliberately NOT case-normalized by its caller. Resolution is not the reason
+# either way: GitHub looks `owner/repo` up case-INSENSITIVELY and redirects to
+# the one canonical casing, so folding would still find the repo (PR #1764
+# review, agy FOLLOW-UP — the point being that each repo has exactly one
+# canonical casing, which is what makes folding lossy rather than unresolvable).
+# The reason is legibility: this field is reproduced verbatim in a report a
+# human reads, and echoing back what the author actually typed is what makes it
+# recognisable. Reviewer and verdict are folded because they are compared
+# against closed enums; this field is compared against nothing.
 _gh_pr_reply_tracking_ref_is_valid() {
     local _ref="${1-}" _owner _rest _repo _num
 
@@ -284,7 +299,9 @@ _gh_pr_reply_origin_tally() {
 # escalated to, so `review-blocked` stops meaning two different things at once
 # ("nobody acted on it" vs "triaged, out of scope here, filed where it
 # belongs"). It changes nothing about the DECISION — the gate still holds — only
-# about what the report can say. Written by `_gh_pr_reply_origin_line`,
+# about what the report can say, and it is accepted on any line (advisory
+# provenance; see `_gh_pr_reply_tracking_ref_is_valid`'s header for why the
+# narrowing lives on the read side). Written by `_gh_pr_reply_origin_line`,
 # validated by `_gh_pr_reply_tracking_ref_is_valid`, and read back by the gate;
 # every other reader here globs on `*:*:*` or takes `${line%%:*}` and is
 # indifferent to it.

--- a/tests/bats/functions/gh_pr_reply_targeted_review.bats
+++ b/tests/bats/functions/gh_pr_reply_targeted_review.bats
@@ -1114,6 +1114,107 @@ agy:BLOCKER:DECLINE:dEitY719/harness-skills#22'
     assert_output 'hold=unresolved-blocker-tracked:agy:dEitY719/harness-skills#22'
 }
 
+# ── PR #1764 review — agy + codex findings on the #1762 shape ─────────
+
+@test "#1762 (PR #1764, codex BLOCKER): #0 is not an issue number" {
+    run _gh_pr_reply_origin_line agy BLOCKER DECLINE 'dEitY719/harness-skills#0'
+    assert_failure 2
+}
+
+@test "#1762 (PR #1764, codex BLOCKER): a zero-padded number is rejected" {
+    # `#022` does not resolve on GitHub, so a report naming it would point at
+    # a target the reader cannot open.
+    run _gh_pr_reply_origin_line agy BLOCKER DECLINE 'dEitY719/harness-skills#022'
+    assert_failure 2
+}
+
+@test "#1762 (PR #1764, agy FOLLOW-UP): an empty owner or repo segment is rejected" {
+    for _ref in 'owner#22' 'owner//repo#22' '/repo#22' 'owner/#22'; do
+        run _gh_pr_reply_origin_line agy BLOCKER DECLINE "$_ref"
+        assert_failure 2
+    done
+}
+
+@test "#1762 (PR #1764, agy FOLLOW-UP): a second / or # is rejected, not reinterpreted" {
+    for _ref in 'a/b/c#1' 'a/b#1#2'; do
+        run _gh_pr_reply_origin_line agy BLOCKER DECLINE "$_ref"
+        assert_failure 2
+    done
+}
+
+@test "#1762 (PR #1764, codex BLOCKER): the ledger write refuses an unvalidated ref" {
+    # `_gh_pr_reply_origin_line` is not the only way a line can reach the
+    # ledger. This function IS the write, and its contract is that garbage is
+    # never persisted — a hand-built line must not get past it either.
+    run bash -c "printf '%s\n' 'agy:BLOCKER:DECLINE:not a ref' \
+        | { . '${_BATS_REAL_DOTFILES_ROOT}/shell-common/functions/gh_pr_reply_targeted_review.sh'; _gh_pr_reply_origins_block abc123; }"
+    assert_failure 2
+    assert_output --partial 'tracking ref'
+}
+
+@test "#1762 (PR #1764, codex BLOCKER): a valid ref still writes fine" {
+    run bash -c "printf '%s\n' 'agy:BLOCKER:DECLINE:dEitY719/harness-skills#22' \
+        | { . '${_BATS_REAL_DOTFILES_ROOT}/shell-common/functions/gh_pr_reply_targeted_review.sh'; _gh_pr_reply_origins_block abc123; }"
+    assert_success
+    assert_output --partial 'agy:BLOCKER:DECLINE:dEitY719/harness-skills#22'
+}
+
+@test "#1762 (PR #1764, codex BLOCKER): history STRIPS a bad ref, keeping the blocker" {
+    # Dropping the whole line would take the BLOCKER's verdict with it and let
+    # the gate certify a PR whose blocker still stands — fail-OPEN, the exact
+    # hole this ledger closes. The verdict must survive; only the ref goes.
+    run bash -c "
+        . '${_BATS_REAL_DOTFILES_ROOT}/shell-common/functions/gh_pr_reply_targeted_review.sh'
+        printf '<!-- pr-reply-origins:abc -->\nagy:BLOCKER:DECLINE:not a ref\n<!-- /pr-reply-origins:abc -->\n' \
+            | jq -Rs '[{user:{login:\"t\"},body:.}]' \
+            | _gh_pr_reply_history_origins t
+    "
+    assert_success
+    assert_output 'agy:BLOCKER:DECLINE'
+}
+
+@test "#1762 (PR #1764, codex BLOCKER): the sanitized history still HOLDS the gate" {
+    run bash -c "
+        . '${_BATS_REAL_DOTFILES_ROOT}/shell-common/functions/gh_pr_reply_targeted_review.sh'
+        printf '<!-- pr-reply-origins:abc -->\nagy:BLOCKER:DECLINE:not a ref\n<!-- /pr-reply-origins:abc -->\n' \
+            | jq -Rs '[{user:{login:\"t\"},body:.}]' \
+            | _gh_pr_reply_history_origins t \
+            | _gh_pr_reply_review_passed_gate yes
+    "
+    assert_success
+    assert_output 'hold=unresolved-blocker:agy'
+}
+
+@test "#1762 (PR #1764, codex BLOCKER): a sanitized history line is re-writable" {
+    # The strip is what lets the strict ledger write above coexist with a
+    # human typing inside the PR comment: one typo must not break the write
+    # for every later pass.
+    run bash -c "
+        . '${_BATS_REAL_DOTFILES_ROOT}/shell-common/functions/gh_pr_reply_targeted_review.sh'
+        printf '<!-- pr-reply-origins:abc -->\nagy:BLOCKER:DECLINE:not a ref\n<!-- /pr-reply-origins:abc -->\n' \
+            | jq -Rs '[{user:{login:\"t\"},body:.}]' \
+            | _gh_pr_reply_history_origins t \
+            | _gh_pr_reply_origins_block abc123
+    "
+    assert_success
+    assert_output --partial 'agy:BLOCKER:DECLINE'
+}
+
+@test "#1762 (PR #1764, agy FOLLOW-UP): extra colons past the ref degrade safely" {
+    run _gate 'agy:BLOCKER:DECLINE:a/b#1:junk'
+    assert_success
+    assert_output 'hold=unresolved-blocker:agy'
+}
+
+@test "#1762 (PR #1764): origin_ref returns the verdict for no 4-field line" {
+    # The trap the shared extractor exists to close: the same expansion on a
+    # 3-field line would hand back DECLINE.
+    run bash -c "{ . '${_BATS_REAL_DOTFILES_ROOT}/shell-common/functions/gh_pr_reply_targeted_review.sh'
+        _gh_pr_reply_origin_ref 'agy:BLOCKER:DECLINE'; }"
+    assert_success
+    assert_output ''
+}
+
 # ---------------------------------------------------------------------
 # The #1616 re-review lane is gone (#1636 F-3)
 # ---------------------------------------------------------------------

--- a/tests/bats/functions/gh_pr_reply_targeted_review.bats
+++ b/tests/bats/functions/gh_pr_reply_targeted_review.bats
@@ -971,8 +971,10 @@ _apply_stub() {
 }
 
 @test "#1762: the ref is preserved verbatim, case included" {
-    # `owner/repo` is case-sensitive on GitHub, so the reviewer/verdict
-    # lowercase-then-uppercase normalization must not reach this field.
+    # NOT because GitHub lookup is case-sensitive — it is not (PR #1764
+    # review, codex FOLLOW-UP corrected this comment). The field is echoed
+    # verbatim into a report a human reads, so the reviewer/verdict
+    # lowercase-then-uppercase normalization must not reach it.
     run _gh_pr_reply_origin_line AGY '[Blocker]' decline dEitY719/Harness-Skills#7
     assert_success
     assert_output 'agy:BLOCKER:DECLINE:dEitY719/Harness-Skills#7'
@@ -1204,6 +1206,39 @@ agy:BLOCKER:DECLINE:dEitY719/harness-skills#22'
     run _gate 'agy:BLOCKER:DECLINE:a/b#1:junk'
     assert_success
     assert_output 'hold=unresolved-blocker:agy'
+}
+
+@test "#1762 (PR #1764, agy FOLLOW-UP): the ledger WRITE rejects a 5-field line" {
+    # `_gh_pr_reply_origin_ref` deliberately hands back everything past the
+    # third colon rather than one isolated token: an isolated token would make
+    # `a:b:c:d:e` look like a VALID 4-field line and let the junk tail into the
+    # ledger. Handing the tail over instead makes the ref fail validation,
+    # which is what closes the write here and drives the strip below.
+    run bash -c "printf '%s\n' 'agy:BLOCKER:DECLINE:a/b#1:junk' \
+        | { . '${_BATS_REAL_DOTFILES_ROOT}/shell-common/functions/gh_pr_reply_targeted_review.sh'; _gh_pr_reply_origins_block abc123; }"
+    assert_failure 2
+    assert_output --partial 'malformed tracking ref'
+}
+
+@test "#1762 (PR #1764, agy FOLLOW-UP): a 5-field ledger line is stripped to 3" {
+    run bash -c "
+        . '${_BATS_REAL_DOTFILES_ROOT}/shell-common/functions/gh_pr_reply_targeted_review.sh'
+        printf '<!-- pr-reply-origins:abc -->\nagy:BLOCKER:DECLINE:a/b#1:junk\n<!-- /pr-reply-origins:abc -->\n' \
+            | jq -Rs '[{user:{login:\"t\"},body:.}]' \
+            | _gh_pr_reply_history_origins t
+    "
+    assert_success
+    assert_output 'agy:BLOCKER:DECLINE'
+}
+
+@test "#1762 (PR #1764, codex FOLLOW-UP): the ref is advisory, allowed on any line" {
+    # The 4th field is provenance, not a verdict, so the WRITER takes it on a
+    # non-blocking ACCEPT too. The narrowing is on the read side: the gate
+    # only ever reads it on a held blocker (see the NON-blocking / tracked
+    # ACCEPT gate cases above), so this can mislead nobody.
+    run _gh_pr_reply_origin_line agy '[FOLLOW-UP]' accept 'dEitY719/harness-skills#22'
+    assert_success
+    assert_output 'agy:FOLLOW-UP:ACCEPT:dEitY719/harness-skills#22'
 }
 
 @test "#1762 (PR #1764): origin_ref returns the verdict for no 4-field line" {

--- a/tests/bats/functions/gh_pr_reply_targeted_review.bats
+++ b/tests/bats/functions/gh_pr_reply_targeted_review.bats
@@ -910,6 +910,211 @@ _apply_stub() {
 }
 
 # ---------------------------------------------------------------------
+# #1762 — the optional 4th field: a DECLINE escalated to a tracking issue
+# ---------------------------------------------------------------------
+#
+# Upstream half of dEitY719/gh-pr-skills#21. Five rollout PRs on 2026-09-05
+# each declined the same BLOCKER with a pointer to dEitY719/harness-skills#22
+# and all five correctly kept `review-blocked` — the item IS unresolved in
+# those PRs. What the ledger could not say is WHERE the item went: a
+# declined-and-escalated BLOCKER wrote the same `<r>:BLOCKER:DECLINE` line as
+# a declined-and-ignored one.
+#
+# The fix keeps `DECLINE` and appends an OPTIONAL 4th field carrying the ref.
+# Two properties are load-bearing and each has its own tests below:
+#   - every existing 3-field line keeps parsing, in every consumer (the ledger
+#     is durable state already posted on live PRs), and
+#   - the gate still HOLDS on a tracked decline. Escalation is not resolution;
+#     only the report line changes.
+
+@test "#1762: origin_line appends the tracking ref as a 4th field" {
+    run _gh_pr_reply_origin_line agy BLOCKER DECLINE dEitY719/harness-skills#22
+    assert_success
+    assert_output 'agy:BLOCKER:DECLINE:dEitY719/harness-skills#22'
+}
+
+@test "#1762: origin_line omits the 4th field when no ref is given" {
+    # The strict-superset guarantee: the 3-argument call is byte-identical to
+    # what it produced before this issue.
+    run _gh_pr_reply_origin_line agy BLOCKER DECLINE
+    assert_success
+    assert_output 'agy:BLOCKER:DECLINE'
+}
+
+@test "#1762: an empty 4th argument is the same as omitting it" {
+    run _gh_pr_reply_origin_line agy BLOCKER DECLINE ''
+    assert_success
+    assert_output 'agy:BLOCKER:DECLINE'
+}
+
+@test "#1762: origin_line rejects a malformed tracking ref (exit 2)" {
+    # A typo must be a NAMED failure at the write boundary, not a garbage
+    # ledger line a later pass silently drops.
+    run _gh_pr_reply_origin_line agy BLOCKER DECLINE 'harness-skills#22'
+    assert_failure 2
+    assert_output --partial 'tracking ref'
+}
+
+@test "#1762: origin_line rejects a ref with no issue number (exit 2)" {
+    run _gh_pr_reply_origin_line agy BLOCKER DECLINE 'dEitY719/harness-skills'
+    assert_failure 2
+}
+
+@test "#1762: origin_line rejects a non-numeric issue number (exit 2)" {
+    run _gh_pr_reply_origin_line agy BLOCKER DECLINE 'dEitY719/harness-skills#abc'
+    assert_failure 2
+}
+
+@test "#1762: origin_line rejects a ref containing ':' (breaks the delimiter)" {
+    run _gh_pr_reply_origin_line agy BLOCKER DECLINE 'dEitY719/harn:ess#22'
+    assert_failure 2
+}
+
+@test "#1762: the ref is preserved verbatim, case included" {
+    # `owner/repo` is case-sensitive on GitHub, so the reviewer/verdict
+    # lowercase-then-uppercase normalization must not reach this field.
+    run _gh_pr_reply_origin_line AGY '[Blocker]' decline dEitY719/Harness-Skills#7
+    assert_success
+    assert_output 'agy:BLOCKER:DECLINE:dEitY719/Harness-Skills#7'
+}
+
+@test "#1762: a tracked decline still HOLDS — escalation is not resolution" {
+    run _gate 'agy:BLOCKER:DECLINE:dEitY719/harness-skills#22'
+    assert_success
+    assert_output 'hold=unresolved-blocker-tracked:agy:dEitY719/harness-skills#22'
+}
+
+@test "#1762: an untracked decline keeps the original token unchanged" {
+    run _gate 'agy:BLOCKER:DECLINE'
+    assert_success
+    assert_output 'hold=unresolved-blocker:agy'
+}
+
+@test "#1762: a tracked ACCEPT is still a pass (the ref never blocks)" {
+    # The 4th field is provenance, not a verdict. Only the verdict decides.
+    run _gate 'codex:BLOCKER:ACCEPT:dEitY719/harness-skills#22'
+    assert_success
+    assert_output 'pass=blockers-resolved:1'
+}
+
+@test "#1762: a 4th field on a NON-blocking line never reaches the gate token" {
+    run _gate 'agy:FOLLOW-UP:DECLINE:dEitY719/harness-skills#22'
+    assert_success
+    assert_output 'pass=no-blocker'
+}
+
+@test "#1762: an unresolved untracked BLOCKER still outranks a tracked one" {
+    # First-unresolved-wins is unchanged; the tracked line is not privileged.
+    run _gate 'codex:BLOCKER:DECLINE
+agy:BLOCKER:DECLINE:dEitY719/harness-skills#22'
+    assert_success
+    assert_output 'hold=unresolved-blocker:codex'
+}
+
+@test "#1762: a malformed ref read back from the ledger degrades, never fails" {
+    # `_gh_pr_reply_history_origins` already drops unparseable ledger lines
+    # silently so a human editing the PR comment cannot hard-error the next
+    # pass. A garbage 4th field follows the same rule: it falls back to the
+    # plain hold token rather than reporting a ref nobody can follow.
+    run _gate 'agy:BLOCKER:DECLINE:not a ref'
+    assert_success
+    assert_output 'hold=unresolved-blocker:agy'
+}
+
+@test "#1762: a QUESTION carrying a ref is tracked too, not only DECLINE" {
+    run _gate 'agy:BLOCKER:QUESTION:dEitY719/harness-skills#22'
+    assert_success
+    assert_output 'hold=unresolved-blocker-tracked:agy:dEitY719/harness-skills#22'
+}
+
+@test "#1762: the report line names both the reviewer and where the item went" {
+    run _gh_pr_reply_review_passed_report \
+        hold=unresolved-blocker-tracked:agy:dEitY719/harness-skills#22
+    assert_success
+    assert_output --partial 'agy'
+    assert_output --partial 'dEitY719/harness-skills#22'
+    assert_output --partial 'review-passed 미부여'
+    assert_output --partial 'review-blocked 유지'
+}
+
+@test "#1762: the tracked report line is a [BLOCKED] line, never an [OK]" {
+    run _gh_pr_reply_review_passed_report \
+        hold=unresolved-blocker-tracked:agy:dEitY719/harness-skills#22
+    assert_success
+    assert_output --partial '[BLOCKED]'
+    refute_output --partial '[OK]'
+}
+
+@test "#1762: apply writes NO label for a tracked decline" {
+    # The whole point: legibility changed, the decision did not.
+    _apply_stub
+    printf '%s\n' 'agy:BLOCKER:DECLINE:dEitY719/harness-skills#22' |
+        _gh_pr_reply_apply_review_passed 1609 acme/widget '' newsha yes \
+            >"${BATS_TEST_TMPDIR}/out"
+    run cat "$APPLY_LOG"
+    assert_output ''
+    run cat "${BATS_TEST_TMPDIR}/out"
+    assert_output --partial 'dEitY719/harness-skills#22'
+    assert_output --partial 'review-passed 미부여'
+}
+
+@test "#1762: apply never deletes review-blocked on the tracked hold path" {
+    _apply_stub
+    printf '%s\n' 'agy:BLOCKER:DECLINE:dEitY719/harness-skills#22' |
+        _gh_pr_reply_apply_review_passed 1609 acme/widget '' newsha yes >/dev/null
+    run cat "$APPLY_LOG"
+    refute_output --partial 'labels/review-blocked'
+}
+
+# ── The other four consumers must swallow the 4-field line unchanged ──
+
+@test "#1762: tally reads the verdict from \$3, not the whole tail" {
+    run bash -c "printf '%s\n' \
+        'agy:BLOCKER:DECLINE:dEitY719/harness-skills#22' \
+        'agy:BLOCKER:ACCEPT' \
+        | { . '${_BATS_REAL_DOTFILES_ROOT}/shell-common/functions/gh_pr_reply_targeted_review.sh'; _gh_pr_reply_origin_tally; }"
+    assert_success
+    assert_output 'reviewer=agy blocking_total=2 blocking_accepted=1 nonblocking_total=0 nonblocking_declined=0'
+}
+
+@test "#1762: origins_block writes a 4-field line without complaint" {
+    run bash -c "printf '%s\n' 'agy:BLOCKER:DECLINE:dEitY719/harness-skills#22' \
+        | { . '${_BATS_REAL_DOTFILES_ROOT}/shell-common/functions/gh_pr_reply_targeted_review.sh'; _gh_pr_reply_origins_block abc123; }"
+    assert_success
+    assert_output --partial 'agy:BLOCKER:DECLINE:dEitY719/harness-skills#22'
+}
+
+@test "#1762: a 4-field line round-trips through the ledger" {
+    run bash -c "
+        . '${_BATS_REAL_DOTFILES_ROOT}/shell-common/functions/gh_pr_reply_targeted_review.sh'
+        block=\$(printf '%s\n' 'agy:BLOCKER:DECLINE:dEitY719/harness-skills#22' \
+            | _gh_pr_reply_origins_block abc123)
+        printf '%s' \"\$block\" | jq -Rs '[{user:{login:\"tester\"},body:.}]' \
+            | _gh_pr_reply_history_origins tester
+    "
+    assert_success
+    assert_output 'agy:BLOCKER:DECLINE:dEitY719/harness-skills#22'
+}
+
+@test "#1762: merge supersedes a tracked line per reviewer, like any other" {
+    run bash -c "{ . '${_BATS_REAL_DOTFILES_ROOT}/shell-common/functions/gh_pr_reply_targeted_review.sh'
+        printf '%s\n' agy:BLOCKER:ACCEPT \
+            | _gh_pr_reply_origins_merge 'agy:BLOCKER:DECLINE:dEitY719/harness-skills#22'; }"
+    assert_success
+    assert_output 'agy:BLOCKER:ACCEPT'
+}
+
+@test "#1762: a tracked history line survives to the gate through merge" {
+    # The cross-pass hole PR #1637 closed must stay closed for the new shape.
+    run bash -c "{ . '${_BATS_REAL_DOTFILES_ROOT}/shell-common/functions/gh_pr_reply_targeted_review.sh'
+        printf '%s\n' codex:FOLLOW-UP:ACCEPT \
+            | _gh_pr_reply_origins_merge 'agy:BLOCKER:DECLINE:dEitY719/harness-skills#22' \
+            | _gh_pr_reply_review_passed_gate yes; }"
+    assert_success
+    assert_output 'hold=unresolved-blocker-tracked:agy:dEitY719/harness-skills#22'
+}
+
+# ---------------------------------------------------------------------
 # The #1616 re-review lane is gone (#1636 F-3)
 # ---------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

- `review-passed` 게이트가 **"BLOCKER 를 DECLINE 하고 추적 이슈로 에스컬레이션했다"** 를 표현할 수 없던 결함을 해소한다. 원장의 `<verdict>` 가 닫힌 enum 이라, 분류해서 제자리에 등록한 항목이 아무도 손대지 않은 항목과 바이트 단위로 같은 `<r>:BLOCKER:DECLINE` 로 기록됐다.
- `DECLINE` 을 그대로 두고 **선택적 4번째 필드**로 추적 ref 를 붙인다 — 3필드 라인은 한 글자도 바뀌지 않는 순수 상위집합이다.
- **게이트의 판정은 그대로다.** 에스컬레이션은 해소가 아니다. 달라지는 건 리포트 한 줄뿐 — 그 항목이 어디로 갔는지 말한다.

2026-09-05 롤아웃 PR 5건(`dEitY719/gh-flow-skills#10`, `dEitY719/gh-issue-skills#14`, `dEitY719/gh-pr-skills#20`, `dEitY719/gh-resolve-skills#12`, `dEitY719/gh-verify-skills#15`)이 전부 같은 `$PWD` BLOCKER 를 `dEitY719/harness-skills#22` 로 넘기며 `review-blocked` 를 유지했다. 판정은 다섯 건 모두 옳다 — 그 PR 안에서 항목은 실제로 미해결이다. 남은 문제는 가독성이었다: `review-blocked` 가 저장소 패밀리 전반에서 두 가지 뜻을 갖게 됐는데 읽는 쪽(사람이든 다음 pass 든)이 구분할 수 없다.

## Changes

`shell-common/functions/gh_pr_reply_targeted_review.sh`

- **`_gh_pr_reply_tracking_ref_is_valid`** (신규) — `owner/repo#N` 을 화이트리스트 문자류로 검증한다. 블랙리스트가 아니라 positive class 로 검사해서 세 가지를 한 번에 얻는다: ref 가 원장 구분자 `:` 를 몰래 넣을 수 없고, 두 번째 `/`·`#`(`a/b/c#1`, `a/b#1#2`)이 조용히 재해석되는 대신 거부되며, 오타가 **쓰기 경계**에서 잡힌다. `owner/repo` 는 GitHub 에서 대소문자를 구분하므로 reviewer/verdict 의 대소문자 정규화를 이 필드에는 적용하지 않는다.
- **`_gh_pr_reply_origin_line`** — 선택적 4번째 위치 인자를 받아 값이 있을 때만 4번째 필드를 붙인다. 오타는 이름 있는 실패(rc 2), 조용한 쓰레기 원장 라인이 아니다.

      agy:BLOCKER:DECLINE:dEitY719/harness-skills#22

- **`_gh_pr_reply_review_passed_gate`** — 기존에는 severity 뒤 전부를 verdict 로 삼아(`_verd="${_rest#*:}"`) 4필드 라인이 `DECLINE:owner/repo#N` 이 됐다. ACCEPT 가 아니니 **hold 는 이미 옳았지만** ref 를 함께 보고할 수 없었다. verdict 와 ref 를 분리하고 새 토큰 `hold=unresolved-blocker-tracked:<r>:<ref>` 를 낸다. `hold=*` 이므로 `_gh_pr_reply_apply_review_passed` 는 지금과 똑같이 **아무 라벨도 쓰지 않는다**.
- **`_gh_pr_reply_review_passed_report`** — 새 토큰을 `[BLOCKED]` 한 줄로 렌더링하며 리뷰어와 추적 ref 를 함께 이름 짓는다.
- 원장에서 되읽은 ref 가 깨져 있으면 하드 실패 대신 3필드 토큰으로 degrade 한다. `_gh_pr_reply_history_origins` 가 이미 같은 이유로 파싱 불가 라인을 조용히 버린다 — 원장은 평범한 PR 코멘트라, 사람이 그 안에 답글을 달았다고 다음 pass 의 게이트가 죽어서는 안 된다. 따라갈 수 없는 ref 를 보고하느니 안 하는 편이 낫고, hold 여부는 어느 쪽이든 동일하다.
- 자기 점검(#724) 명단과 malformed-line 메시지의 want-shape 를 `[:<owner>/<repo>#<N>]` 까지 포함하도록 갱신.

`tests/bats/functions/gh_pr_reply_targeted_review.bats` — `#1762` 섹션 24건 추가.

## 왜 이 모양인가 (호환 vs `DECLINE-TRACKED`)

이슈는 두 가지 모양을 제안했다. 5번째 verdict 토큰(`DECLINE-TRACKED`)이 아니라 **선택적 4번째 필드**를 골랐다:

- 원장은 이미 살아있는 PR 에 올라가 있는 **영속 상태**다. 마이그레이션이 아니라 순수 상위집합이어야 한다.
- verdict enum 을 늘리면 그 enum 을 읽는 모든 곳(`_gh_pr_reply_origin_tally` 의 awk `$3` 비교 포함)이 새 토큰을 알아야 한다. 필드를 늘리면 아무도 몰라도 된다.
- ref 는 판정이 아니라 **출처(provenance)** 다. verdict 자리에 두면 게이트가 "추적된 DECLINE 은 다르게 취급해야 하나"를 묻고 싶어진다. 답은 "아니오"이고, 필드 분리가 그 답을 구조로 못 박는다.

## Test plan

- [x] `bats tests/bats/functions/gh_pr_reply_targeted_review.bats` — **115/115** (기존 91 + 신규 24)
- [x] `bats tests/bats/skills/gh_pr_reply_review_passed_gate.bats` — 28/28 (프로덕션 함수를 그대로 source 하는 미러 픽스처, #1524)
- [x] `bats tests/bats/functions/gh_pr_reply.bats` — 30/30
- [x] `bats tests/bats/skills/gh_pr_merge_train_review_verdict_gate.bats` — 52/52
- [x] `bats tests/bats/skills/gh_pr_merge_review_passed_cleanup.bats` — 10/10
- [x] `bats tests/bats/skills/gh_pr_resolve_ci_fail_review_passed.bats` — 8/8
- [x] `shellcheck -x -e SC1090,SC1091 shell-common/functions/gh_pr_reply_targeted_review.sh` — clean
- [x] **hold 동작 불변** 을 테스트로 고정: tracked decline 은 여전히 hold 이고 `apply` 는 라벨을 하나도 쓰지 않으며 `review-blocked` 를 지우지도 않는다.
- [x] **3필드 하위호환** 을 소비자별로 고정: `origin_tally` / `origins_block` / `history_origins` / `origins_merge` 는 `*:*:*` 글롭이나 `${line%%:*}` 만 보므로 무변경 — 추정이 아니라 테스트로 확인했다(구현 전에 이미 green 이었다).

## Related

Closes #1762

상위 이슈는 `dEitY719/gh-pr-skills#21`. 문서 절반(`skills/reply/references/review-passed-gate.md` — 게이트와 `pr-reply-origins` 원장의 SSOT, 그리고 verdict 루브릭)은 그 저장소가 별도 PR 로 맡는다. 해당 저장소의 vendored `lib/vendor/shell-common/functions/gh_pr_reply_targeted_review.sh` 는 이 PR 이 머지된 뒤 `dEitY719/harness-skills#24` 의 vendor 재생성으로 따라온다.

---
<details>
<summary>🤖 AI Metrics · 📊 ~2000 tokens · 👤 ~3 h · 🤖 ~1 min</summary>

<!-- ai-metrics:gh-pr -->
📊 ~2000 tokens · 👤 ~3 h · 🤖 ~1 min
<!-- /ai-metrics:gh-pr -->

</details>
