### PR TITLE
fix(gh-pr-review): agy 레인을 stream-json stdin 전송으로 전환

### DIFF
--- a/shell-common/functions/gh_pr_review.sh
+++ b/shell-common/functions/gh_pr_review.sh
@@ -223,6 +223,17 @@ _gh_pr_review_require_ai_cli() {
     opencode | hermes)
         _gh_pr_review_require_internal_cli "$ai" || return 1
         ;;
+    agy)
+        # Since #1761 the agy lane builds its stdin NDJSON and parses the
+        # stream-json reply with `jq`, so jq is as much a hard requirement as
+        # the CLI itself. Without this check a jq-less host fails deep inside
+        # the lane with `jq: command not found` attributed to agy — name the
+        # tool that is actually missing (PR #1765 codex BLOCKER).
+        if ! command -v jq >/dev/null 2>&1; then
+            echo "Required CLI 'jq' not found in PATH (--ai agy needs it for the stream-json transport)" >&2
+            return 1
+        fi
+        ;;
     esac
     if ! command -v "$ai" >/dev/null 2>&1; then
         echo "Required CLI '$ai' not found in PATH" >&2

--- a/shell-common/functions/gh_pr_review.sh
+++ b/shell-common/functions/gh_pr_review.sh
@@ -517,15 +517,24 @@ _gh_pr_review_run_ai() {
                 # `response` is what plain `agy --print` used to write to
                 # stdout, so everything downstream (tee -> AI_OUT -> comment
                 # body) keeps seeing exactly the same review text.
+                # The exit code alone is NOT the success signal (PR #1765
+                # codex BLOCKER): the stream carries its own `result.status`,
+                # and a non-SUCCESS result that still exited 0 would post an
+                # empty review as if the lane had passed. Gate on the status
+                # and let `jq -e` turn "no SUCCESS result at all" into a
+                # failure instead of silent empty output.
                 printf '%s\n' "$_agy_stream" |
-                    jq -r 'select(.event == "result") | .result.response // ""' \
-                        2>>"$_stderr_file" || _rc=$?
-            else
+                    jq -er 'select(.event == "result" and .result.status == "SUCCESS")
+                            | .result.response // ""' \
+                        2>>"$_stderr_file" || _rc=1
+            fi
+            if [ "$_rc" -ne 0 ]; then
                 # A non-SUCCESS run reports its cause in `result.error` on
                 # *stdout*, not stderr — without this the failure summary
                 # below would have an empty stderr file to work with.
                 printf '%s\n' "$_agy_stream" |
-                    jq -r 'select(.event == "result") | .result.error // empty' \
+                    jq -r 'select(.event == "result")
+                           | "agy result status=\(.result.status // "?"): \(.result.error // "no error reported")"' \
                         >>"$_stderr_file" 2>/dev/null
             fi
         fi

--- a/shell-common/functions/gh_pr_review.sh
+++ b/shell-common/functions/gh_pr_review.sh
@@ -426,7 +426,9 @@ _gh_pr_review_timeout() {
 #
 # Args: $1 = ai (codex|agy|claude|opencode), $2 = PROMPT_FILE, $3 = optional
 # CLAUDE_CONFIG_DIR (claude --user routing), $4 = optional pre-allocated
-# stderr temp path. Stdout of the CLI streams to the caller's stdout;
+# stderr temp path. Stdout of the CLI streams to the caller's stdout
+# (except agy, which must buffer: its failure cause arrives on stdout, so
+# the stream has to survive to be re-read — see that lane's comment);
 # stderr is captured for the failure summary.
 _gh_pr_review_run_ai() {
     local ai="$1"
@@ -504,8 +506,12 @@ _gh_pr_review_run_ai() {
         # `--print` still needs a value even in stream-json mode (Go's flag
         # parser rejects a bare `--print` with "flag needs an argument"), so it
         # is passed empty and the stdin message carries the prompt.
+        # `2>` before `<` is deliberate: redirections apply left to right, so
+        # with `<` first an unreadable $prompt_file is reported before stderr
+        # is redirected and the summary below gets "<no stderr>" (bash; zsh
+        # reports to the original stderr either way). Do not reorder.
         if ! _prompt_content=$(jq -Rs '{event: "user", message: {content: .}}' \
-            <"$prompt_file" 2>"$_stderr_file"); then
+            2>"$_stderr_file" <"$prompt_file"); then
             _rc=1
         else
             # `printf` is a shell builtin, so the prompt reaches agy through a
@@ -535,7 +541,7 @@ _gh_pr_review_run_ai() {
                 printf '%s\n' "$_agy_stream" |
                     jq -r 'select(.event == "result")
                            | "agy result status=\(.result.status // "?"): \(.result.error // "no error reported")"' \
-                        >>"$_stderr_file" 2>/dev/null
+                        >>"$_stderr_file" 2>&1
             fi
         fi
         ;;
@@ -551,9 +557,8 @@ _gh_pr_review_run_ai() {
         # (issue #1452): there is no `exec` subcommand — the one-shot
         # non-interactive flag is `-z` / `--oneshot`, and it takes the prompt
         # as a value argument rather than --file/stdin, guarded by
-        # _gh_pr_review_argv_prompt_or_fail. Re-checked for #1761: hermes has
-        # no stdin equivalent of agy's `--input-format stream-json`, so this
-        # lane keeps the argv ceiling until it grows one.
+        # _gh_pr_review_argv_prompt_or_fail — see that helper's header for why
+        # this lane still has an argv ceiling.
         if ! _gh_pr_review_require_internal_cli hermes >"$_stderr_file" 2>&1; then
             _rc=1
         elif _prompt_content=$(_gh_pr_review_argv_prompt_or_fail "hermes -z" "$prompt_file" "$_stderr_file"); then

--- a/shell-common/functions/gh_pr_review.sh
+++ b/shell-common/functions/gh_pr_review.sh
@@ -530,30 +530,28 @@ _gh_pr_review_run_ai() {
             _agy_stream=$(printf '%s\n' "$_prompt_content" |
                 agy --print '' --input-format stream-json \
                     --output-format stream-json 2>>"$_stderr_file") || _rc=$?
-            if [ "$_rc" -eq 0 ]; then
-                # `response` is what plain `agy --print` used to write to
-                # stdout, so everything downstream (tee -> AI_OUT -> comment
-                # body) keeps seeing exactly the same review text.
-                # The exit code alone is NOT the success signal (PR #1765
-                # codex BLOCKER): the stream carries its own `result.status`,
-                # and a non-SUCCESS result that still exited 0 would post an
-                # empty review as if the lane had passed. Gate on the status
-                # and let `jq -e` turn "no SUCCESS result at all" into a
-                # failure instead of silent empty output.
-                printf '%s\n' "$_agy_stream" |
-                    jq -er 'select(.event == "result" and .result.status == "SUCCESS")
-                            | .result.response // ""' \
-                        2>>"$_stderr_file" || _rc=1
-            fi
-            if [ "$_rc" -ne 0 ]; then
-                # A non-SUCCESS run reports its cause in `result.error` on
-                # *stdout*, not stderr — without this the failure summary
-                # below would have an empty stderr file to work with.
-                printf '%s\n' "$_agy_stream" |
-                    jq -r 'select(.event == "result")
-                           | "agy result status=\(.result.status // "?"): \(.result.error // "no error reported")"' \
-                        >>"$_stderr_file" 2>&1
-            fi
+            # One jq pass over the buffered stream, not two (PR #1765 agy
+            # FOLLOW-UP): status, response and error come out of the same
+            # program. `response` is what plain `agy --print` used to write
+            # to stdout, so everything downstream (tee -> AI_OUT -> comment
+            # body) keeps seeing exactly the same review text.
+            # The exit code alone is NOT the success signal (PR #1765 codex
+            # BLOCKER): the stream carries its own `result.status`, and a
+            # non-SUCCESS result that still exited 0 would post an empty
+            # review as if the lane had passed. `halt_error` routes the
+            # non-SUCCESS cause — reported in `result.error` on *stdout*,
+            # not stderr — into $_stderr_file so the failure summary below
+            # has something to work with, and `jq -e` turns "no result event
+            # at all" into a failure instead of silent empty output.
+            # `_rc` keeps agy's own exit code when it already failed: the
+            # summary prints it verbatim as "exit $_rc".
+            printf '%s\n' "$_agy_stream" |
+                jq -er 'select(.event == "result")
+                        | if .result.status == "SUCCESS" then .result.response // ""
+                          else "agy result status=\(.result.status // "?"): \(.result.error // "no error reported")\n"
+                               | halt_error(1)
+                          end' \
+                    2>>"$_stderr_file" || { [ "$_rc" -ne 0 ] || _rc=1; }
         fi
         ;;
     claude)

--- a/shell-common/functions/gh_pr_review.sh
+++ b/shell-common/functions/gh_pr_review.sh
@@ -256,13 +256,17 @@ _gh_pr_review_require_internal_cli() {
     return 0
 }
 
-# _gh_pr_review_argv_prompt_or_fail — shared MAX_ARG_STRLEN guard for AI
-# CLIs that take the whole prompt as a value argument instead of --file or
-# stdin (agy --print, hermes -z). The kernel caps a single argv string at
-# MAX_ARG_STRLEN (32 pages = 131072 bytes on Linux) — passing an oversized
-# prompt straight through would blow past that as a bare "Argument list
-# too long" exec failure, so this guards it explicitly up front.
-# Args: $1 = CLI label for the error message (e.g. "agy --print"),
+# _gh_pr_review_argv_prompt_or_fail — MAX_ARG_STRLEN guard for AI CLIs that
+# take the whole prompt as a value argument instead of --file or stdin. The
+# kernel caps a single argv string at MAX_ARG_STRLEN (32 pages = 131072 bytes
+# on Linux) — passing an oversized prompt straight through would blow past
+# that as a bare "Argument list too long" exec failure, so this guards it
+# explicitly up front.
+# Sole remaining caller is `hermes -z` (issue #1761 moved agy onto stdin via
+# --input-format stream-json; `hermes --help` documents no equivalent — its
+# one-shot flag is `-z PROMPT` / `--oneshot PROMPT`, positional only). Revisit
+# if hermes grows a stdin path.
+# Args: $1 = CLI label for the error message (e.g. "hermes -z"),
 #       $2 = prompt_file to read, $3 = file to write an over-limit or
 #       read-error message to.
 # On success prints the prompt content on stdout and returns 0; on
@@ -452,6 +456,7 @@ _gh_pr_review_run_ai() {
     fi
     local _rc=0
     local _prompt_content
+    local _agy_stream
     local _opencode_workdir
     # Issue #1506: opencode / hermes routinely run 8-10 minutes and had no
     # bounded exit path at all. Without this the only bound is whatever
@@ -483,13 +488,46 @@ _gh_pr_review_run_ai() {
         codex exec --color=never <"$prompt_file" 2>"$_stderr_file" || _rc=$?
         ;;
     agy)
-        # `agy --print` runs the Antigravity CLI non-interactively but
-        # takes the prompt as a value argument, not stdin — guarded by
-        # _gh_pr_review_argv_prompt_or_fail (shared with the hermes case).
-        if _prompt_content=$(_gh_pr_review_argv_prompt_or_fail "agy --print" "$prompt_file" "$_stderr_file"); then
-            agy --print "$_prompt_content" 2>>"$_stderr_file" || _rc=$?
-        else
+        # Issue #1761: this used to be `agy --print "$prompt"`, which put the
+        # whole prompt in one argv value — capped by the kernel at
+        # MAX_ARG_STRLEN (131072B). A 62-file PR (131746B) tripped the guard
+        # and the lane produced no review at all. `--input-format stream-json`
+        # reads the prompt as one NDJSON message on stdin instead, so there is
+        # no argv ceiling; it requires `--output-format stream-json`, so the
+        # review text has to be lifted back out of the reply stream.
+        # Shapes below were verified against the real CLI, not just `agy --help`:
+        #   in   {"event":"user","message":{"content":"<prompt>"}}
+        #   out  {"event":"init",...}
+        #        {"event":"step_update",...}   (one per turn / tool step)
+        #        {"event":"result","result":{"status":"SUCCESS",
+        #                                    "response":"<review text>"}}
+        # `--print` still needs a value even in stream-json mode (Go's flag
+        # parser rejects a bare `--print` with "flag needs an argument"), so it
+        # is passed empty and the stdin message carries the prompt.
+        if ! _prompt_content=$(jq -Rs '{event: "user", message: {content: .}}' \
+            <"$prompt_file" 2>"$_stderr_file"); then
             _rc=1
+        else
+            # `printf` is a shell builtin, so the prompt reaches agy through a
+            # pipe and never through argv — that is the whole point of #1761.
+            _agy_stream=$(printf '%s\n' "$_prompt_content" |
+                agy --print '' --input-format stream-json \
+                    --output-format stream-json 2>>"$_stderr_file") || _rc=$?
+            if [ "$_rc" -eq 0 ]; then
+                # `response` is what plain `agy --print` used to write to
+                # stdout, so everything downstream (tee -> AI_OUT -> comment
+                # body) keeps seeing exactly the same review text.
+                printf '%s\n' "$_agy_stream" |
+                    jq -r 'select(.event == "result") | .result.response // ""' \
+                        2>>"$_stderr_file" || _rc=$?
+            else
+                # A non-SUCCESS run reports its cause in `result.error` on
+                # *stdout*, not stderr — without this the failure summary
+                # below would have an empty stderr file to work with.
+                printf '%s\n' "$_agy_stream" |
+                    jq -r 'select(.event == "result") | .result.error // empty' \
+                        >>"$_stderr_file" 2>/dev/null
+            fi
         fi
         ;;
     claude)
@@ -502,9 +540,11 @@ _gh_pr_review_run_ai() {
     hermes)
         # Confirmed against real `hermes --help` output on an internal PC
         # (issue #1452): there is no `exec` subcommand — the one-shot
-        # non-interactive flag is `-z` / `--oneshot`, and like `agy --print`
-        # it takes the prompt as a value argument rather than --file/stdin,
-        # guarded by the same _gh_pr_review_argv_prompt_or_fail helper.
+        # non-interactive flag is `-z` / `--oneshot`, and it takes the prompt
+        # as a value argument rather than --file/stdin, guarded by
+        # _gh_pr_review_argv_prompt_or_fail. Re-checked for #1761: hermes has
+        # no stdin equivalent of agy's `--input-format stream-json`, so this
+        # lane keeps the argv ceiling until it grows one.
         if ! _gh_pr_review_require_internal_cli hermes >"$_stderr_file" 2>&1; then
             _rc=1
         elif _prompt_content=$(_gh_pr_review_argv_prompt_or_fail "hermes -z" "$prompt_file" "$_stderr_file"); then

--- a/tests/bats/functions/gh_pr_review.bats
+++ b/tests/bats/functions/gh_pr_review.bats
@@ -1145,12 +1145,14 @@ EOF
     local f="$TEST_TEMP_HOME/big.txt"
     # 131746 bytes — the size observed live on the 62-file PR that produced
     # `prompt 131746B > 131072B argv limit` and no review at all.
-    head -c 131746 /dev/zero | tr '\0' 'x' >"$f"
+    local size=131746 prefix="agy reviewed: "
+    head -c "$size" /dev/zero | tr '\0' 'x' >"$f"
     run _gh_pr_review_run_ai agy "$f"
     assert_success
-    refute_output --partial "argv limit"
-    # "agy reviewed: " (14) + the full prompt — proves nothing was truncated.
-    [ "${#output}" -eq $((14 + 131746)) ]
+    # The stub's prefix + the whole prompt — proves nothing was truncated.
+    # Derived from $prefix/$size rather than hardcoded so changing either
+    # does not turn this into a bare `131760 != 131755`.
+    [ "${#output}" -eq $((${#prefix} + size)) ]
 }
 
 @test "run_ai agy: unreadable prompt file → fails, does not silently swallow the read error" {
@@ -1314,7 +1316,8 @@ EOF
 # ---------------------------------------------------------------------------
 # _gh_pr_review_run_ai — hermes transport (issue #1377, corrected in #1452:
 # hermes has no `exec` subcommand — the one-shot flag is `-z` and it takes the
-# prompt as a value argument, so it shares agy's MAX_ARG_STRLEN guard)
+# prompt as a value argument, so it is the sole user of the MAX_ARG_STRLEN
+# guard since #1761 moved agy onto stdin)
 # ---------------------------------------------------------------------------
 
 _stub_hermes_echo() {

--- a/tests/bats/functions/gh_pr_review.bats
+++ b/tests/bats/functions/gh_pr_review.bats
@@ -1097,45 +1097,60 @@ EOF
 }
 
 # ---------------------------------------------------------------------------
-# _gh_pr_review_run_ai — agy transport (issue #1244 / PR #1245 review)
+# _gh_pr_review_run_ai — agy transport (issue #1244 / PR #1245 review; moved
+# from the `--print <value>` argv path to `--input-format stream-json` on
+# stdin in issue #1761, which removed the MAX_ARG_STRLEN ceiling)
 # ---------------------------------------------------------------------------
 
-# Stub `agy` so the run_ai dispatcher can exercise the --print value-argument
-# path without invoking the real Antigravity CLI. Echoes its own argv back
-# so tests can assert on exactly what the function passed as $1.
+# Stub `agy` so the run_ai dispatcher can exercise the stream-json stdin
+# transport without invoking the real Antigravity CLI. Mirrors the real CLI's
+# NDJSON contract: reads {"event":"user","message":{"content":...}} from
+# stdin, writes an `init` line then a `result` line whose `response` echoes
+# the prompt back — so tests can prove the whole prompt round-trips. Its own
+# argv lands in $AGY_STUB_ARGV so tests can prove nothing went through argv.
 _stub_agy_echo() {
     local stub_dir="$TEST_TEMP_HOME/bin"
     mkdir -p "$stub_dir"
+    export AGY_STUB_ARGV="$TEST_TEMP_HOME/agy-argv.txt"
+    : >"$AGY_STUB_ARGV"
     cat >"$stub_dir/agy" <<'EOF'
 #!/bin/sh
-# $1 is --print; $2 is the prompt value this test asserts on.
-echo "agy called with: $2"
-exit 0
+printf '%s\n' "$*" >"$AGY_STUB_ARGV"
+printf '{"event":"init","conversation_id":"stub"}\n'
+printf '{"event":"step_update","step_update":{"state":"DONE"}}\n'
+jq -c '{event:"result",result:{status:"SUCCESS",response:("agy reviewed: " + .message.content)}}'
 EOF
     chmod +x "$stub_dir/agy"
     export PATH="$stub_dir:$PATH"
 }
 
-@test "run_ai agy: small prompt → passed as value argument, not stdin" {
+@test "run_ai agy: prompt goes to stdin as stream-json, never as an argv value" {
     _source_module
     _stub_agy_echo
     local f="$TEST_TEMP_HOME/prompt.txt"
     printf 'review this diff' >"$f"
     run _gh_pr_review_run_ai agy "$f"
     assert_success
-    assert_output --partial "agy called with: review this diff"
+    # The `result` event's `response` is what reaches the PR comment body.
+    assert_output "agy reviewed: review this diff"
+    run cat "$AGY_STUB_ARGV"
+    assert_output --partial "--input-format stream-json"
+    assert_output --partial "--output-format stream-json"
+    refute_output --partial "review this diff"
 }
 
-@test "run_ai agy: prompt at/over MAX_ARG_STRLEN (131072 bytes) → fails with clear message, agy never invoked" {
+@test "run_ai agy: prompt over MAX_ARG_STRLEN (131072 bytes) still reaches agy (#1761)" {
     _source_module
     _stub_agy_echo
     local f="$TEST_TEMP_HOME/big.txt"
-    # 131072 bytes exactly — the guard's `-ge` boundary.
-    head -c 131072 /dev/zero | tr '\0' 'x' >"$f"
+    # 131746 bytes — the size observed live on the 62-file PR that produced
+    # `prompt 131746B > 131072B argv limit` and no review at all.
+    head -c 131746 /dev/zero | tr '\0' 'x' >"$f"
     run _gh_pr_review_run_ai agy "$f"
-    assert_failure
-    assert_output --partial "over the 131072-byte argv limit"
-    refute_output --partial "agy called with"
+    assert_success
+    refute_output --partial "argv limit"
+    # "agy reviewed: " (14) + the full prompt — proves nothing was truncated.
+    [ "${#output}" -eq $((14 + 131746)) ]
 }
 
 @test "run_ai agy: unreadable prompt file → fails, does not silently swallow the read error" {
@@ -1146,8 +1161,28 @@ EOF
     chmod 000 "$f"
     run _gh_pr_review_run_ai agy "$f"
     assert_failure
-    refute_output --partial "agy called with"
+    refute_output --partial "agy reviewed"
     chmod 644 "$f" # restore so bats can clean up TEST_TEMP_HOME
+}
+
+@test "run_ai agy: stream-json ERROR result surfaces its cause (it lands on stdout, not stderr)" {
+    _source_module
+    local stub_dir="$TEST_TEMP_HOME/bin"
+    mkdir -p "$stub_dir"
+    cat >"$stub_dir/agy" <<'EOF'
+#!/bin/sh
+cat >/dev/null
+printf '{"event":"init","conversation_id":"stub"}\n'
+printf '{"event":"result","result":{"status":"ERROR","response":"","error":"model quota exhausted"}}\n'
+exit 1
+EOF
+    chmod +x "$stub_dir/agy"
+    export PATH="$stub_dir:$PATH"
+    local f="$TEST_TEMP_HOME/prompt.txt"
+    printf 'review this diff' >"$f"
+    run _gh_pr_review_run_ai agy "$f"
+    assert_failure 1
+    assert_output --partial "model quota exhausted"
 }
 
 # ---------------------------------------------------------------------------
@@ -1449,7 +1484,7 @@ _assert_slow_cli_within_bound() {
 
     run _gh_pr_review_run_ai agy "$f"
     assert_success
-    assert_output --partial "agy called with: review this diff"
+    assert_output --partial "agy reviewed: review this diff"
     # The success path still cleans the stderr file up after itself.
     [ ! -e "$fallback" ]
 }
@@ -1470,7 +1505,7 @@ _assert_slow_cli_within_bound() {
     assert_failure 1
     assert_output --partial "Could not create stderr temp file under /tmp"
     # Aborts before invoking the CLI — nothing is written through the link.
-    refute_output --partial "agy called with"
+    refute_output --partial "agy reviewed"
     [ -L "$fallback" ]
     run cat "$victim"
     assert_output "original"

--- a/tests/bats/functions/gh_pr_review.bats
+++ b/tests/bats/functions/gh_pr_review.bats
@@ -1225,6 +1225,30 @@ EOF
     assert_output --partial "model quota exhausted"
 }
 
+@test "run_ai agy: agy's own exit code survives the single-pass stream parse (#1765)" {
+    # PR #1765 agy FOLLOW-UP collapsed the two stream jq passes into one that
+    # also fails on non-SUCCESS. The failure summary prints "exit $_rc"
+    # verbatim, so that one program must not flatten agy's real exit code to
+    # a generic 1 — 3 here is distinguishable from the jq fallback.
+    _source_module
+    local stub_dir="$TEST_TEMP_HOME/bin"
+    mkdir -p "$stub_dir"
+    cat >"$stub_dir/agy" <<'EOF'
+#!/bin/sh
+cat >/dev/null
+printf '{"event":"result","result":{"status":"ERROR","error":"upstream 503"}}\n'
+exit 3
+EOF
+    chmod +x "$stub_dir/agy"
+    export PATH="$stub_dir:$PATH"
+    local f="$TEST_TEMP_HOME/prompt.txt"
+    printf 'review this diff' >"$f"
+    run _gh_pr_review_run_ai agy "$f"
+    assert_failure 3
+    assert_output --partial "(exit 3)"
+    assert_output --partial "upstream 503"
+}
+
 # ---------------------------------------------------------------------------
 # _gh_pr_review_run_ai — opencode transport (issue #1334)
 # ---------------------------------------------------------------------------

--- a/tests/bats/functions/gh_pr_review.bats
+++ b/tests/bats/functions/gh_pr_review.bats
@@ -178,6 +178,21 @@ EOF
     assert_success
 }
 
+@test "require_ai_cli: agy without jq → exit 1 naming jq, not agy (#1761 transport dep)" {
+    # PR #1765 codex BLOCKER: the stream-json lane needs jq as much as it
+    # needs agy, but preflight only knew about the CLI.
+    _source_module
+    local stub_dir="$TEST_TEMP_HOME/bin"
+    mkdir -p "$stub_dir"
+    printf '#!/bin/sh\nexit 0\n' >"$stub_dir/agy"
+    chmod +x "$stub_dir/agy"
+    # agy present, jq absent — the PATH holds the stub and nothing else.
+    PATH="$stub_dir" run _gh_pr_review_require_ai_cli agy
+    assert_failure 1
+    assert_output --partial "Required CLI 'jq' not found in PATH"
+    refute_output --partial "Required CLI 'agy'"
+}
+
 @test "require_ai_cli: opencode on non-internal PC refuses before PATH check" {
     _source_module
     _dotfiles_setup_mode() { echo external; }

--- a/tests/bats/functions/gh_pr_review.bats
+++ b/tests/bats/functions/gh_pr_review.bats
@@ -1165,6 +1165,29 @@ EOF
     chmod 644 "$f" # restore so bats can clean up TEST_TEMP_HOME
 }
 
+@test "run_ai agy: ERROR result with a ZERO exit still fails — status, not exit code, is the signal" {
+    # PR #1765 codex BLOCKER: agy exiting 0 on a non-SUCCESS stream result
+    # would have posted an empty review as a passing lane.
+    _source_module
+    local stub_dir="$TEST_TEMP_HOME/bin"
+    mkdir -p "$stub_dir"
+    cat >"$stub_dir/agy" <<'EOF'
+#!/bin/sh
+cat >/dev/null
+printf '{"event":"init","conversation_id":"stub"}\n'
+printf '{"event":"result","result":{"status":"ERROR","response":"","error":"context window exceeded"}}\n'
+exit 0
+EOF
+    chmod +x "$stub_dir/agy"
+    export PATH="$stub_dir:$PATH"
+    local f="$TEST_TEMP_HOME/prompt.txt"
+    printf 'review this diff' >"$f"
+    run _gh_pr_review_run_ai agy "$f"
+    assert_failure
+    assert_output --partial "context window exceeded"
+    assert_output --partial "status=ERROR"
+}
+
 @test "run_ai agy: stream-json ERROR result surfaces its cause (it lands on stdout, not stderr)" {
     _source_module
     local stub_dir="$TEST_TEMP_HOME/bin"


### PR DESCRIPTION
## Summary
- `gh-pr:review --ai agy` 레인이 프롬프트를 argv 값 1개로 넘겨 커널 `MAX_ARG_STRLEN`(131072B) 상한에 걸렸다. 62-file PR 에서 실제로 `prompt 131746B > 131072B argv limit` 로 막혀 그 레인이 리뷰를 아예 만들지 못했다.
- `agy --input-format stream-json` 으로 프롬프트를 stdin NDJSON 으로 넘겨 argv 천장을 제거했다. 이 플래그가 `--output-format stream-json` 을 강제하므로 결과 파싱도 함께 바꿨다.
- `hermes -z` 는 stdin 등가물이 없어 그대로 두고, `_gh_pr_review_argv_prompt_or_fail` 은 hermes 전용 가드로 남는다.

## Changes
- `shell-common/functions/gh_pr_review.sh`
  - `_gh_pr_review_run_ai` 의 `agy` 분기를 `jq -Rs` 로 만든 NDJSON 1줄을 stdin 으로 흘리는 방식으로 교체. `--print` 는 stream-json 모드에서도 값이 필요해(Go flag 가 bare `--print` 를 거부) 빈 문자열로 넘긴다.
  - 응답은 최종 `result` 이벤트의 `response` 에서 뽑는다 — 기존 `agy --print` 가 stdout 에 쓰던 텍스트와 동일해서 `tee -> AI_OUT -> 코멘트 본문` 하류는 무변경이다.
  - 비-SUCCESS 는 원인을 stderr 가 아니라 stdout 의 `result.error` 에 싣기 때문에, 실패 요약이 빈 stderr 를 보지 않도록 stderr 파일로 옮겨 붙인다.
  - `_gh_pr_review_argv_prompt_or_fail` / hermes 분기의 주석을 실제 상태(agy 는 stdin, hermes 만 argv)로 정정.
- `tests/bats/functions/gh_pr_review.bats`
  - `agy` 스텁을 stream-json 계약대로 재작성(stdin NDJSON 을 읽어 `init` + `result` 를 출력, 자기 argv 를 파일로 기록).
  - 131746B 프롬프트가 잘림 없이 agy 에 도달하는지, 일반 프롬프트가 같은 리뷰 텍스트로 왕복하는지, argv 에는 프롬프트가 실리지 않는지 검증.
  - `result.status=ERROR` 원인이 실패 요약에 드러나는지 검증하는 케이스 추가.

## 실제 CLI 로 확인한 NDJSON 계약
help 문구가 아니라 `agy` 를 직접 왕복시켜 확인했다.

```
in   {"event":"user","message":{"content":"<prompt>"}}
out  {"event":"init","conversation_id":"...","init":{...}}
     {"event":"step_update","step_update":{...}}      # turn / tool step 마다
     {"event":"result","result":{"status":"SUCCESS","response":"<review text>",...}}
```

- `--print` 를 플래그 뒤에 두면 `flag needs an argument: -print`, 앞에 두고 값을 안 주면 `--print took "--input-format" as its prompt` 로 실패한다 → 빈 값 명시가 필요.
- 입력이 `{"type":...}`(Claude Code 형식)이면 `stream input message is missing the "event" field`, `message` 가 문자열이면 `cannot unmarshal string into ... streamInputUserMessage` 로 거절된다.

## Test plan
- [x] `./tests/bats/lib/bats-core/bin/bats tests/bats/functions/gh_pr_review.bats` — 76/76 통과
- [x] `./tests/bats/lib/bats-core/bin/bats tests/bats/functions/devx_pr_review_all*.bats` — 149/149 통과
- [x] `shellcheck -x -e SC1090,SC1091 shell-common/functions/gh_pr_review.sh` — 통과
- [x] 실제 `agy` 로 `_gh_pr_review_run_ai agy <prompt_file>` 직접 실행 → 응답 텍스트만 stdout 에 나오고 rc=0
- [x] `tests/bats/skills` 의 기존 실패 35건은 이 변경 전후 동일(무관)

## Related
Closes #1761

### Follow-up (별건)
`gh-pr-skills` / `gh-verify-skills` 에 있는 이 파일의 vendored 복사본은 이 PR 머지 후 재-vendoring 이 필요하다. 별도 후속 작업으로 처리한다.

---
<details>
<summary>🤖 AI Metrics · 📊 ~4000 tokens · 👤 ~2 h · 🤖 ~9 min</summary>

<!-- ai-metrics:gh-pr -->
📊 ~4000 tokens · 👤 ~2 h · 🤖 ~9 min
<!-- /ai-metrics:gh-pr -->

</details>
