### PR TITLE
fix(agy-print): 값 없는 후행 --print 로 stdin 을 먹이던 두 호출부를 stream-json 으로 전환

### DIFF
--- a/shell-common/functions/agy_run.sh
+++ b/shell-common/functions/agy_run.sh
@@ -1,0 +1,67 @@
+#!/bin/sh
+# shellcheck shell=bash
+# shell-common/functions/agy_run.sh
+# SSOT for the agy (Antigravity CLI) non-interactive transport.
+#
+# Why this exists: the same 15 lines were hand-copied into three call sites
+# (gh_pr_review.sh, ai_usage.sh, claude_plugins_docs_ko.sh) and had already
+# started to drift — one had a `jq` preflight, the others didn't. The shapes
+# below were verified against the real CLI, not just `agy --help`:
+#   in   {"event":"user","message":{"content":"<prompt>"}}
+#   out  {"event":"init",...}
+#        {"event":"step_update",...}   (one per turn / tool step)
+#        {"event":"result","result":{"status":"SUCCESS","response":"<text>"}}
+#
+# Two flag facts that cost two bugs to learn, so they live here now:
+#  - `agy --print "$prompt"` puts the whole prompt in one argv value, capped
+#    by the kernel at MAX_ARG_STRLEN (131072B). Issue #1761: a 62-file PR
+#    (131746B) tripped it and produced no review at all.
+#  - `--print` still needs a value even in stream-json mode (Go's flag parser
+#    rejects a bare `--print` with "flag needs an argument"). Issue #1767: a
+#    bare trailing `--print` meant the prompt piped on stdin was never read.
+#    So it is passed empty and the stdin message carries the prompt.
+
+case $- in *i*) ;; *) [ -n "${DOTFILES_FORCE_INIT-}" ] || return 0 ;; esac
+
+# Run agy with the prompt on stdin; print its response text on stdout.
+#
+# Args: any extra agy flags (e.g. --dangerously-skip-permissions).
+# Stdin: the raw prompt text. Stdout: `.result.response` — byte-identical to
+# what plain `agy --print <prompt>` used to write, so callers that tee it into
+# a file or a comment body need no other change. Stderr is left alone for the
+# caller to redirect. Returns agy's own exit code, or 1 when the stream
+# carried no SUCCESS result (the exit code alone is NOT the success signal —
+# a non-SUCCESS result that still exited 0 would otherwise look like a pass).
+_agy_run_stream() {
+    # Named here rather than reported as a mysterious `jq: command not found`
+    # attributed to agy (PR #1765 codex BLOCKER).
+    command -v jq >/dev/null 2>&1 || {
+        printf "Required CLI 'jq' not found in PATH (agy needs it for the stream-json transport)\n" >&2
+        return 1
+    }
+
+    local _msg _stream _ec
+    # Fail closed: an unreadable prompt (or a jq failure) must not reach agy
+    # as empty stdin and come back looking like a successful empty review.
+    _msg=$(jq -Rs '{event: "user", message: {content: .}}') || return 1
+    # `printf` is a shell builtin, so the prompt reaches agy through a pipe
+    # and never through argv — that is the whole point of #1761.
+    _stream=$(printf '%s\n' "$_msg" |
+        agy "$@" --print '' --input-format stream-json --output-format stream-json)
+    _ec=$?
+    # One jq pass over the buffered stream, not two (PR #1765 agy FOLLOW-UP):
+    # status, response and error come out of the same program. `halt_error`
+    # routes the non-SUCCESS cause — reported in `result.error` on *stdout*,
+    # not stderr — to stderr so a caller capturing it has something to show,
+    # and `jq -e` turns "no result event at all" into a failure instead of
+    # silent empty output. Buffering into `_stream` is what makes agy's own
+    # exit code recoverable: POSIX has no PIPESTATUS, so mid-pipeline agy
+    # would lose it, and the caller logs/prints that code verbatim.
+    printf '%s\n' "$_stream" |
+        jq -er 'select(.event == "result")
+                | if .result.status == "SUCCESS" then .result.response // ""
+                  else "agy result status=\(.result.status // "?"): \(.result.error // "no error reported")\n"
+                       | halt_error(1)
+                  end' || [ "$_ec" -ne 0 ] || _ec=1
+    return $_ec
+}

--- a/shell-common/functions/ai_usage.sh
+++ b/shell-common/functions/ai_usage.sh
@@ -351,23 +351,16 @@ _ai_usage_run() {
         # rather than silently reporting 0 tokens. Usage/cost tracking for
         # agy is a follow-up issue once its output format is investigated.
         #
-        # Issue #1767: a bare trailing `--print` needs a value (Go's flag
-        # parser rejects it with "flag needs an argument: -print"), so the
-        # prompt piped on stdin was never read. Same fix gh_pr_review.sh
-        # applied (#1761/#1765): send the prompt as stream-json and pull the
-        # human-readable text back out of `.result.response`.
-        local _agy_stream
-        _agy_stream=$(printf '%s\n' "$_prompt" |
-            jq -Rs '{event: "user", message: {content: .}}' |
-            agy --dangerously-skip-permissions --print '' \
-                --input-format stream-json --output-format stream-json)
+        # Issue #1767: a bare trailing `--print` needs a value, so the prompt
+        # piped on stdin was never read. The transport (and the reason for
+        # every flag) is `_agy_run_stream` — see functions/agy_run.sh.
+        # Auto-sourced with the rest of functions/ in a real shell; the
+        # explicit source is for standalone `. ai_usage.sh` (bats, skills).
+        # shellcheck disable=SC1090
+        command -v _agy_run_stream >/dev/null 2>&1 ||
+            . "${SHELL_COMMON:-$HOME/dotfiles/shell-common}/functions/agy_run.sh"
+        printf '%s\n' "$_prompt" | _agy_run_stream --dangerously-skip-permissions
         _ec=$?
-        printf '%s\n' "$_agy_stream" |
-            jq -er 'select(.event == "result")
-                    | if .result.status == "SUCCESS" then .result.response // ""
-                      else "agy result status=\(.result.status // "?"): \(.result.error // "no error reported")\n"
-                           | halt_error(1)
-                      end' || { [ "$_ec" -ne 0 ] || _ec=1; }
         printf '{"ai":"agy","ts":"%s","label":%s,"exit_code":%d,"tracking":"unsupported"}\n' \
             "$_now" \
             "$(printf '%s' "$_label" | jq -Rsc . 2>/dev/null || printf '"%s"' "$_label")" \

--- a/shell-common/functions/ai_usage.sh
+++ b/shell-common/functions/ai_usage.sh
@@ -350,8 +350,24 @@ _ai_usage_run() {
         # graceful-degradation shape as the cli_failed records above —
         # rather than silently reporting 0 tokens. Usage/cost tracking for
         # agy is a follow-up issue once its output format is investigated.
-        printf '%s\n' "$_prompt" | agy --dangerously-skip-permissions --print
+        #
+        # Issue #1767: a bare trailing `--print` needs a value (Go's flag
+        # parser rejects it with "flag needs an argument: -print"), so the
+        # prompt piped on stdin was never read. Same fix gh_pr_review.sh
+        # applied (#1761/#1765): send the prompt as stream-json and pull the
+        # human-readable text back out of `.result.response`.
+        local _agy_stream
+        _agy_stream=$(printf '%s\n' "$_prompt" |
+            jq -Rs '{event: "user", message: {content: .}}' |
+            agy --dangerously-skip-permissions --print '' \
+                --input-format stream-json --output-format stream-json)
         _ec=$?
+        printf '%s\n' "$_agy_stream" |
+            jq -er 'select(.event == "result")
+                    | if .result.status == "SUCCESS" then .result.response // ""
+                      else "agy result status=\(.result.status // "?"): \(.result.error // "no error reported")\n"
+                           | halt_error(1)
+                      end' || { [ "$_ec" -ne 0 ] || _ec=1; }
         printf '{"ai":"agy","ts":"%s","label":%s,"exit_code":%d,"tracking":"unsupported"}\n' \
             "$_now" \
             "$(printf '%s' "$_label" | jq -Rsc . 2>/dev/null || printf '"%s"' "$_label")" \

--- a/shell-common/functions/claude_plugins_docs_ko.sh
+++ b/shell-common/functions/claude_plugins_docs_ko.sh
@@ -57,7 +57,7 @@ generate_plugin_doc_ko() {
 
         ux_section "Available AI Tools"
         ux_bullet "claude (default) - Anthropic Claude (uses -p flag)"
-        ux_bullet "agy - Antigravity CLI (uses --print flag)"
+        ux_bullet "agy - Antigravity CLI (stream-json on stdin)"
         ux_bullet "codex - Codex CLI (uses 'exec' subcommand)"
         ux_bullet "Other tools - Any CLI tool that accepts -p, --prompt, exec, or positional argument"
 
@@ -136,22 +136,17 @@ generate_plugin_doc_ko() {
         rc=$?
         ;;
     agy)
-        # Issue #1767: a bare trailing `--print` needs a value (Go's flag
-        # parser rejects it with "flag needs an argument: -print") — the
-        # prompt piped on stdin was never actually read. Same fix as
-        # gh_pr_review.sh (#1761/#1765): send the prompt as stream-json and
-        # pull the response back out of `.result.response`.
-        local _agy_stream
-        _agy_stream=$(_generate_plugin_doc_ko_prompt "$plugin_file" |
-            jq -Rs '{event: "user", message: {content: .}}' |
-            "$ai_tool" --print '' --input-format stream-json --output-format stream-json)
+        # Issue #1767: a bare trailing `--print` needs a value, so the prompt
+        # piped on stdin was never actually read. The transport (and the
+        # reason for every flag) is `_agy_run_stream` — see agy_run.sh.
+        # Stderr stays on the terminal rather than being merged into
+        # $output_file: the failure path below deletes that file, so a
+        # diagnostic written into it would never be seen.
+        # shellcheck disable=SC1090
+        command -v _agy_run_stream >/dev/null 2>&1 ||
+            . "${SHELL_COMMON:-$HOME/dotfiles/shell-common}/functions/agy_run.sh"
+        _generate_plugin_doc_ko_prompt "$plugin_file" | _agy_run_stream >"$output_file"
         rc=$?
-        printf '%s\n' "$_agy_stream" |
-            jq -er 'select(.event == "result")
-                    | if .result.status == "SUCCESS" then .result.response // ""
-                      else "agy result status=\(.result.status // "?"): \(.result.error // "no error reported")\n"
-                           | halt_error(1)
-                      end' >"$output_file" 2>&1 || { [ "$rc" -ne 0 ] || rc=1; }
         ;;
     codex)
         # Codex uses 'exec' subcommand for non-interactive execution
@@ -463,7 +458,7 @@ create_plugin_structure_ko() {
 
         ux_section "Available AI Tools"
         ux_bullet "claude (default) - Anthropic Claude (uses -p flag)"
-        ux_bullet "agy - Antigravity CLI (uses --print flag)"
+        ux_bullet "agy - Antigravity CLI (stream-json on stdin)"
         ux_bullet "codex - Codex CLI (uses 'exec' subcommand)"
         ux_bullet "Other tools - Any CLI tool that accepts -p, --prompt, exec, or positional argument"
 

--- a/shell-common/functions/claude_plugins_docs_ko.sh
+++ b/shell-common/functions/claude_plugins_docs_ko.sh
@@ -136,9 +136,22 @@ generate_plugin_doc_ko() {
         rc=$?
         ;;
     agy)
-        # agy reads the prompt from stdin under --print
-        _generate_plugin_doc_ko_prompt "$plugin_file" | "$ai_tool" --print >"$output_file" 2>&1
+        # Issue #1767: a bare trailing `--print` needs a value (Go's flag
+        # parser rejects it with "flag needs an argument: -print") — the
+        # prompt piped on stdin was never actually read. Same fix as
+        # gh_pr_review.sh (#1761/#1765): send the prompt as stream-json and
+        # pull the response back out of `.result.response`.
+        local _agy_stream
+        _agy_stream=$(_generate_plugin_doc_ko_prompt "$plugin_file" |
+            jq -Rs '{event: "user", message: {content: .}}' |
+            "$ai_tool" --print '' --input-format stream-json --output-format stream-json)
         rc=$?
+        printf '%s\n' "$_agy_stream" |
+            jq -er 'select(.event == "result")
+                    | if .result.status == "SUCCESS" then .result.response // ""
+                      else "agy result status=\(.result.status // "?"): \(.result.error // "no error reported")\n"
+                           | halt_error(1)
+                      end' >"$output_file" 2>&1 || { [ "$rc" -ne 0 ] || rc=1; }
         ;;
     codex)
         # Codex uses 'exec' subcommand for non-interactive execution

--- a/shell-common/functions/gh_pr_review.sh
+++ b/shell-common/functions/gh_pr_review.sh
@@ -469,7 +469,6 @@ _gh_pr_review_run_ai() {
     fi
     local _rc=0
     local _prompt_content
-    local _agy_stream
     local _opencode_workdir
     local _opencode_prompt
     # Issue #1506: opencode / hermes routinely run 8-10 minutes and had no
@@ -502,58 +501,24 @@ _gh_pr_review_run_ai() {
         codex exec --color=never <"$prompt_file" 2>"$_stderr_file" || _rc=$?
         ;;
     agy)
-        # Issue #1761: this used to be `agy --print "$prompt"`, which put the
-        # whole prompt in one argv value — capped by the kernel at
-        # MAX_ARG_STRLEN (131072B). A 62-file PR (131746B) tripped the guard
-        # and the lane produced no review at all. `--input-format stream-json`
-        # reads the prompt as one NDJSON message on stdin instead, so there is
-        # no argv ceiling; it requires `--output-format stream-json`, so the
-        # review text has to be lifted back out of the reply stream.
-        # Shapes below were verified against the real CLI, not just `agy --help`:
-        #   in   {"event":"user","message":{"content":"<prompt>"}}
-        #   out  {"event":"init",...}
-        #        {"event":"step_update",...}   (one per turn / tool step)
-        #        {"event":"result","result":{"status":"SUCCESS",
-        #                                    "response":"<review text>"}}
-        # `--print` still needs a value even in stream-json mode (Go's flag
-        # parser rejects a bare `--print` with "flag needs an argument"), so it
-        # is passed empty and the stdin message carries the prompt.
+        # Transport (stream-json on stdin, and the reason for every flag)
+        # lives in functions/agy_run.sh — issues #1761 and #1767 both came
+        # from this being hand-copied per call site. `response` is what plain
+        # `agy --print` used to write to stdout, so everything downstream
+        # (tee -> AI_OUT -> comment body) sees the same review text, and the
+        # helper returns agy's own exit code, which the summary prints
+        # verbatim as "exit $_rc".
+        #
         # `2>` before `<` is deliberate: redirections apply left to right, so
         # with `<` first an unreadable $prompt_file is reported before stderr
         # is redirected and the summary below gets "<no stderr>" (bash; zsh
         # reports to the original stderr either way). Do not reorder.
-        if ! _prompt_content=$(jq -Rs '{event: "user", message: {content: .}}' \
-            2>"$_stderr_file" <"$prompt_file"); then
-            _rc=1
-        else
-            # `printf` is a shell builtin, so the prompt reaches agy through a
-            # pipe and never through argv — that is the whole point of #1761.
-            _agy_stream=$(printf '%s\n' "$_prompt_content" |
-                agy --print '' --input-format stream-json \
-                    --output-format stream-json 2>>"$_stderr_file") || _rc=$?
-            # One jq pass over the buffered stream, not two (PR #1765 agy
-            # FOLLOW-UP): status, response and error come out of the same
-            # program. `response` is what plain `agy --print` used to write
-            # to stdout, so everything downstream (tee -> AI_OUT -> comment
-            # body) keeps seeing exactly the same review text.
-            # The exit code alone is NOT the success signal (PR #1765 codex
-            # BLOCKER): the stream carries its own `result.status`, and a
-            # non-SUCCESS result that still exited 0 would post an empty
-            # review as if the lane had passed. `halt_error` routes the
-            # non-SUCCESS cause — reported in `result.error` on *stdout*,
-            # not stderr — into $_stderr_file so the failure summary below
-            # has something to work with, and `jq -e` turns "no result event
-            # at all" into a failure instead of silent empty output.
-            # `_rc` keeps agy's own exit code when it already failed: the
-            # summary prints it verbatim as "exit $_rc".
-            printf '%s\n' "$_agy_stream" |
-                jq -er 'select(.event == "result")
-                        | if .result.status == "SUCCESS" then .result.response // ""
-                          else "agy result status=\(.result.status // "?"): \(.result.error // "no error reported")\n"
-                               | halt_error(1)
-                          end' \
-                    2>>"$_stderr_file" || { [ "$_rc" -ne 0 ] || _rc=1; }
-        fi
+        # Auto-sourced with the rest of functions/ in a real shell; the
+        # explicit source is for standalone `. gh_pr_review.sh` (skills, bats).
+        # shellcheck disable=SC1090
+        command -v _agy_run_stream >/dev/null 2>&1 ||
+            . "${SHELL_COMMON:-$HOME/dotfiles/shell-common}/functions/agy_run.sh"
+        _agy_run_stream 2>>"$_stderr_file" <"$prompt_file" || _rc=$?
         ;;
     claude)
         if [ -n "$cfg_dir" ]; then

--- a/tests/bats/functions/ai_usage.bats
+++ b/tests/bats/functions/ai_usage.bats
@@ -321,9 +321,8 @@ _setup_agy_stub() {
     cat >"$STUB_BIN/agy" <<'STUB'
 #!/usr/bin/env bash
 printf 'agy-stub: args=%s\n' "$*" >&2
-prompt=$(cat | jq -r '.message.content')
 printf '{"event":"init"}\n'
-printf '%s' "$prompt" | jq -Rs '{event: "result", result: {status: "SUCCESS", response: .}}'
+jq -c '{event: "result", result: {status: "SUCCESS", response: .message.content}}'
 exit "${AGY_STUB_EXIT:-0}"
 STUB
     chmod +x "$STUB_BIN/agy"

--- a/tests/bats/functions/ai_usage.bats
+++ b/tests/bats/functions/ai_usage.bats
@@ -311,20 +311,25 @@ _usage_record_count() {
 # minimal untracked record is appended — not full usage parsing.
 # ---------------------------------------------------------------------------
 
-# Stub agy — echoes its argv and copies stdin to stdout so a test can
-# assert on the exact invocation shape, then exits with $AGY_STUB_EXIT
-# (default 0).
+# Stub agy — echoes its argv on stderr (so it survives past the stream-json
+# capture below) and, on stdin, expects the {event:"user",...} NDJSON
+# message #1767 introduced; it echoes the prompt back inside a
+# {event:"result", result:{status:"SUCCESS", response: <prompt>}} line so a
+# test can assert the prompt actually reached agy via stdin, not argv. Exits
+# with $AGY_STUB_EXIT (default 0).
 _setup_agy_stub() {
     cat >"$STUB_BIN/agy" <<'STUB'
 #!/usr/bin/env bash
-printf 'agy-stub: args=%s\n' "$*"
-cat
+printf 'agy-stub: args=%s\n' "$*" >&2
+prompt=$(cat | jq -r '.message.content')
+printf '{"event":"init"}\n'
+printf '%s' "$prompt" | jq -Rs '{event: "result", result: {status: "SUCCESS", response: .}}'
 exit "${AGY_STUB_EXIT:-0}"
 STUB
     chmod +x "$STUB_BIN/agy"
 }
 
-@test "agy: invoked with --dangerously-skip-permissions --print and prompt on stdin" {
+@test "agy: prompt reaches agy via stream-json stdin, not a bare trailing --print (issue #1767)" {
     _setup_agy_stub
 
     run bash --noprofile --norc -c "
@@ -342,6 +347,7 @@ STUB
 
     assert_output --partial "rc=0"
     assert_output --partial "agy-stub: args=--dangerously-skip-permissions --print"
+    assert_output --partial "--input-format stream-json --output-format stream-json"
     assert_output --partial "hello agy"
     [ "$(jq -r '.ai' "$USAGE_LOG")" = "agy" ]
     [ "$(jq -r '.tracking' "$USAGE_LOG")" = "unsupported" ]

--- a/tests/bats/functions/ai_usage.bats
+++ b/tests/bats/functions/ai_usage.bats
@@ -353,6 +353,40 @@ STUB
     [ "$(jq -r '.exit_code' "$USAGE_LOG")" = "0" ]
 }
 
+# Stub agy that exits 0 but reports a non-SUCCESS result — the exact shape
+# PR #1765 codex BLOCKER warned a bare exit-code check would misreport as a
+# pass (PR #1769 codex BLOCKER: this path was untested for the ai_usage.sh
+# call site specifically).
+_setup_agy_stub_error_status() {
+    cat >"$STUB_BIN/agy" <<'STUB'
+#!/usr/bin/env bash
+printf '{"event":"init"}\n'
+printf '{"event":"result","result":{"status":"ERROR","error":"stub failure"}}\n'
+exit 0
+STUB
+    chmod +x "$STUB_BIN/agy"
+}
+
+@test "agy: ERROR result with a ZERO exit still fails (issue #1769 codex BLOCKER)" {
+    _setup_agy_stub_error_status
+
+    run bash --noprofile --norc -c "
+        export DOTFILES_ROOT='${DOTFILES_ROOT}'
+        export SHELL_COMMON='${SHELL_COMMON}'
+        export DOTFILES_FORCE_INIT=1
+        export DOTFILES_TEST_MODE=1
+        export HOME='${HOME}'
+        export TERM=dumb
+        export PATH='${STUB_BIN}:/usr/bin:/bin'
+        . '${DOTFILES_ROOT}/shell-common/functions/ai_usage.sh'
+        _ai_usage_run agy '${USAGE_LOG}' 'test-label' 'hello agy'
+        echo \"rc=\$?\"
+    "
+
+    refute_output --partial "rc=0"
+    [ "$(jq -r '.exit_code' "$USAGE_LOG")" != "0" ]
+}
+
 @test "agy: non-zero exit propagates and is recorded" {
     _setup_agy_stub
 

--- a/tests/bats/functions/claude_plugins_docs_ko.bats
+++ b/tests/bats/functions/claude_plugins_docs_ko.bats
@@ -1,0 +1,80 @@
+#!/usr/bin/env bats
+# tests/bats/functions/claude_plugins_docs_ko.bats
+# Coverage for generate_plugin_doc_ko's agy branch (issue #1767, #1769 codex
+# BLOCKER: this call site had no regression coverage for the stream-json
+# transport at all).
+
+load '../test_helper'
+
+setup() {
+    setup_isolated_home
+    STUB_BIN="$TEST_TEMP_HOME/stub-bin"
+    mkdir -p "$STUB_BIN"
+    PLUGIN_FILE="$TEST_TEMP_HOME/plugin.md"
+    OUTPUT_FILE="$TEST_TEMP_HOME/out_KO.md"
+    printf '# A Plugin\n\nDoes a thing.\n' >"$PLUGIN_FILE"
+}
+
+teardown() {
+    teardown_isolated_home
+}
+
+# Stub agy speaking the stream-json protocol: reads the {event:"user",...}
+# NDJSON message on stdin, writes a diagnostic line to STDERR (the exact
+# channel the pre-fix code merged into $output_file via `2>&1`), then the
+# result event on stdout.
+_stub_agy_success() {
+    cat >"$STUB_BIN/agy" <<'STUB'
+#!/usr/bin/env bash
+printf 'agy-stub: diagnostic noise on stderr\n' >&2
+jq -Rs '{event: "result", result: {status: "SUCCESS", response: "한국어 요약 결과"}}' </dev/null
+exit 0
+STUB
+    chmod +x "$STUB_BIN/agy"
+}
+
+_stub_agy_error_status() {
+    cat >"$STUB_BIN/agy" <<'STUB'
+#!/usr/bin/env bash
+printf 'agy-stub: diagnostic noise on stderr\n' >&2
+printf '{"event":"result","result":{"status":"ERROR","error":"stub failure"}}\n'
+exit 0
+STUB
+    chmod +x "$STUB_BIN/agy"
+}
+
+_run_generate() {
+    run bash --noprofile --norc -c "
+        export DOTFILES_ROOT='${DOTFILES_ROOT}'
+        export SHELL_COMMON='${SHELL_COMMON}'
+        export DOTFILES_FORCE_INIT=1
+        export DOTFILES_TEST_MODE=1
+        export HOME='${HOME}'
+        export TERM=dumb
+        export PATH='${STUB_BIN}:/usr/bin:/bin'
+        . '${DOTFILES_ROOT}/shell-common/tools/ux_lib/ux_lib.sh'
+        . '${DOTFILES_ROOT}/shell-common/functions/claude_plugins_docs_ko.sh'
+        generate_plugin_doc_ko '${PLUGIN_FILE}' '${OUTPUT_FILE}' agy
+        echo \"rc=\$?\"
+    "
+}
+
+@test "generate_plugin_doc_ko agy: output file holds the response text only, no stderr noise (issue #1769 agy BLOCKER)" {
+    _stub_agy_success
+
+    _run_generate
+
+    assert_output --partial "rc=0"
+    [ -f "$OUTPUT_FILE" ]
+    grep -q "한국어 요약 결과" "$OUTPUT_FILE"
+    ! grep -q "diagnostic noise" "$OUTPUT_FILE"
+}
+
+@test "generate_plugin_doc_ko agy: non-SUCCESS result fails and removes the output file" {
+    _stub_agy_error_status
+
+    _run_generate
+
+    refute_output --partial "rc=0"
+    [ ! -f "$OUTPUT_FILE" ]
+}


### PR DESCRIPTION
## Summary
- `agy --print`가 값을 요구하는 플래그라 값 없이 끝에 두면 Go 플래그 파서가 즉시 죽어, stdin으로 흘린 프롬프트가 애초에 읽히지 않는 문제를 두 호출부에서 고쳤다.

## Changes
- `ai_usage.sh`: agy 분기를 `--print '' --input-format stream-json --output-format stream-json`로 전환하고 `.result.status`가 `SUCCESS`일 때만 `.result.response`를 뽑아 출력하도록 변경 (PR #1765 gh_pr_review.sh와 동일 패턴).
- `claude_plugins_docs_ko.sh`: 동일한 stream-json 패턴 적용, 사실과 다른 "agy reads the prompt from stdin under --print" 주석 정정.
- `tests/bats/functions/ai_usage.bats`: agy 스텁을 stream-json 프로토콜(user 이벤트 입력 → result 이벤트 출력)에 맞게 재작성.
- `skill_loader.sh:43`의 `agy --print "$(cat …)"` help 문구는 값 인자 형태라 문법상 유효해 변경하지 않음(대형 파일에서는 여전히 argv 상한선에 걸림).

## Test plan
- [x] `./tests/bats/lib/bats-core/bin/bats tests/bats/functions/ai_usage.bats` — 19/19 통과
- [x] `./tests/bats/lib/bats-core/bin/bats tests/bats/functions/gh_pr_review.bats` — 회귀 없음 확인

## Related
Closes #1767

---
<details>
<summary>🤖 AI Metrics · 📊 ~1000 tokens · 👤 ~2 h · 🤖 ~9 min</summary>

<!-- ai-metrics:gh-pr -->
📊 ~1000 tokens · 👤 ~2 h · 🤖 ~9 min
<!-- /ai-metrics:gh-pr -->

</details>
