### PR TITLE
docs(ssot): external PC Obsidian vault WSL 단일 클론 통합 기록

### DIFF
--- a/docs/.ssot/pc-environment.md
+++ b/docs/.ssot/pc-environment.md
@@ -16,7 +16,7 @@
 | 모드 | 대수 | 사양 / LLM | 네트워크 | 비고 |
 |------|------|-----------|----------|------|
 | `internal` | 2 | 1대만 사내 local LLM 연동 가능 | 사내망 | GHES 사용 |
-| `external` | 1 | 최고 사양, **Ollama 로컬 서빙** | 회사에서 외부 접속 가능 | (이 세션 PC) |
+| `external` | 1 | 최고 사양, **Ollama 로컬 서빙** | 회사에서 외부 접속 가능 | (이 세션 PC) · Obsidian vault WSL 단일 클론 통합 (2026-09-06, Windows-native 앱 폐기) |
 | `public` | 2 | 노트북, 저사양 → **local LLM 불가** | 집 | |
 
 


### PR DESCRIPTION
## Summary
- Windows-native Obsidian + WSL peer clone 이원화가 매 pull마다 충돌을 유발해, external PC(이 세션 PC)를 WSL 단일 클론으로 통합하고 Windows-native 앱은 폐기
- `docs/.ssot/pc-environment.md` §2 PC 인벤토리의 `external` 행 비고에 기록

## Test plan
- [x] 문서 전용 변경, 코드/동작 영향 없음

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q6M5iWAbt6bqXSKFxwzixm