### PR TITLE
fix(gh-pr-review): opencode --file 프롬프트를 --dir 안으로 복사

### DIFF
--- a/shell-common/functions/gh_pr_review.sh
+++ b/shell-common/functions/gh_pr_review.sh
@@ -453,6 +453,7 @@ _gh_pr_review_run_ai() {
     local _rc=0
     local _prompt_content
     local _opencode_workdir
+    local _opencode_prompt
     # Issue #1506: opencode / hermes routinely run 8-10 minutes and had no
     # bounded exit path at all. Without this the only bound is whatever
     # ambient timeout the *caller* (a Bash tool call, a CI step) happens to
@@ -524,11 +525,21 @@ _gh_pr_review_run_ai() {
             }
         fi
         if [ "$_rc" -eq 0 ]; then
+            # opencode-guard auto-rejects, in non-interactive mode, any
+            # --file path outside --dir (issue #1763) — PROMPT_FILE always
+            # lives in a sibling /tmp dir, never under $_opencode_workdir, so
+            # copy it in first and point --file at the copy.
+            _opencode_prompt="$_opencode_workdir/prompt.md"
+            if ! cp "$prompt_file" "$_opencode_prompt" 2>"$_stderr_file"; then
+                _rc=1
+            fi
+        fi
+        if [ "$_rc" -eq 0 ]; then
             _gh_pr_review_timeout "$_slow_cli_timeout_sec" \
                 opencode run "$_ai_file_instruction" \
                 --model codemate/CodeLLMPro \
                 --dir "$_opencode_workdir" \
-                --file "$prompt_file" 2>"$_stderr_file" || _rc=$?
+                --file "$_opencode_prompt" 2>"$_stderr_file" || _rc=$?
         fi
         [ -n "$_opencode_workdir" ] && rm -rf "$_opencode_workdir"
         ;;

--- a/tests/bats/functions/gh_pr_review.bats
+++ b/tests/bats/functions/gh_pr_review.bats
@@ -1182,7 +1182,45 @@ EOF
     assert_output --partial "opencode args: [run]"
     assert_output --partial "[--model] [codemate/CodeLLMPro]"
     assert_output --partial "[--dir]"
-    assert_output --partial "[--file] [$f]"
+    refute_output --partial "[--file] [$f]"
+}
+
+@test "run_ai opencode: --file prompt path lives inside --dir (issue #1763)" {
+    # opencode-guard rejects, in non-interactive mode, any --file path
+    # outside --dir. Passing the original $prompt_file (always under
+    # /tmp/gh-pr-review-prompt.*, a sibling of --dir's own /tmp/gh-pr-
+    # review-opencode.* directory) makes opencode unable to read its own
+    # prompt and return empty output every time.
+    _source_module
+    _dotfiles_setup_mode() { echo internal; }
+    local stub_dir="$TEST_TEMP_HOME/bin"
+    mkdir -p "$stub_dir"
+    cat >"$stub_dir/opencode" <<'EOF'
+#!/bin/sh
+dir="" file="" prev=""
+for arg in "$@"; do
+    case "$prev" in
+    --dir) dir="$arg" ;;
+    --file) file="$arg" ;;
+    esac
+    prev="$arg"
+done
+printf 'dir=%s\n' "$dir"
+printf 'file=%s\n' "$file"
+case "$file" in
+"$dir"/*) cat "$file" ;;
+*) echo "REFUSED: file outside dir" >&2; exit 1 ;;
+esac
+EOF
+    chmod +x "$stub_dir/opencode"
+    export PATH="$stub_dir:$PATH"
+    local f="$TEST_TEMP_HOME/prompt.txt"
+    printf 'review this diff' >"$f"
+
+    run _gh_pr_review_run_ai opencode "$f"
+    assert_success
+    assert_output --partial "review this diff"
+    refute_output --partial "REFUSED"
 }
 
 @test "run_ai opencode: non-internal mode refuses without invoking opencode" {


### PR DESCRIPTION
## Summary
- `gh-pr-review --ai opencode`가 opencode-guard의 non-interactive 파일 접근 거부로 인해 항상 빈 리뷰로 끝나던 결함 수정

## Changes
- `shell-common/functions/gh_pr_review.sh`: `_gh_pr_review_run_ai()`의 opencode 분기에서 `--dir`(sandbox 루트) 밖에 있던 `PROMPT_FILE`을 `--file`로 그대로 넘기던 것을, `$_opencode_workdir` 안으로 복사한 뒤 그 경로를 `--file`에 넘기도록 수정
- `tests/bats/functions/gh_pr_review.bats`: opencode `--file` 인자가 원본 prompt 경로가 아님을 확인하도록 기존 테스트를 갱신하고, `--file` 경로가 실제로 `--dir` 안에 있어야 함을 검증하는 회귀 테스트 추가 (issue #1763)

## Test plan
- [x] `./tests/bats/lib/bats-core/bin/bats tests/bats/functions/gh_pr_review.bats` — 76/76 통과
- [x] `shellcheck shell-common/functions/gh_pr_review.sh` — clean
- [x] `./tests/test` (bats + pytest + golden rules 전체) — 통과

## Related
Closes #1763

---
<details>
<summary>🤖 AI Metrics · 📊 ~2000 tokens · 👤 ~2 h · 🤖 ~0 min</summary>

<!-- ai-metrics:gh-pr -->
📊 ~2000 tokens · 👤 ~2 h · 🤖 ~0 min
<!-- /ai-metrics:gh-pr -->

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Gp2TauS9KyZ8UvR4BRUbH4
