### PR TITLE
fix(gcp-scan): 스칼라 배열 삽입으로 인한 인덱스 밀림 오탐 해소

### DIFF
--- a/shell-common/functions/gcp_scan.sh
+++ b/shell-common/functions/gcp_scan.sh
@@ -436,10 +436,59 @@ _gcp_scan_json_leaves() {
     # `-S` sorts object keys so a pure key reordering — not meaningful in JSON
     # — does not read as new content. An empty file yields no records and rc 0,
     # which is the correct reading of "the commit adds this file".
-    jq -Sc '
+    #
+    # $2 (optional, issue #1775) is a JSON array of array paths whose ELEMENT
+    # records are suppressed — see `_gcp_scan_json_absorbed_array_paths`. The
+    # array's own `[$p, []]` record still shows, so the array cannot vanish.
+    jq -Sc --argjson drop "${2:-[]}" '
+        def dropped($p): any($drop[]; . as $d | ($p | length) > ($d | length) and $p[0:($d | length)] == $d);
         [[], (if type == "object" then {} elif type == "array" then [] else . end)],
-        (paths as $p | [$p, (getpath($p) | if type == "object" then {} elif type == "array" then [] else . end)])
+        (paths as $p | select(dropped($p) | not) | [$p, (getpath($p) | if type == "object" then {} elif type == "array" then [] else . end)])
     ' "$1"
+}
+
+_gcp_scan_json_absorbed_array_paths() {
+    # Issue #1775. Emits (as one compact JSON array) the paths of the scalar
+    # arrays whose base/$1 -> theirs/$3 -> ours/$2 difference is pure INDEX
+    # SHIFT rather than content, so the caller can compare them by value order
+    # instead of by absolute index.
+    #
+    # Why #1688's index-in-the-path design needs this exception: in an
+    # alphabetically sorted registry (`claude/plugin/plugins.json`) both
+    # branches append. If HEAD independently inserted an earlier-sorting entry,
+    # every later element shifts one slot, so the value the commit adds — which
+    # HEAD ALREADY HAS — carries a different index and reads as "content HEAD
+    # lacks" forever. That is the #1688 bug in a new coordinate.
+    #
+    # The discriminator is RELATIVE order, which an index shift cannot change:
+    # an array qualifies only when base is a subsequence of theirs (the commit
+    # only INSERTED — a removal must stay visible, the #1177 data-loss
+    # direction) AND theirs is a subsequence of ours (HEAD already holds every
+    # value the commit has, in the same relative order). The #1688 reorder case
+    # (`["b","a"]` vs `["a","b"]`) fails the second test — the two branches
+    # disagree about which of two shared values comes first — so it still reads
+    # as real content.
+    #
+    # Scalar arrays only. An array holding objects/arrays renders as deeper
+    # records whose paths this suppression would not reach, and its element
+    # order is far likelier to be meaningful; those keep the #1688 comparison.
+    jq -nc --slurpfile b "$1" --slurpfile o "$2" --slurpfile t "$3" '
+        def sc: type == "array" and all(.[]; type != "object" and type != "array");
+        # true when $a is a subsequence of the input array (greedy is exact here).
+        def subseq($a): (reduce .[] as $y ($a; if length > 0 and .[0] == $y then .[1:] else . end)) | length == 0;
+        ($b[0]) as $B | ($o[0]) as $O | ($t[0]) as $T |
+        if ($O | type) == "null" or ($T | type) == "null" then []
+        else
+            [ (([] | select($T | sc)), ($T | paths(sc))) as $p
+              | ($T | getpath($p)) as $Ta
+              | (((try ($O | getpath($p)) catch null) // []) | if sc then . else null end) as $Oa
+              | (((try ($B | getpath($p)) catch null) // []) | if sc then . else null end) as $Ba
+              | select($Oa != null and $Ba != null)
+              | select(($Ta | subseq($Ba)) and ($Oa | subseq($Ta)))
+              | $p
+            ]
+        end
+    '
 }
 
 _gcp_scan_conflict_adds_new_content() {
@@ -461,7 +510,7 @@ _gcp_scan_conflict_adds_new_content() {
     # below is what distinguishes the two, letting Stage-1.6 defer the drift
     # case to Stage-2 (no-op) while still flagging the real one. Non-destructive:
     # reads blobs only (no checkout / cherry-pick).
-    local sha="$1" f="$2" parent td _b _o _t
+    local sha="$1" f="$2" parent td _b _o _t _drop
     parent=$(git rev-parse -q --verify "${sha}^1" 2>/dev/null) || return 0
     td=$(mktemp -d "${TMPDIR:-/tmp}/gcp_drift.XXXXXX" 2>/dev/null) || return 0
     # base = the file in the commit's parent (the cherry-pick merge base);
@@ -519,11 +568,19 @@ _gcp_scan_conflict_adds_new_content() {
     # valid: it falls back to exact comparison and stays visible.
     # NOTE: a bare `exit` (not `exit 0`) is required on a hit — `exit 0` would
     # still run END, whose `exit 1` would override it back to "drift".
+    #
+    # `_gcp_scan_json_absorbed_array_paths` (#1775) is the one exception to the
+    # index-in-the-path rule: for a scalar array the commit only INSERTED into
+    # and whose values HEAD already holds in the same relative order, the
+    # per-element records are suppressed on all three sides, so an unrelated
+    # insertion earlier in a sorted registry cannot re-brand an already-applied
+    # value as new content. A reorder still fails its subsequence test.
     _b="${td}/base" _o="${td}/ours" _t="${td}/theirs"
     if command -v jq >/dev/null 2>&1 &&
-        _gcp_scan_json_leaves "${td}/base" >"${td}/base.j" 2>/dev/null &&
-        _gcp_scan_json_leaves "${td}/ours" >"${td}/ours.j" 2>/dev/null &&
-        _gcp_scan_json_leaves "${td}/theirs" >"${td}/theirs.j" 2>/dev/null; then
+        _drop=$(_gcp_scan_json_absorbed_array_paths "${td}/base" "${td}/ours" "${td}/theirs" 2>/dev/null) &&
+        _gcp_scan_json_leaves "${td}/base" "$_drop" >"${td}/base.j" 2>/dev/null &&
+        _gcp_scan_json_leaves "${td}/ours" "$_drop" >"${td}/ours.j" 2>/dev/null &&
+        _gcp_scan_json_leaves "${td}/theirs" "$_drop" >"${td}/theirs.j" 2>/dev/null; then
         _b="${td}/base.j" _o="${td}/ours.j" _t="${td}/theirs.j"
     fi
     if awk '

--- a/shell-common/functions/gcp_scan.sh
+++ b/shell-common/functions/gcp_scan.sh
@@ -469,20 +469,29 @@ _gcp_scan_json_absorbed_array_paths() {
     # disagree about which of two shared values comes first — so it still reads
     # as real content.
     #
-    # Scalar arrays only. An array holding objects/arrays renders as deeper
-    # records whose paths this suppression would not reach, and its element
-    # order is far likelier to be meaningful; those keep the #1688 comparison.
+    # Scalar arrays only — a deliberately conservative carve-out, not a
+    # technical limit: the subsequence/equality machinery below would work
+    # just as well if `sc` also allowed object/array elements. It is narrowed
+    # to scalars because an array of objects/arrays is judged far likelier to
+    # have order that IS meaningful; those keep the #1688 index-sensitive
+    # comparison until evidence says otherwise.
     jq -nc --slurpfile b "$1" --slurpfile o "$2" --slurpfile t "$3" '
         def sc: type == "array" and all(.[]; type != "object" and type != "array");
         # true when $a is a subsequence of the input array (greedy is exact here).
         def subseq($a): (reduce .[] as $y ($a; if length > 0 and .[0] == $y then .[1:] else . end)) | length == 0;
+        # every path in the input, root ([]) included — the builtin `paths`
+        # filter is this same generator with the root filtered back out.
+        def scalar_array_paths: . as $root | path(..) | select(. as $p | $root | getpath($p) | sc);
+        # $x at $p if that side holds a scalar array there, else null (a
+        # missing or shape-mismatched side never qualifies as absorbed).
+        def side($x; $p): (try ($x | getpath($p)) catch null) // [] | if sc then . else null end;
         ($b[0]) as $B | ($o[0]) as $O | ($t[0]) as $T |
         if ($O | type) == "null" or ($T | type) == "null" then []
         else
-            [ (([] | select($T | sc)), ($T | paths(sc))) as $p
+            [ ($T | scalar_array_paths) as $p
               | ($T | getpath($p)) as $Ta
-              | (((try ($O | getpath($p)) catch null) // []) | if sc then . else null end) as $Oa
-              | (((try ($B | getpath($p)) catch null) // []) | if sc then . else null end) as $Ba
+              | (side($O; $p)) as $Oa
+              | (side($B; $p)) as $Ba
               | select($Oa != null and $Ba != null)
               | select(($Ta | subseq($Ba)) and ($Oa | subseq($Ta)))
               | $p

--- a/tests/bats/functions/gcp.bats
+++ b/tests/bats/functions/gcp.bats
@@ -1109,6 +1109,43 @@ FIXTURE
     assert_output --partial "rc=1"
 }
 
+# --- issue #1775 PR #1776 review (agy/codex FOLLOW-UP): coverage gaps ------
+
+@test "drift #1775: a nested (non-root) scalar array absorbs index shift too (1)" {
+    run_in_bash "
+        $(_gcp903_make_repo)
+        printf '{\n  \"plugins\": [\n    \"a\"\n  ]\n}\n' > reg.json && git add reg.json && git commit -qm 'add reg'
+        git checkout -q -b source
+        printf '{\n  \"plugins\": [\n    \"a\",\n    \"c\"\n  ]\n}\n' > reg.json && git add reg.json && git commit -qm 'register c'
+        src=\$(git rev-parse HEAD)
+        git checkout -q main
+        printf '{\n  \"plugins\": [\n    \"a\",\n    \"b\",\n    \"c\"\n  ]\n}\n' > reg.json && git add reg.json && git commit -qm 'register b; c already present'
+        _gcp_scan_conflict_adds_new_content \"\$src\" reg.json; echo \"adds=\$?\"
+    "
+    assert_success
+    # Same index-shift shape as the root-array #1775 test, one level deeper —
+    # _gcp_scan_json_absorbed_array_paths must not be root-path-only.
+    assert_output --partial "adds=1"
+}
+
+@test "drift #1775: duplicate-valued array elements still absorb an index shift (1)" {
+    run_in_bash "
+        $(_gcp903_make_repo)
+        printf '[\n  \"a\",\n  \"a\"\n]\n' > reg.json && git add reg.json && git commit -qm 'add reg'
+        git checkout -q -b source
+        printf '[\n  \"a\",\n  \"a\",\n  \"b\"\n]\n' > reg.json && git add reg.json && git commit -qm 'register b'
+        src=\$(git rev-parse HEAD)
+        git checkout -q main
+        printf '[\n  \"z\",\n  \"a\",\n  \"a\",\n  \"b\"\n]\n' > reg.json && git add reg.json && git commit -qm 'register z before the duplicate pair; b already present'
+        _gcp_scan_conflict_adds_new_content \"\$src\" reg.json; echo \"adds=\$?\"
+    "
+    assert_success
+    # The greedy subseq check must not misfire on duplicate values — each
+    # occurrence of \"a\" consumes independently in order, so the shift past
+    # the duplicate pair still reads as pure index drift, not new content.
+    assert_output --partial "adds=1"
+}
+
 # --- issue #1775: an unrelated insertion shifts the absolute indices --------
 
 @test "drift #1775: 배열에 값 삽입으로 인덱스가 밀려도 이미 존재하는 값은 no-op (1)" {

--- a/tests/bats/functions/gcp.bats
+++ b/tests/bats/functions/gcp.bats
@@ -1109,6 +1109,47 @@ FIXTURE
     assert_output --partial "rc=1"
 }
 
+# --- issue #1775: an unrelated insertion shifts the absolute indices --------
+
+@test "drift #1775: 배열에 값 삽입으로 인덱스가 밀려도 이미 존재하는 값은 no-op (1)" {
+    run_in_bash "
+        $(_gcp903_make_repo)
+        printf '[\n  \"a\"\n]\n' > reg.json && git add reg.json && git commit -qm 'add reg'
+        git checkout -q -b source
+        printf '[\n  \"a\",\n  \"c\"\n]\n' > reg.json && git add reg.json && git commit -qm 'register c'
+        src=\$(git rev-parse HEAD)
+        git checkout -q main
+        # HEAD already carries \"c\", but an unrelated later commit inserted the
+        # alphabetically-earlier \"b\" before it, so \"c\" sits at index 2 here and
+        # at index 1 in the commit being picked.
+        printf '[\n  \"a\",\n  \"b\",\n  \"c\"\n]\n' > reg.json && git add reg.json && git commit -qm 'register b; c already present'
+        _gcp_scan_conflict_adds_new_content \"\$src\" reg.json; echo \"adds=\$?\"
+        _gcp_scan_preflight_is_noop \"\$src\"; echo \"noop=\$?\"
+    "
+    assert_success
+    # Relative order of every shared value is unchanged between theirs and ours
+    # -> pure index shift, not content. Contrast with the reorder test above.
+    assert_output --partial "adds=1"
+    assert_output --partial "noop=0"
+}
+
+@test "drift #1775: an element the commit REMOVES from an array is still real content (0)" {
+    run_in_bash "
+        $(_gcp903_make_repo)
+        printf '[\n  \"a\",\n  \"b\"\n]\n' > reg.json && git add reg.json && git commit -qm 'add reg'
+        git checkout -q -b source
+        printf '[\n  \"a\"\n]\n' > reg.json && git add reg.json && git commit -qm 'unregister b'
+        src=\$(git rev-parse HEAD)
+        git checkout -q main
+        printf '[\n  \"a\",\n  \"b\",\n  \"c\"\n]\n' > reg.json && git add reg.json && git commit -qm 'HEAD keeps b, adds c'
+        _gcp_scan_conflict_adds_new_content \"\$src\" reg.json; echo \"rc=\$?\"
+    "
+    assert_success
+    # theirs is a subsequence of ours, but base is NOT a subsequence of theirs
+    # -> the removal must stay visible (#1177 data-loss direction).
+    assert_output --partial "rc=0"
+}
+
 # --- round 2 (agy + codex BLOCKER): the commit's own delta ------------------
 
 @test "drift #1688: a JSON commit whose only work is deleting a stray comma is NOT dropped (0)" {


### PR DESCRIPTION
## Summary
- `_gcp_scan_conflict_adds_new_content`의 JSON 구조 비교(#1688)가 배열 원소의
  절대 인덱스를 그대로 비교해, 알파벳 정렬 배열(`plugins.json` 등)에 두 브랜치가
  각각 다른 위치에 값을 삽입하면 뒤 인덱스가 밀려 이미 HEAD에 반영된 값을
  "새 내용"으로 오판했다.
- `_gcp_scan_json_absorbed_array_paths`를 추가해, 스칼라 배열 중 (1) base가
  theirs의 부분수열이고(삭제는 계속 노출) (2) theirs가 ours의 부분수열인
  (HEAD가 같은 상대 순서로 이미 보유) 경우에만 원소별 인덱스 비교를 건너뛴다.

## Changes
- `shell-common/functions/gcp_scan.sh`: `_gcp_scan_json_leaves`에 배열-경로
  드롭 목록 인자를 추가하고, 신규 `_gcp_scan_json_absorbed_array_paths`로
  스칼라 배열의 부분수열 검사를 수행, `_gcp_scan_conflict_adds_new_content`가
  이 드롭 목록을 세 leaves 렌더에 전달하도록 연결.
- `tests/bats/functions/gcp.bats`: #1775 재현 케이스(인덱스 밀림 → no-op)와
  회귀 가드(원소 삭제는 여전히 실제 내용으로 노출) 2건 추가.

## Test plan
- [x] `./tests/bats/lib/bats-core/bin/bats tests/bats/functions/gcp.bats` — 137/137 통과 (기존 135 + 신규 2), `not ok` 0건.
- [x] `shellcheck -x shell-common/functions/gcp_scan.sh` — clean.
- [x] 기존 `#1688` 재정렬 회귀 테스트(`["b","a"]` vs `["a","b"]`)는 그대로 실제 충돌(rc=0)로 유지됨을 수동 트레이스로 확인.

## Related
Closes #1775

---
<details>
<summary>🤖 AI Metrics · 📊 ~2000 tokens · 👤 ~2 h · 🤖 ~31 min</summary>

<!-- ai-metrics:gh-pr -->
📊 ~2000 tokens · 👤 ~2 h · 🤖 ~31 min
<!-- /ai-metrics:gh-pr -->

</details>
