### PR TITLE
fix(schedule-agent-prompt): --cancel <id> refuses a terminal-status job

### DIFF
--- a/shell-common/tools/custom/schedule_agent_prompt.sh
+++ b/shell-common/tools/custom/schedule_agent_prompt.sh
@@ -591,6 +591,13 @@ _sap_cancel_cmd() {
         _sap_st=$(jq -r '.status // ""' "${_sap_jobf}" 2>/dev/null)
         if [ -n "${_sap_want}" ]; then
             [ "${_sap_id}" = "${_sap_want}" ] || continue
+            case "${_sap_st}" in
+            pending) ;;
+            *)
+                ux_error "Job ${_sap_id} is already ${_sap_st} — nothing to cancel."
+                return 1
+                ;;
+            esac
         else
             [ "${_sap_st}" = "pending" ] || continue
         fi

--- a/shell-common/tools/custom/schedule_agent_prompt.sh
+++ b/shell-common/tools/custom/schedule_agent_prompt.sh
@@ -594,7 +594,7 @@ _sap_cancel_cmd() {
             case "${_sap_st}" in
             pending) ;;
             *)
-                ux_error "Job ${_sap_id} is already ${_sap_st} — nothing to cancel."
+                ux_error "Job ${_sap_id} is already ${_sap_st:-unknown} — nothing to cancel."
                 return 1
                 ;;
             esac

--- a/tests/bats/tools/schedule_agent_prompt.bats
+++ b/tests/bats/tools/schedule_agent_prompt.bats
@@ -568,6 +568,23 @@ _prompt_calls() {
     assert_output "failed"
 }
 
+@test "A6h: --cancel <id> on a job with an unparseable status names it 'unknown'" {
+    _set_agents "${_A}|w1N:pH"
+    sap --at "$(_future_hhmm)" --agent-cwd "${_A}"
+    assert_success
+    local id f
+    id="$(_job_field '.id')"
+    f="$(_job_file)"
+    jq 'del(.status)' "$f" >"${f}.t" && mv "${f}.t" "$f"
+
+    sap --cancel "${id}"
+    assert_failure
+    assert_output --partial "already unknown"
+
+    run jq -r '.status' "$f"
+    assert_output "null"
+}
+
 # ---------------------------------------------------------------------------
 # A7 — a --wait that never settles
 # ---------------------------------------------------------------------------

--- a/tests/bats/tools/schedule_agent_prompt.bats
+++ b/tests/bats/tools/schedule_agent_prompt.bats
@@ -523,6 +523,51 @@ _prompt_calls() {
     assert_output "pending"
 }
 
+@test "A6f: --cancel <id> refuses a job that already completed" {
+    _set_agents "${_A}|w1N:pH"
+    sap --at "$(_future_hhmm)" --agent-cwd "${_A}"
+    assert_success
+    local id
+    id="$(_job_field '.id')"
+
+    _expire_job
+    _dispatch_job
+    assert_success
+    run _job_field '.status'
+    assert_output "completed"
+
+    sap --cancel "${id}"
+    assert_failure
+    assert_output --partial "already completed"
+
+    run _job_field '.status'
+    assert_output "completed"
+}
+
+@test "A6g: --cancel <id> refuses a job that already failed" {
+    _set_agents "${_A}|w1N:pH"
+    sap --at "$(_future_hhmm)" --agent-cwd "${_A}"
+    assert_success
+    local id
+    id="$(_job_field '.id')"
+    _expire_job
+
+    export FAIL_PANE="w1N:pH"
+    export FAIL_RC=1
+    export FAIL_OUT="herdr: agent_prompt_stalled"
+    _dispatch_job
+    assert_failure
+    run _job_field '.status'
+    assert_output "failed"
+
+    sap --cancel "${id}"
+    assert_failure
+    assert_output --partial "already failed"
+
+    run _job_field '.status'
+    assert_output "failed"
+}
+
 # ---------------------------------------------------------------------------
 # A7 — a --wait that never settles
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- `--cancel <JOB_ID>`가 completed/failed로 끝난 잡의 상태를 조용히 "cancelled"로 덮어써서, `--status`가 실제로 디스패치되고 프롬프트를 넣은 잡을 마치 취소된 적 없는 잡처럼 잘못 보고하던 문제를 고친다.

## Changes
- `fix(schedule-agent-prompt)`: `_sap_cancel_cmd`의 id 지정 분기에 pending 상태 가드를 추가. 이미 종료 상태인 잡을 `--cancel <id>`로 지정하면 상태를 건드리지 않고 `Job <id> is already <status> — nothing to cancel.`을 출력하며 실패 종료한다. no-id 분기(전체 pending 취소)는 기존 동작 그대로.
- 회귀 테스트 2건 추가: A6f(완료된 잡), A6g(실패한 잡) — 모두 `--cancel <id>`가 상태를 바꾸지 않고 거부함을 검증.

## Test plan
- [x] `./tests/bats/lib/bats-core/bin/bats tests/bats/tools/schedule_agent_prompt.bats` — 38/38 green (기존 36 + 신규 A6f/A6g 2)
- [x] `bash -n shell-common/tools/custom/schedule_agent_prompt.sh` — 문법 확인

## Related
Closes #1772

---
<details>
<summary>🤖 AI Metrics · 📊 ~2500 tokens · 👤 ~2 h · 🤖 ~4 min</summary>

<!-- ai-metrics:gh-pr -->
📊 ~2500 tokens · 👤 ~2 h · 🤖 ~4 min
<!-- /ai-metrics:gh-pr -->

</details>
