### PR TITLE
feat(obsidian): Local REST API backend for read/create/search/property:set

### DIFF
--- a/obsidian/AGENTS.md
+++ b/obsidian/AGENTS.md
@@ -21,12 +21,71 @@ One executable = one SSOT. No loader wiring, no interactive guard, no function.
 
 ## What it does
 
-`bin/obsidian` routes to the right backend for the environment:
+`bin/obsidian` routes to the right backend for the environment. The first
+matching row wins:
 
-| Environment | Backend | Behavior |
-|-------------|---------|----------|
+| Condition | Backend | Behavior |
+|-----------|---------|----------|
+| REST configured + a subcommand | Local REST API (HTTPS) | `read`/`create`/`search`/`property:set` only — everything else is a loud error |
+| REST configured + no args | latest `Obsidian-*.AppImage` | launches the GUI (WSLg window under WSL) |
 | WSL | `Obsidian.com` CLI redirector | forwards subcommands (`search`/`read`/`create`/...) |
 | native Linux | latest `Obsidian-*.AppImage` | launches the GUI |
+
+"REST configured" = both `OBSIDIAN_REST_API_KEY` and `OBSIDIAN_REST_API_URL`
+are non-empty. No network probe is involved — reachability is the request's
+problem, not the router's. On a PC that never sets them, behavior is
+byte-for-byte what it was before the REST backend existed.
+
+## REST backend
+
+For the PC whose vault is a single unified copy opened by a Linux AppImage
+**inside WSL** (WSLg), not the Windows-native app: there is no `Obsidian.com`
+redirector to forward to, so agent access goes through the community plugin
+**"Local REST API with MCP"** (`obsidian-local-rest-api`, v5.1.0+) instead.
+Credentials come from the environment first, then
+`~/.config/obsidian-rest-api/env` fills any gap:
+
+```
+OBSIDIAN_REST_API_KEY=<hex key from the plugin's settings tab>
+OBSIDIAN_REST_API_URL=https://127.0.0.1:27124
+```
+
+A missing, empty, or unreadable file is not an error — routing just falls
+through to the legacy rows above. Needs `curl` + `jq` on PATH; the plugin's
+cert is self-signed, so requests go out with `curl -sk` (no validation, no
+pinning). The key is never printed, not even in error output.
+
+### What it covers
+
+| Subcommand | REST call |
+|------------|-----------|
+| `read` | `GET /vault/<path>` (or `/active/` with no target) |
+| `create` | `GET` existence probe, then `PUT /vault/<path>` (`text/markdown`) |
+| `search` | `POST /search/simple/?query=…` |
+| `property:set` | `PATCH /vault/<path>` — a v2 JSON frontmatter `replace` instruction |
+
+- `path=` is vault-root-relative; `.md` is appended when the basename has no
+  extension.
+- `file=` resolves like a wikilink. The API has no link resolver, so one
+  JsonLogic query lists every note's path and the basename is matched against
+  it. Zero matches and multiple matches are both errors — never a silent write
+  to the wrong note.
+- No `file=`/`path=` targets the active note, matching the native CLI.
+- Bare flags (`silent`, `total`, `--copy`, …) only steer the native GUI, which
+  the REST backend has no hand in: accepted and ignored. `overwrite` is real —
+  without it `create` refuses to clobber an existing note.
+- An unknown `key=value` parameter (e.g. `template=`) is a loud error, because
+  silently dropping it would write a note the caller did not ask for.
+
+### What it does NOT cover
+
+`append`, `backlinks`, `daily:*`, `tags`, `tasks`, `plugin:*`, `dev:*`, `eval`,
+and `vault=` targeting all exit nonzero with a one-line reason. This is
+deliberate: the REST API has no equivalent endpoint for them (and talks to
+exactly one vault — whichever its Obsidian instance has open), and a
+partial emulation would be worse than a refusal. Windows-native Obsidian
+(`OBSIDIAN_CLI_BIN`) still implements the full first-party CLI — unset
+`OBSIDIAN_REST_API_URL` to route back to it on a PC that has both.
 
 ## Wiring
 
@@ -41,6 +100,8 @@ in `shell-common/config/symlinks.conf`.
 | `OBSIDIAN_CLI_BIN` | WSL redirector | `/mnt/c/Program Files/Obsidian/Obsidian.com` |
 | `OBSIDIAN_BIN` | explicit AppImage | — |
 | `OBSIDIAN_HOME` | AppImage scan dir | `~/application` |
+| `OBSIDIAN_REST_API_KEY` | REST auth | — (falls back to `~/.config/obsidian-rest-api/env`) |
+| `OBSIDIAN_REST_API_URL` | REST base URL | — (ditto; e.g. `https://127.0.0.1:27124`) |
 
 ## Usage
 
@@ -49,7 +110,7 @@ obsidian search query="PARA" limit=5
 obsidian read file="My Note"
 obsidian property:set name="status" value="done" file="My Task"
 obsidian create name="New Note" path="folder/New Note.md" content="# Hello" silent
-obsidian backlinks file="My Note"
+obsidian backlinks file="My Note"   # native CLI only — refused by the REST backend
 obsidian            # no args -> launch / focus the app
 obsidian -h         # wrapper help
 ```
@@ -90,6 +151,15 @@ Bundled skills: `obsidian-markdown`, `obsidian-bases`, `json-canvas`,
 
 ## Tests
 
-`tests/bats/tools/obsidian.bats` — black-box checks (help, WSL/Linux routing,
-env overrides, exit codes) run against the executable. Run:
+`tests/bats/tools/obsidian.bats` — black-box checks (help, WSL/Linux/REST
+routing, env overrides, exit codes) run against the executable. Run:
 `./tests/bats/lib/bats-core/bin/bats tests/bats/tools/obsidian.bats`
+
+The REST cases mock at the network boundary: a fake `curl` first on `PATH`
+records each request and replays canned statuses/bodies, so the assertions are
+on the real method/URL/headers/body the script built. Two things stay
+untested, for the same reason as before: the native-Linux `_ob_is_wsl` false
+branch (the test host *is* WSL) and any behavior of the Obsidian server
+itself. Every test isolates `$HOME` — the developer's own
+`~/.config/obsidian-rest-api/env` would otherwise reroute the legacy-path
+tests into the REST backend.

--- a/obsidian/bin/obsidian
+++ b/obsidian/bin/obsidian
@@ -8,20 +8,46 @@
 # functions are not. This is the SSOT for the `obsidian` command (issue #1023).
 #
 # Routed by environment:
-#   - WSL:          Windows desktop CLI redirector (Obsidian.com)
-#                   forwards subcommands: search / read / create / property:set / ...
-#   - native Linux: latest Obsidian-*.AppImage (GUI launcher)
+#   - REST configured: Local REST API plugin over HTTPS (read/create/search/
+#                      property:set only); no args -> launch the AppImage
+#   - WSL:             Windows desktop CLI redirector (Obsidian.com)
+#                      forwards subcommands: search / read / create / ...
+#   - native Linux:    latest Obsidian-*.AppImage (GUI launcher)
 #
 # Path overrides:
 #   OBSIDIAN_CLI_BIN  WSL redirector  (default: /mnt/c/Program Files/Obsidian/Obsidian.com)
 #   OBSIDIAN_BIN      explicit AppImage path (native Linux)
 #   OBSIDIAN_HOME     dir scanned for Obsidian-*.AppImage (default: ~/application)
 #
+# REST backend overrides (env wins; ~/.config/obsidian-rest-api/env fills gaps):
+#   OBSIDIAN_REST_API_KEY  API key of the "Local REST API with MCP" plugin
+#   OBSIDIAN_REST_API_URL  e.g. https://127.0.0.1:27124
+#
 # Usage:
 #   obsidian search query="PARA" limit=5
 #   obsidian read file="My Note"
 #   obsidian create name="New Note" path="folder/New Note.md" content="# Hello" silent
 #   obsidian                          # no args -> launch the app / GUI
+
+# ----------------------------------------------------------------- REST config
+# Env wins; the file only fills the gaps. An unreadable/empty/broken file is
+# NOT an error — routing simply falls through to the legacy OS-based branches.
+_ob_rest_key=${OBSIDIAN_REST_API_KEY-}
+_ob_rest_url=${OBSIDIAN_REST_API_URL-}
+if [ -z "$_ob_rest_key" ] || [ -z "$_ob_rest_url" ]; then
+	if [ -r "$HOME/.config/obsidian-rest-api/env" ]; then
+		# shellcheck source=/dev/null
+		. "$HOME/.config/obsidian-rest-api/env" 2>/dev/null || true
+		[ -n "$_ob_rest_key" ] || _ob_rest_key=${OBSIDIAN_REST_API_KEY-}
+		[ -n "$_ob_rest_url" ] || _ob_rest_url=${OBSIDIAN_REST_API_URL-}
+	fi
+fi
+
+# True when both REST credentials are known. Deliberately no network probe —
+# "configured" is a routing question, reachability is the request's problem.
+_ob_rest_configured() {
+	[ -n "$_ob_rest_key" ] && [ -n "$_ob_rest_url" ]
+}
 
 # True when running under WSL.
 _ob_is_wsl() {
@@ -58,12 +84,229 @@ _ob_usage() {
 	cat <<'USAGE'
 obsidian - launch Obsidian / forward CLI commands
 Usage: obsidian [cli-subcommand args...]
+  REST:  read / create / search / property:set via the Local REST API plugin
+         (active when OBSIDIAN_REST_API_KEY + OBSIDIAN_REST_API_URL are set)
   WSL:   forwards to Obsidian.com (search/read/create/property:set/backlinks/...)
   Linux: launches the latest Obsidian-*.AppImage
   (no args) launches / focuses the app
-Overrides: OBSIDIAN_CLI_BIN (WSL), OBSIDIAN_BIN / OBSIDIAN_HOME (Linux)
+Overrides: OBSIDIAN_CLI_BIN (WSL), OBSIDIAN_BIN / OBSIDIAN_HOME (Linux),
+           OBSIDIAN_REST_API_KEY / OBSIDIAN_REST_API_URL (REST)
 USAGE
 }
+
+_ob_err() {
+	printf 'obsidian: %s\n' "$1" >&2
+}
+
+# ---------------------------------------------------------------- REST backend
+
+_ob_tmpd=""
+_ob_rest_cleanup() {
+	[ -n "$_ob_tmpd" ] && rm -rf "$_ob_tmpd"
+}
+
+# Percent-encode each path segment, keeping "/" as a real separator (the API
+# does not resolve an encoded %2F between path components).
+_ob_urlpath() {
+	jq -rn --arg p "$1" '$p | split("/") | map(@uri) | join("/")'
+}
+
+# $1 method, $2 url path, rest: extra curl args.
+# Body -> $_ob_tmpd/body, status -> $_ob_status. Returns nonzero unless 2xx.
+_ob_req() {
+	_ob_method=$1
+	_ob_path=$2
+	shift 2
+	_ob_status=$(curl -sk -X "$_ob_method" \
+		-H "Authorization: Bearer $_ob_rest_key" \
+		-o "$_ob_tmpd/body" -w '%{http_code}' \
+		"$@" "${_ob_rest_url%/}$_ob_path" 2>/dev/null) || _ob_status=000
+	case "$_ob_status" in
+	2*) return 0 ;;
+	esac
+	return 1
+}
+
+# Report the failed request in $1's name and exit. Never echoes the API key.
+_ob_req_die() {
+	if [ "$_ob_status" = "000" ]; then
+		_ob_err "$1: cannot reach the Obsidian REST API at ${_ob_rest_url}"
+		printf '  -> Is Obsidian running with the "Local REST API" plugin enabled?\n' >&2
+		exit 1
+	fi
+	_ob_detail=$(jq -r '.message // .error // empty' "$_ob_tmpd/body" 2>/dev/null)
+	[ -n "$_ob_detail" ] || _ob_detail=$(head -c 200 "$_ob_tmpd/body" 2>/dev/null)
+	_ob_err "$1 failed (HTTP $_ob_status) $_ob_detail"
+	exit 1
+}
+
+# Append .md when the basename carries no extension (Obsidian's own convention).
+_ob_with_ext() {
+	case "${1##*/}" in
+	*.*) printf '%s' "$1" ;;
+	*) printf '%s.md' "$1" ;;
+	esac
+}
+
+# Resolve a wikilink-style `file=` name to exactly one vault path, into
+# $_ob_resolved. There is no REST endpoint for link resolution, so list every
+# note (one JsonLogic query returning each file's path) and match on basename.
+# Runs in the caller's shell, not a subshell — a bad name must `exit`, and an
+# exit inside a command substitution would only kill the substitution.
+_ob_resolve_file() {
+	_ob_want=$(_ob_with_ext "$1")
+	_ob_req POST /search/ \
+		-H 'Content-Type: application/vnd.olrapi.jsonlogic+json' \
+		--data-binary '{"var":"path"}' || _ob_req_die "file=\"$1\" lookup"
+	_ob_hits=$(jq -r --arg n "$_ob_want" \
+		'.[].filename | select(. == $n or endswith("/" + $n))' \
+		"$_ob_tmpd/body" 2>/dev/null)
+	if [ -z "$_ob_hits" ]; then
+		_ob_err "no note named \"$1\" in the vault"
+		exit 1
+	fi
+	if [ "$(printf '%s\n' "$_ob_hits" | wc -l)" -gt 1 ]; then
+		_ob_err "\"$1\" is ambiguous — $(printf '%s\n' "$_ob_hits" | wc -l) notes match:"
+		printf '%s\n' "$_ob_hits" | sed 's/^/  -> /' >&2
+		printf '  -> Use path="..." to pick one.\n' >&2
+		exit 1
+	fi
+	_ob_resolved=$_ob_hits
+}
+
+# Set $_ob_url to the note addressed by path= / file=, or /active/ when neither
+# is given (matching the native CLI, which falls back to the active file).
+_ob_set_note_url() {
+	if [ -n "$_ob_p_path" ]; then
+		_ob_url="/vault/$(_ob_urlpath "$(_ob_with_ext "$_ob_p_path")")"
+	elif [ -n "$_ob_p_file" ]; then
+		_ob_resolve_file "$_ob_p_file"
+		_ob_url="/vault/$(_ob_urlpath "$_ob_resolved")"
+	else
+		_ob_url="/active/"
+	fi
+}
+
+_ob_p_file=""
+_ob_p_path=""
+_ob_p_name=""
+_ob_p_value=""
+_ob_p_content=""
+_ob_p_query=""
+_ob_p_limit=""
+_ob_p_overwrite=""
+
+# Parse `key=value` params. Bare words are boolean flags: `silent` and friends
+# only steer the native GUI, which the REST backend has no hand in — accept and
+# ignore them. An unknown `key=value` is a loud error, never a silent drop.
+_ob_parse_params() {
+	for _ob_a in "$@"; do
+		case "$_ob_a" in
+		file=*) _ob_p_file=${_ob_a#file=} ;;
+		path=*) _ob_p_path=${_ob_a#path=} ;;
+		name=*) _ob_p_name=${_ob_a#name=} ;;
+		value=*) _ob_p_value=${_ob_a#value=} ;;
+		content=*) _ob_p_content=${_ob_a#content=} ;;
+		query=*) _ob_p_query=${_ob_a#query=} ;;
+		limit=*) _ob_p_limit=${_ob_a#limit=} ;;
+		overwrite) _ob_p_overwrite=1 ;;
+		*=*)
+			_ob_err "parameter \"${_ob_a%%=*}\" is not supported by the REST backend"
+			exit 2
+			;;
+		*) ;; # bare flag (silent, --copy, total, ...) — no GUI to steer
+		esac
+	done
+}
+
+_ob_rest_read() {
+	_ob_set_note_url
+	_ob_req GET "$_ob_url" || _ob_req_die read
+	cat "$_ob_tmpd/body"
+}
+
+_ob_rest_create() {
+	if [ -n "$_ob_p_path" ]; then
+		_ob_target=$(_ob_with_ext "$_ob_p_path")
+	elif [ -n "$_ob_p_name" ]; then
+		_ob_target=$(_ob_with_ext "$_ob_p_name")
+	else
+		_ob_err 'create needs name="..." or path="..."'
+		exit 2
+	fi
+	_ob_url="/vault/$(_ob_urlpath "$_ob_target")"
+	if [ -z "$_ob_p_overwrite" ] && _ob_req GET "$_ob_url"; then
+		_ob_err "$_ob_target already exists — pass the \`overwrite\` flag to replace it"
+		exit 1
+	fi
+	# \n / \t in content are escapes, as the native CLI documents them.
+	printf '%b' "$_ob_p_content" >"$_ob_tmpd/req"
+	_ob_req PUT "$_ob_url" \
+		-H 'Content-Type: text/markdown' \
+		--data-binary "@$_ob_tmpd/req" || _ob_req_die create
+	printf '%s\n' "$_ob_target"
+}
+
+_ob_rest_search() {
+	if [ -z "$_ob_p_query" ]; then
+		_ob_err 'search needs query="..."'
+		exit 2
+	fi
+	_ob_req POST /search/simple/ \
+		-G --data-urlencode "query=$_ob_p_query" || _ob_req_die search
+	jq -r --argjson n "${_ob_p_limit:-0}" '
+		(if $n > 0 then .[0:$n] else . end)[]
+		| .filename, "    " + ((.matches[0].context // "") | gsub("\\s+"; " "))
+	' "$_ob_tmpd/body"
+}
+
+_ob_rest_property_set() {
+	if [ -z "$_ob_p_name" ]; then
+		_ob_err 'property:set needs name="..."'
+		exit 2
+	fi
+	_ob_set_note_url
+	jq -n --arg k "$_ob_p_name" --arg v "$_ob_p_value" \
+		'{targetType: "frontmatter", target: $k, operation: "replace",
+		  value: $v, createTargetIfMissing: true}' >"$_ob_tmpd/req"
+	_ob_req PATCH "$_ob_url" \
+		-H 'Content-Type: application/json' \
+		--data-binary "@$_ob_tmpd/req" || _ob_req_die property:set
+}
+
+_ob_rest_dispatch() {
+	_ob_cmd=$1
+	shift
+	case "$_ob_cmd" in
+	read | create | search | property:set) ;;
+	vault=*)
+		_ob_err 'vault="..." is meaningless for the REST backend — it talks to the one vault its Obsidian instance has open'
+		exit 2
+		;;
+	*)
+		_ob_err "\"$_ob_cmd\" has no REST-backed equivalent (this backend covers read, create, search, property:set)"
+		printf '  -> Windows-native Obsidian (OBSIDIAN_CLI_BIN) still implements it; unset OBSIDIAN_REST_API_URL to route there.\n' >&2
+		exit 2
+		;;
+	esac
+	for _ob_dep in curl jq; do
+		command -v "$_ob_dep" >/dev/null 2>&1 || {
+			_ob_err "$_ob_dep is required for the REST backend but was not found in PATH"
+			exit 127
+		}
+	done
+	_ob_parse_params "$@"
+	_ob_tmpd=$(mktemp -d) || exit 1
+	trap _ob_rest_cleanup EXIT INT TERM
+	case "$_ob_cmd" in
+	read) _ob_rest_read ;;
+	create) _ob_rest_create ;;
+	search) _ob_rest_search ;;
+	property:set) _ob_rest_property_set ;;
+	esac
+}
+
+# ---------------------------------------------------------------------- routing
 
 case "${1:-}" in
 -h | --help | help)
@@ -72,7 +315,14 @@ case "${1:-}" in
 	;;
 esac
 
-if _ob_is_wsl; then
+# REST owns every subcommand once configured; with no args it is this PC's
+# AppImage (launched inside WSL via WSLg), not the Windows-native app.
+if _ob_rest_configured && [ $# -gt 0 ]; then
+	_ob_rest_dispatch "$@"
+	exit $?
+fi
+
+if _ob_is_wsl && ! _ob_rest_configured; then
 	_ob_bin=$(_ob_cli_bin)
 	# DrvFs (/mnt/c) may drop the Linux -x bit depending on mount options, yet
 	# WSL interop still runs the Windows binary — test existence (-f), not

--- a/tests/bats/tools/obsidian.bats
+++ b/tests/bats/tools/obsidian.bats
@@ -5,13 +5,97 @@
 # directly with env overrides and assert on output / exit code.
 #
 # Note: the WSL branch is exercised by forcing WSL_DISTRO_NAME. The native
-# Linux (AppImage) branch is not unit-tested here because the test host is
-# itself WSL (/proc/version contains "microsoft"), so it cannot be forced
-# off without a production test-hook — out of scope.
+# Linux (AppImage) branch is not unit-tested via _ob_is_wsl because the test
+# host is itself WSL (/proc/version contains "microsoft"), so it cannot be
+# forced off without a production test-hook — out of scope. The AppImage
+# launch IS covered for the REST-configured case, which reaches it regardless
+# of WSL.
+#
+# The REST backend is exercised through a fake `curl` first on PATH that
+# records each request and replays canned responses — no Obsidian instance
+# and no network. The assertions are on the real request shape the script
+# built (method, URL, headers, body), so the REST code path really runs.
 
 load '../test_helper'
 
 OBSIDIAN_BIN="${DOTFILES_ROOT}/obsidian/bin/obsidian"
+
+setup() {
+    # The developer's own ~/.config/obsidian-rest-api/env would otherwise
+    # reroute every legacy-path test into the REST backend. Isolate $HOME and
+    # clear the env vars so each test states its own backend explicitly.
+    TEST_HOME="$(mktemp -d)"
+    export HOME="$TEST_HOME"
+    unset OBSIDIAN_REST_API_KEY OBSIDIAN_REST_API_URL
+
+    export OB_STUB_DIR="${BATS_TEST_TMPDIR}/stub"
+    mkdir -p "${OB_STUB_DIR}/bin"
+}
+
+teardown() {
+    [ -n "$TEST_HOME" ] && rm -rf "$TEST_HOME"
+}
+
+# A `curl` that records every invocation and replays canned responses.
+#   $OB_STUB_DIR/codes    one HTTP status per line, Nth line = Nth request
+#   $OB_STUB_DIR/bodyN    response body for the Nth request (optional)
+#   $OB_STUB_DIR/reqN     args of the Nth request, one per line (written here)
+#   $OB_STUB_DIR/reqbodyN --data-binary @file payload of the Nth request
+_install_curl_stub() {
+    cat >"${OB_STUB_DIR}/bin/curl" <<'STUB'
+#!/bin/sh
+d=${OB_STUB_DIR}
+n=$(cat "$d/n" 2>/dev/null || echo 0)
+n=$((n + 1))
+printf '%s' "$n" >"$d/n"
+: >"$d/req$n"
+out=""
+prev=""
+for a in "$@"; do
+    printf '%s\n' "$a" >>"$d/req$n"
+    [ "$prev" = "-o" ] && out=$a
+    case "$prev$a" in
+    "--data-binary@"*) cp "${a#@}" "$d/reqbody$n" 2>/dev/null ;;
+    esac
+    prev=$a
+done
+code=$(sed -n "${n}p" "$d/codes" 2>/dev/null)
+[ -n "$code" ] || code=200
+if [ -n "$out" ]; then
+    if [ -f "$d/body$n" ]; then cat "$d/body$n" >"$out"; else : >"$out"; fi
+fi
+printf '%s' "$code"
+STUB
+    chmod +x "${OB_STUB_DIR}/bin/curl"
+    printf '%s\n' "$@" >"${OB_STUB_DIR}/codes"
+}
+
+# Run the wrapper with the REST backend configured and the curl stub on PATH.
+_run_rest() {
+    run env \
+        OBSIDIAN_REST_API_KEY=testkey \
+        OBSIDIAN_REST_API_URL=https://127.0.0.1:27124 \
+        OB_STUB_DIR="${OB_STUB_DIR}" \
+        PATH="${OB_STUB_DIR}/bin:${PATH}" \
+        "$OBSIDIAN_BIN" "$@"
+}
+
+# Assert the Nth recorded request carried the exact argument <2>.
+_assert_req_arg() {
+    grep -Fxq -- "$2" "${OB_STUB_DIR}/req$1" ||
+        fail "request $1 has no arg '$2'; got: $(tr '\n' ' ' <"${OB_STUB_DIR}/req$1")"
+}
+
+# Assert the Nth recorded request's URL (curl's last arg).
+_assert_req_url() {
+    local got
+    got=$(tail -n1 "${OB_STUB_DIR}/req$1")
+    [ "$got" = "$2" ] || fail "request $1 URL: expected '$2', got '$got'"
+}
+
+_req_count() {
+    cat "${OB_STUB_DIR}/n" 2>/dev/null || echo 0
+}
 
 @test "obsidian executable exists and is executable" {
     [ -x "$OBSIDIAN_BIN" ]
@@ -69,4 +153,265 @@ OBSIDIAN_BIN="${DOTFILES_ROOT}/obsidian/bin/obsidian"
     run zsh "$OBSIDIAN_BIN" -h
     assert_success
     assert_output --partial "Usage"
+}
+
+# ------------------------------------------------------------- REST: routing
+
+@test "REST not configured: WSL still forwards the subcommand verbatim" {
+    local stub="${BATS_TEST_TMPDIR}/Obsidian.com"
+    printf '#!/bin/sh\nprintf "RAN %%s\\n" "$*"\n' >"$stub"
+    chmod +x "$stub"
+    run env WSL_DISTRO_NAME=Ubuntu OBSIDIAN_CLI_BIN="$stub" \
+        "$OBSIDIAN_BIN" backlinks file="My Note"
+    assert_success
+    assert_output "RAN backlinks file=My Note"
+}
+
+@test "REST configured: no-args launch uses the AppImage even under WSL" {
+    local app="${BATS_TEST_TMPDIR}/Obsidian-9.9.9.AppImage"
+    printf '#!/bin/sh\necho APPIMAGE_LAUNCHED\n' >"$app"
+    chmod +x "$app"
+    run env WSL_DISTRO_NAME=Ubuntu \
+        OBSIDIAN_REST_API_KEY=testkey \
+        OBSIDIAN_REST_API_URL=https://127.0.0.1:27124 \
+        OBSIDIAN_BIN="$app" \
+        OBSIDIAN_CLI_BIN=/no/such/Obsidian.com \
+        "$OBSIDIAN_BIN"
+    assert_success
+    assert_output "APPIMAGE_LAUNCHED"
+}
+
+@test "REST credentials are read from ~/.config/obsidian-rest-api/env" {
+    mkdir -p "${HOME}/.config/obsidian-rest-api"
+    cat >"${HOME}/.config/obsidian-rest-api/env" <<'EOF'
+OBSIDIAN_REST_API_KEY=filekey
+OBSIDIAN_REST_API_URL=https://file.example:1234
+EOF
+    _install_curl_stub 200
+    printf 'from-file\n' >"${OB_STUB_DIR}/body1"
+    run env OB_STUB_DIR="${OB_STUB_DIR}" PATH="${OB_STUB_DIR}/bin:${PATH}" \
+        "$OBSIDIAN_BIN" read path="note.md"
+    assert_success
+    _assert_req_url 1 "https://file.example:1234/vault/note.md"
+    _assert_req_arg 1 "Authorization: Bearer filekey"
+}
+
+@test "REST: exported env wins over the config file" {
+    mkdir -p "${HOME}/.config/obsidian-rest-api"
+    cat >"${HOME}/.config/obsidian-rest-api/env" <<'EOF'
+OBSIDIAN_REST_API_KEY=filekey
+OBSIDIAN_REST_API_URL=https://file.example:1234
+EOF
+    _install_curl_stub 200
+    _run_rest read path="note.md"
+    assert_success
+    _assert_req_url 1 "https://127.0.0.1:27124/vault/note.md"
+    _assert_req_arg 1 "Authorization: Bearer testkey"
+}
+
+@test "REST: an unreadable config file falls through to legacy WSL routing" {
+    mkdir -p "${HOME}/.config/obsidian-rest-api"
+    : >"${HOME}/.config/obsidian-rest-api/env" # empty: no key, no url
+    run env WSL_DISTRO_NAME=Ubuntu OBSIDIAN_CLI_BIN=/no/such/Obsidian.com \
+        "$OBSIDIAN_BIN" search query=x
+    assert_failure 127
+    assert_output --partial "CLI redirector not found"
+}
+
+# ------------------------------------------------------- REST: request shapes
+
+@test "REST read path=: GET /vault/<path>, .md appended, insecure TLS" {
+    _install_curl_stub 200
+    printf '# Hello\n' >"${OB_STUB_DIR}/body1"
+    _run_rest read path="folder/note"
+    assert_success
+    assert_output "# Hello"
+    _assert_req_arg 1 "GET"
+    _assert_req_arg 1 "-sk" # self-signed cert accepted
+    _assert_req_arg 1 "Authorization: Bearer testkey"
+    _assert_req_url 1 "https://127.0.0.1:27124/vault/folder/note.md"
+}
+
+@test "REST read with no target reads the active note" {
+    _install_curl_stub 200
+    printf 'active body\n' >"${OB_STUB_DIR}/body1"
+    _run_rest read
+    assert_success
+    assert_output "active body"
+    _assert_req_url 1 "https://127.0.0.1:27124/active/"
+}
+
+@test "REST read file=: resolves the wikilink, then GETs the encoded path" {
+    _install_curl_stub 200 200
+    cat >"${OB_STUB_DIR}/body1" <<'EOF'
+[{"filename":"10-Project/My Note.md","result":"10-Project/My Note.md"},
+ {"filename":"30-Resource/Other.md","result":"30-Resource/Other.md"}]
+EOF
+    printf 'resolved body\n' >"${OB_STUB_DIR}/body2"
+    _run_rest read file="My Note"
+    assert_success
+    assert_output "resolved body"
+    _assert_req_url 1 "https://127.0.0.1:27124/search/"
+    _assert_req_arg 1 "Content-Type: application/vnd.olrapi.jsonlogic+json"
+    _assert_req_url 2 "https://127.0.0.1:27124/vault/10-Project/My%20Note.md"
+}
+
+@test "REST read file=: unknown name fails loudly (no write, exit 1)" {
+    _install_curl_stub 200
+    printf '[{"filename":"a/b.md","result":"a/b.md"}]\n' >"${OB_STUB_DIR}/body1"
+    _run_rest read file="Nope"
+    assert_failure 1
+    assert_output --partial 'no note named "Nope"'
+}
+
+@test "REST read file=: ambiguous name lists the candidates and refuses" {
+    _install_curl_stub 200
+    cat >"${OB_STUB_DIR}/body1" <<'EOF'
+[{"filename":"a/Dup.md","result":"x"},{"filename":"b/Dup.md","result":"x"}]
+EOF
+    _run_rest read file="Dup"
+    assert_failure 1
+    assert_output --partial "ambiguous"
+    assert_output --partial "a/Dup.md"
+    assert_output --partial "b/Dup.md"
+    assert_output --partial 'Use path="..."'
+}
+
+@test "REST create: probes for an existing file, then PUTs text/markdown" {
+    _install_curl_stub 404 204
+    _run_rest create name="New Note" path="folder/New Note.md" \
+        content='# Hello\nsecond line' silent
+    assert_success
+    assert_output "folder/New Note.md"
+    # 1: existence probe
+    _assert_req_arg 1 "GET"
+    _assert_req_url 1 "https://127.0.0.1:27124/vault/folder/New%20Note.md"
+    # 2: the write
+    _assert_req_arg 2 "PUT"
+    _assert_req_arg 2 "Content-Type: text/markdown"
+    _assert_req_url 2 "https://127.0.0.1:27124/vault/folder/New%20Note.md"
+    # \n in content is an escape, as the native CLI documents it
+    printf '# Hello\nsecond line' >"${BATS_TEST_TMPDIR}/expected"
+    diff "${BATS_TEST_TMPDIR}/expected" "${OB_STUB_DIR}/reqbody2"
+}
+
+@test "REST create: name= only lands at the vault root with .md appended" {
+    _install_curl_stub 404 204
+    _run_rest create name="Loose" content="x"
+    assert_success
+    _assert_req_url 2 "https://127.0.0.1:27124/vault/Loose.md"
+}
+
+@test "REST create: refuses to clobber an existing note without overwrite" {
+    _install_curl_stub 200
+    _run_rest create path="folder/note.md" content="x"
+    assert_failure 1
+    assert_output --partial "already exists"
+    assert_output --partial "overwrite"
+    [ "$(_req_count)" = "1" ] # probed only; never wrote
+}
+
+@test "REST create: the overwrite flag skips the probe and writes" {
+    _install_curl_stub 204
+    _run_rest create path="folder/note.md" content="x" overwrite
+    assert_success
+    [ "$(_req_count)" = "1" ]
+    _assert_req_arg 1 "PUT"
+}
+
+@test "REST search: POSTs /search/simple/ with the url-encoded query" {
+    _install_curl_stub 200
+    cat >"${OB_STUB_DIR}/body1" <<'EOF'
+[{"filename":"a/one.md","matches":[{"context":"hit  one","match":{"start":0,"end":3}}]},
+ {"filename":"b/two.md","matches":[{"context":"hit two","match":{"start":0,"end":3}}]},
+ {"filename":"c/three.md","matches":[]}]
+EOF
+    _run_rest search query="search term" limit=2
+    assert_success
+    _assert_req_arg 1 "POST"
+    _assert_req_arg 1 "--data-urlencode"
+    _assert_req_arg 1 "query=search term"
+    _assert_req_url 1 "https://127.0.0.1:27124/search/simple/"
+    assert_line --index 0 "a/one.md"
+    assert_line --index 1 "    hit one"
+    assert_line --index 2 "b/two.md"
+    refute_output --partial "c/three.md" # limit=2 honored
+}
+
+@test "REST property:set: PATCHes a frontmatter replace instruction" {
+    _install_curl_stub 200
+    _run_rest property:set name="status" value="done" path="folder/note.md"
+    assert_success
+    _assert_req_arg 1 "PATCH"
+    _assert_req_arg 1 "Content-Type: application/json"
+    _assert_req_url 1 "https://127.0.0.1:27124/vault/folder/note.md"
+    run jq -r '[.targetType, .target, .operation, .value,
+                (.createTargetIfMissing|tostring)] | join("|")' \
+        "${OB_STUB_DIR}/reqbody1"
+    assert_output "frontmatter|status|replace|done|true"
+}
+
+@test "REST property:set: JSON payload is escaped, never injected" {
+    _install_curl_stub 200
+    _run_rest property:set name="note" value='he said "hi" \ bye' path="n.md"
+    assert_success
+    run jq -r '.value' "${OB_STUB_DIR}/reqbody1"
+    assert_output 'he said "hi" \ bye'
+}
+
+# --------------------------------------------------------- REST: loud refusals
+
+@test "REST: an unsupported subcommand fails loudly without any request" {
+    _install_curl_stub 200
+    _run_rest backlinks file="My Note"
+    assert_failure 2
+    assert_output --partial "backlinks"
+    assert_output --partial "no REST-backed equivalent"
+    assert_output --partial "OBSIDIAN_CLI_BIN"
+    [ "$(_req_count)" = "0" ]
+}
+
+@test "REST: daily:append is refused, not half-emulated" {
+    _install_curl_stub 200
+    _run_rest daily:append content="- [ ] task"
+    assert_failure 2
+    assert_output --partial "daily:append"
+    [ "$(_req_count)" = "0" ]
+}
+
+@test "REST: vault= targeting is refused" {
+    _install_curl_stub 200
+    _run_rest vault="My Vault" search query="test"
+    assert_failure 2
+    assert_output --partial "vault="
+    [ "$(_req_count)" = "0" ]
+}
+
+@test "REST: an unknown key=value parameter is refused, not dropped" {
+    _install_curl_stub 200
+    _run_rest create name="N" template="Daily" content="x"
+    assert_failure 2
+    assert_output --partial "template"
+    [ "$(_req_count)" = "0" ]
+}
+
+@test "REST: an unreachable API reports the URL, never the key" {
+    # Real curl against a closed port: exercises the 000 branch end to end.
+    run env OBSIDIAN_REST_API_KEY=supersecretkey \
+        OBSIDIAN_REST_API_URL=https://127.0.0.1:1 \
+        "$OBSIDIAN_BIN" read path="note.md"
+    assert_failure 1
+    assert_output --partial "cannot reach the Obsidian REST API"
+    assert_output --partial "https://127.0.0.1:1"
+    refute_output --partial "supersecretkey"
+}
+
+@test "REST: an HTTP error surfaces the API's message" {
+    _install_curl_stub 404
+    printf '{"message":"Not Found","errorCode":40400}\n' >"${OB_STUB_DIR}/body1"
+    _run_rest read path="missing.md"
+    assert_failure 1
+    assert_output --partial "HTTP 404"
+    assert_output --partial "Not Found"
+    refute_output --partial "testkey"
 }


### PR DESCRIPTION
## Summary
- Windows-native Obsidian(`Obsidian.com` CLI 리다이렉터) 없이도 AI 에이전트가 vault의 `read`/`create`/`search`/`property:set`을 쓸 수 있도록, REST 자격증명이 설정돼 있으면 `obsidian-local-rest-api`(Local REST API with MCP) 플러그인으로 요청을 우회
- `daily:*`/`tags`/`tasks`/`plugin:*`/`dev:*`/`eval`/`backlinks`/`vault=`는 REST 엔드포인트 자체가 없어 명확한 에러로 거부 — 전체 대체 불가능, 부분 대체가 의도된 스코프
- REST 미설정 PC(대부분)는 기존 WSL redirector / native AppImage 동작 100% 그대로
- 외부 PC(단일 WSL vault로 통합 완료) 전용: `~/.config/obsidian-rest-api/env`에 `OBSIDIAN_REST_API_KEY`/`OBSIDIAN_REST_API_URL` 설정, `no-args` 실행도 Windows 앱 대신 WSLg AppImage로

## Test plan
- [x] `shellcheck obsidian/bin/obsidian` clean
- [x] `./tests/bats/lib/bats-core/bin/bats tests/bats/tools/obsidian.bats` — 32/32 (기존 9건 포함, 회귀 없음)
- [x] 실제 실행 중인 vault(`https://127.0.0.1:27124`)에 대해 `search`/`read`/`create`/`property:set` 실제 호출로 end-to-end 검증, 테스트 노트는 정리 완료

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q6M5iWAbt6bqXSKFxwzixm