### PR TITLE
Add devx_pr_verify_merged_parse (mirror devx_pr_verify_live_parse)

### DIFF
--- a/shell-common/functions/devx_pr_verify_merged.sh
+++ b/shell-common/functions/devx_pr_verify_merged.sh
@@ -53,6 +53,19 @@ _devx_pr_verify_merged_pos_int() {
     esac
 }
 
+# A newline inside a free-form value would inject an extra line into the
+# `key=value` stdout contract callers parse line-by-line, forging a field
+# that was never passed (#1779 codex BLOCKER). `=` needs no guard — the
+# contract splits on the first one, so an embedded `=` stays in the value.
+# Returns 1 when "$1" contains a newline.
+_devx_pr_verify_merged_no_newline() {
+    case "$1" in
+    *"
+"*) return 1 ;;
+    *) return 0 ;;
+    esac
+}
+
 devx_pr_verify_merged_parse() {
     local pr=""
     local remote="origin"
@@ -197,6 +210,19 @@ devx_pr_verify_merged_parse() {
 
     if [ "$_clone_dir_set" -eq 1 ] && [ -z "$clone_dir" ]; then
         echo "--clone-dir value must not be empty" >&2
+        return 2
+    fi
+
+    # Both free-form values that reach stdout unescaped. `env_axes` and
+    # `matrix` are whitelisted below and `pr` is digits-only, so these two
+    # are the whole injection surface.
+    if ! _devx_pr_verify_merged_no_newline "$clone_dir"; then
+        echo "--clone-dir value must not contain a newline" >&2
+        return 2
+    fi
+
+    if ! _devx_pr_verify_merged_no_newline "$remote"; then
+        echo "remote name must not contain a newline: '$remote'" >&2
         return 2
     fi
 

--- a/shell-common/functions/devx_pr_verify_merged.sh
+++ b/shell-common/functions/devx_pr_verify_merged.sh
@@ -1,0 +1,239 @@
+#!/bin/sh
+# shellcheck shell=bash
+# shell-common/functions/devx_pr_verify_merged.sh
+# Pure arg parser for the devx:pr-verify-merged skill. Mirrors the
+# devx_pr_verify_live_parse contract: one `key=value` line per resolved arg
+# on success, errors to stderr. Exit 0 ok/help, exit 2 arg error. Runtime
+# checks (PR merge state, gh auth, clone/build success) belong to the skill
+# body.
+#
+# This file lives under shell-common/functions/, so it is auto-sourced into
+# the user's interactive shell. Every variable the parser assigns is `local`
+# (house style here — see gh_pr_review.sh) so a call cannot clobber the
+# user's `$pr` / `$remote` / `$matrix`. Callers read the stdout `key=value`
+# contract, never the shell variables.
+
+# Advisory only (issue #1454, propagated by #1505): warn once on stderr when
+# this file was sourced from a checkout that is a different git repo than
+# $HOME/dotfiles. Never blocks, and deliberately NOT wrapped in an
+# interactive guard — this is a pure function-defining library that
+# non-interactive skill callers rely on; the guard function is itself a
+# silent no-op outside the genuine foreign-checkout case.
+#
+# The self-path branch must stay here at file top level — zsh rebinds $0 to
+# the sourced file (FUNCTION_ARGZERO) only for this file's own statements,
+# and inside a function $0 is the function's own name. Plain POSIX sh has
+# neither $0-rebinding nor $BASH_SOURCE, and would abort on the bash array
+# syntax, hence the $BASH_VERSION arm. Everything after it lives once, in
+# _dotfiles_root_guard_self.
+if [ -n "${ZSH_VERSION-}" ]; then
+    _drg_self="$0"
+elif [ -n "${BASH_VERSION-}" ]; then
+    _drg_self="${BASH_SOURCE[0]-}"
+else
+    _drg_self=""
+fi
+_drg_helper="${SHELL_COMMON:-$HOME/dotfiles/shell-common}/functions/dotfiles_root.sh"
+if [ -r "$_drg_helper" ]; then
+    . "$_drg_helper" || true
+fi
+if command -v _dotfiles_root_guard_self >/dev/null 2>&1; then
+    _dotfiles_root_guard_self "$_drg_self" "devx_pr_verify_merged"
+else
+    printf '[devx_pr_verify_merged] %s missing or did not define _dotfiles_root_guard_self — #1454 guard skipped (#724).\n' \
+        "$_drg_helper" >&2
+fi
+unset _drg_self _drg_helper
+
+_devx_pr_verify_merged_pos_int() {
+    case "$1" in
+    "" | *[!0-9]*) return 1 ;;
+    *[!0]*) return 0 ;;
+    *) return 1 ;;
+    esac
+}
+
+devx_pr_verify_merged_parse() {
+    local pr=""
+    local remote="origin"
+    local matrix="auto"
+    local env_axes=""
+    local clone_dir=""
+    local diff_check=1
+    local issue_mode="create"
+    local post_comment=1
+    local _remote_set=0
+    local _pos_seen=0
+    local _pr_set=0
+    local _matrix_set=0
+    local _env_set=0
+    local _clone_dir_set=0
+    local _no_issue=0
+    local _rest=""
+    local _item=""
+
+    while [ "$#" -gt 0 ]; do
+        case "$1" in
+        --matrix | --env | --clone-dir)
+            [ "$#" -lt 2 ] && {
+                echo "missing value for $1" >&2
+                return 2
+            }
+            ;;
+        esac
+        case "$1" in
+        --matrix)
+            matrix="$2"
+            _matrix_set=1
+            shift 2
+            ;;
+        --matrix=*)
+            matrix="${1#--matrix=}"
+            _matrix_set=1
+            shift
+            ;;
+        --env)
+            env_axes="$2"
+            _env_set=1
+            shift 2
+            ;;
+        --env=*)
+            env_axes="${1#--env=}"
+            _env_set=1
+            shift
+            ;;
+        --clone-dir)
+            clone_dir="$2"
+            _clone_dir_set=1
+            shift 2
+            ;;
+        --clone-dir=*)
+            clone_dir="${1#--clone-dir=}"
+            _clone_dir_set=1
+            shift
+            ;;
+        --no-diff-check)
+            diff_check=0
+            shift
+            ;;
+        --dry-run)
+            issue_mode="dry-run"
+            shift
+            ;;
+        --no-issue)
+            _no_issue=1
+            shift
+            ;;
+        --no-comment)
+            post_comment=0
+            shift
+            ;;
+        -h | --help | help)
+            echo "help_requested=1"
+            return 0
+            ;;
+        -*)
+            # Single- and double-dash typos alike are flag errors, not
+            # positionals — `-x` must not surface as a PR# complaint.
+            echo "Unknown flag: $1" >&2
+            return 2
+            ;;
+        *)
+            # `[pr-number] [remote]` with an optional PR#. Discriminator:
+            # PR numbers start with a digit (optionally `#`-prefixed, the
+            # common GitHub PR notation), git remote names conventionally
+            # do not. A leading digit therefore always means "this is the
+            # PR#" — `12a` / `#12a` stay a loud PR# error instead of
+            # silently becoming a remote name.
+            if [ "$_pos_seen" -eq 0 ]; then
+                _pos_seen=1
+                case "$1" in
+                [0-9]* | '#'*)
+                    # Stripping `#` is a no-op on a bare digit string, so
+                    # one arm covers `123` and `#123` alike.
+                    pr="${1#\#}"
+                    _pr_set=1
+                    ;;
+                *)
+                    remote="$1"
+                    _remote_set=1
+                    ;;
+                esac
+            elif [ "$_remote_set" -eq 0 ]; then
+                remote="$1"
+                _remote_set=1
+            else
+                echo "Unexpected positional arg: $1" >&2
+                return 2
+            fi
+            shift
+            ;;
+        esac
+    done
+
+    # Gate on "a PR# positional was given", not on `pr` being non-empty: a
+    # bare `#` strips to an empty PR# and must still be rejected here
+    # instead of silently falling back to PR auto-detection (#1748 codex
+    # review, PR #1749).
+    if [ "$_pr_set" -eq 1 ]; then
+        if ! _devx_pr_verify_merged_pos_int "$pr"; then
+            echo "PR# must be a positive integer: '$pr'" >&2
+            return 2
+        fi
+    fi
+
+    # An explicitly passed but empty value is an error for every
+    # value-taking flag — silently dropping it would verify a different
+    # clone than the user asked for.
+    if [ "$_matrix_set" -eq 1 ] && [ -z "$matrix" ]; then
+        echo "--matrix value must not be empty" >&2
+        return 2
+    fi
+
+    if [ "$_env_set" -eq 1 ] && [ -z "$env_axes" ]; then
+        echo "--env value must not be empty" >&2
+        return 2
+    fi
+
+    if [ "$_clone_dir_set" -eq 1 ] && [ -z "$clone_dir" ]; then
+        echo "--clone-dir value must not be empty" >&2
+        return 2
+    fi
+
+    case "$matrix" in
+    auto | full) ;;
+    *)
+        echo "--matrix must be auto or full: '$matrix'" >&2
+        return 2
+        ;;
+    esac
+
+    if [ -n "$env_axes" ]; then
+        _rest="${env_axes},"
+        while [ -n "$_rest" ]; do
+            _item="${_rest%%,*}"
+            _rest="${_rest#*,}"
+            case "$_item" in
+            path | locale | shell | eol) ;;
+            *)
+                echo "--env axis must be one of path,locale,shell,eol: '$_item'" >&2
+                return 2
+                ;;
+            esac
+        done
+    fi
+
+    if [ "$_no_issue" -eq 1 ]; then
+        issue_mode="none"
+    fi
+
+    printf '%s\n' "pr=$pr"
+    printf '%s\n' "remote=$remote"
+    printf '%s\n' "matrix=$matrix"
+    printf '%s\n' "env_axes=$env_axes"
+    printf '%s\n' "clone_dir=$clone_dir"
+    printf '%s\n' "diff_check=$diff_check"
+    printf '%s\n' "issue_mode=$issue_mode"
+    printf '%s\n' "post_comment=$post_comment"
+    return 0
+}

--- a/tests/bats/functions/devx_pr_verify_merged.bats
+++ b/tests/bats/functions/devx_pr_verify_merged.bats
@@ -1,0 +1,389 @@
+#!/usr/bin/env bats
+# tests/bats/functions/devx_pr_verify_merged.bats
+# Unit tests for devx_pr_verify_merged_parse (pure arg parser).
+load '../test_helper'
+
+setup() {
+    # shellcheck disable=SC1090
+    source "${DOTFILES_ROOT:?}/shell-common/functions/devx_pr_verify_merged.sh"
+}
+
+@test "no args -> defaults, pr empty (auto-detect at runtime)" {
+    run devx_pr_verify_merged_parse
+    assert_success
+    assert_line "pr="
+    assert_line "remote=origin"
+    assert_line "matrix=auto"
+    assert_line "env_axes="
+    assert_line "clone_dir="
+    assert_line "diff_check=1"
+    assert_line "issue_mode=create"
+    assert_line "post_comment=1"
+}
+
+@test "pr only -> remote origin" {
+    run devx_pr_verify_merged_parse 123
+    assert_success
+    assert_line "pr=123"
+    assert_line "remote=origin"
+}
+
+@test "pr + remote positional" {
+    run devx_pr_verify_merged_parse 123 upstream
+    assert_success
+    assert_line "pr=123"
+    assert_line "remote=upstream"
+}
+
+# A first positional that does NOT start with a digit is the remote, not a
+# malformed PR# — that is how `[pr-number] [remote]` with an optional
+# pr-number stays expressible. Digit-leading typos are still PR# errors
+# (see "digit-leading typo stays a PR# error" below).
+@test "non-digit first positional -> remote, not a PR# error" {
+    run devx_pr_verify_merged_parse abc
+    assert_success
+    assert_line "pr="
+    assert_line "remote=abc"
+}
+
+@test "pr '0' -> exit 2 (zero is not a positive integer)" {
+    run devx_pr_verify_merged_parse 0
+    assert_failure 2
+}
+
+@test "pr '00' -> exit 2 (all-zero rejected)" {
+    run devx_pr_verify_merged_parse 00
+    assert_failure 2
+}
+
+@test "--matrix full ok" {
+    run devx_pr_verify_merged_parse --matrix full
+    assert_success
+    assert_line "matrix=full"
+}
+
+@test "--matrix=full equals form ok" {
+    run devx_pr_verify_merged_parse --matrix=full
+    assert_success
+    assert_line "matrix=full"
+}
+
+@test "--matrix bogus -> exit 2" {
+    run devx_pr_verify_merged_parse --matrix bogus
+    assert_failure 2
+    assert_output --partial "--matrix must be auto or full: 'bogus'"
+}
+
+@test "--matrix with no value -> exit 2" {
+    run devx_pr_verify_merged_parse --matrix
+    assert_failure 2
+}
+
+@test "--matrix= empty equals form -> exit 2" {
+    run devx_pr_verify_merged_parse --matrix=
+    assert_failure 2
+    assert_output --partial "--matrix value must not be empty"
+}
+
+@test "--matrix with empty string value -> exit 2" {
+    run devx_pr_verify_merged_parse --matrix ""
+    assert_failure 2
+    assert_output --partial "--matrix value must not be empty"
+}
+
+@test "--env single axis ok" {
+    run devx_pr_verify_merged_parse --env path
+    assert_success
+    assert_line "env_axes=path"
+}
+
+@test "--env CSV of axes ok" {
+    run devx_pr_verify_merged_parse --env path,locale,shell,eol
+    assert_success
+    assert_line "env_axes=path,locale,shell,eol"
+}
+
+@test "--env= equals form ok" {
+    run devx_pr_verify_merged_parse --env=locale
+    assert_success
+    assert_line "env_axes=locale"
+}
+
+@test "--env with unknown axis -> exit 2" {
+    run devx_pr_verify_merged_parse --env path,bogus
+    assert_failure 2
+    assert_output --partial "--env axis must be one of path,locale,shell,eol: 'bogus'"
+}
+
+@test "--env with trailing comma -> exit 2" {
+    run devx_pr_verify_merged_parse --env path,
+    assert_failure 2
+    assert_output --partial "--env axis must be one of path,locale,shell,eol: ''"
+}
+
+@test "--env with empty element -> exit 2" {
+    run devx_pr_verify_merged_parse --env path,,eol
+    assert_failure 2
+    assert_output --partial "--env axis must be one of path,locale,shell,eol: ''"
+}
+
+@test "--env with no value -> exit 2" {
+    run devx_pr_verify_merged_parse --env
+    assert_failure 2
+}
+
+@test "--env= empty equals form -> exit 2" {
+    run devx_pr_verify_merged_parse --env=
+    assert_failure 2
+    assert_output --partial "--env value must not be empty"
+}
+
+@test "--env with empty string value -> exit 2" {
+    run devx_pr_verify_merged_parse --env ""
+    assert_failure 2
+    assert_output --partial "--env value must not be empty"
+}
+
+@test "--clone-dir space form" {
+    run devx_pr_verify_merged_parse --clone-dir /tmp/verify-clone
+    assert_success
+    assert_line "clone_dir=/tmp/verify-clone"
+}
+
+@test "--clone-dir= equals form preserves spaces" {
+    run devx_pr_verify_merged_parse --clone-dir="/tmp/my clone"
+    assert_success
+    assert_line "clone_dir=/tmp/my clone"
+}
+
+@test "--clone-dir with no value -> exit 2" {
+    run devx_pr_verify_merged_parse --clone-dir
+    assert_failure 2
+}
+
+@test "--clone-dir= empty equals form -> exit 2" {
+    run devx_pr_verify_merged_parse --clone-dir=
+    assert_failure 2
+    assert_output --partial "--clone-dir value must not be empty"
+}
+
+@test "--clone-dir with empty string value -> exit 2" {
+    run devx_pr_verify_merged_parse --clone-dir ""
+    assert_failure 2
+    assert_output --partial "--clone-dir value must not be empty"
+}
+
+@test "--no-diff-check -> diff_check=0" {
+    run devx_pr_verify_merged_parse --no-diff-check
+    assert_success
+    assert_line "diff_check=0"
+}
+
+@test "--dry-run -> issue_mode=dry-run" {
+    run devx_pr_verify_merged_parse --dry-run
+    assert_success
+    assert_line "issue_mode=dry-run"
+}
+
+@test "--no-issue -> issue_mode=none" {
+    run devx_pr_verify_merged_parse --no-issue
+    assert_success
+    assert_line "issue_mode=none"
+}
+
+@test "--no-issue wins over --dry-run" {
+    run devx_pr_verify_merged_parse --dry-run --no-issue
+    assert_success
+    assert_line "issue_mode=none"
+}
+
+@test "--no-comment -> post_comment=0" {
+    run devx_pr_verify_merged_parse --no-comment
+    assert_success
+    assert_line "post_comment=0"
+    assert_line "issue_mode=create"
+}
+
+@test "unknown flag -> exit 2" {
+    run devx_pr_verify_merged_parse 123 --bogus
+    assert_failure 2
+    assert_output --partial "Unknown flag: --bogus"
+}
+
+@test "single-dash typo -> Unknown flag, not a PR# error" {
+    run devx_pr_verify_merged_parse -x
+    assert_failure 2
+    assert_output --partial "Unknown flag: -x"
+    refute_output --partial "PR# must be a positive integer"
+}
+
+@test "single-dash typo after a pr -> Unknown flag" {
+    run devx_pr_verify_merged_parse 123 -x
+    assert_failure 2
+    assert_output --partial "Unknown flag: -x"
+}
+
+@test "pr + literal origin remote (no extra) -> exit 0 with remote=origin" {
+    run devx_pr_verify_merged_parse 123 origin
+    assert_success
+    assert_line "remote=origin"
+}
+
+@test "third positional -> exit 2" {
+    run devx_pr_verify_merged_parse 123 origin extra
+    assert_failure 2
+    assert_output --partial "Unexpected positional arg: extra"
+}
+
+@test "remote-only positional -> pr empty (auto-detect), remote used" {
+    run devx_pr_verify_merged_parse upstream
+    assert_success
+    assert_line "pr="
+    assert_line "remote=upstream"
+}
+
+@test "pr + remote still both resolve" {
+    run devx_pr_verify_merged_parse 1273 upstream
+    assert_success
+    assert_line "pr=1273"
+    assert_line "remote=upstream"
+}
+
+@test "digit-leading typo stays a PR# error, not a remote" {
+    run devx_pr_verify_merged_parse 12a
+    assert_failure 2
+    assert_output --partial "PR# must be a positive integer: '12a'"
+}
+
+# #1748: `#N` is the common GitHub PR notation and must classify as a PR#,
+# not fall through to the remote-name branch.
+@test "hash-prefixed PR# -> pr stripped of '#', remote defaults to origin" {
+    run devx_pr_verify_merged_parse "#1745"
+    assert_success
+    assert_line "pr=1745"
+    assert_line "remote=origin"
+}
+
+@test "hash-prefixed digit-leading typo stays a PR# error, not a remote" {
+    run devx_pr_verify_merged_parse "#12a"
+    assert_failure 2
+    assert_output --partial "PR# must be a positive integer: '12a'"
+}
+
+# codex review on PR #1749: a bare "#" strips to an empty pr, which must not
+# silently bypass validation and fall back to PR auto-detection.
+@test "bare hash with no digits -> exit 2, not silent auto-detect fallback" {
+    run devx_pr_verify_merged_parse "#"
+    assert_failure 2
+    assert_output --partial "PR# must be a positive integer: ''"
+}
+
+@test "remote-only + extra positional -> exit 2" {
+    run devx_pr_verify_merged_parse upstream extra
+    assert_failure 2
+    assert_output --partial "Unexpected positional arg: extra"
+}
+
+@test "-h -> help_requested" {
+    run devx_pr_verify_merged_parse -h
+    assert_success
+    assert_output --partial "help_requested=1"
+}
+
+@test "--help -> help_requested" {
+    run devx_pr_verify_merged_parse --help
+    assert_success
+    assert_output --partial "help_requested=1"
+}
+
+@test "help word -> help_requested" {
+    run devx_pr_verify_merged_parse help
+    assert_success
+    assert_output --partial "help_requested=1"
+}
+
+@test "combined flags resolve together" {
+    run devx_pr_verify_merged_parse 99 upstream --matrix full \
+        --env path,locale,shell,eol --clone-dir /tmp/verify-clone \
+        --no-diff-check --dry-run --no-comment
+    assert_success
+    assert_line "pr=99"
+    assert_line "remote=upstream"
+    assert_line "matrix=full"
+    assert_line "env_axes=path,locale,shell,eol"
+    assert_line "clone_dir=/tmp/verify-clone"
+    assert_line "diff_check=0"
+    assert_line "issue_mode=dry-run"
+    assert_line "post_comment=0"
+}
+
+# The parser lives in shell-common/functions/, which zsh/main.zsh auto-sources
+# into the user's interactive shell — so every variable it assigns must be
+# `local`. These leak guards call the function DIRECTLY (no `run`): `run`
+# executes in a subshell, where a global assignment would be invisible and the
+# regression would pass unnoticed.
+@test "parse does not leak pr/remote into the caller's shell" {
+    pr="SENTINEL_PR"
+    remote="SENTINEL_REMOTE"
+    devx_pr_verify_merged_parse 123 upstream >/dev/null
+    [ "$pr" = "SENTINEL_PR" ]
+    [ "$remote" = "SENTINEL_REMOTE" ]
+}
+
+@test "parse does not leak matrix/env_axes/clone_dir into the caller's shell" {
+    matrix="SENTINEL_MATRIX"
+    env_axes="SENTINEL_ENV_AXES"
+    clone_dir="SENTINEL_CLONE_DIR"
+    devx_pr_verify_merged_parse --matrix full --env path,locale \
+        --clone-dir /tmp/verify-clone >/dev/null
+    [ "$matrix" = "SENTINEL_MATRIX" ]
+    [ "$env_axes" = "SENTINEL_ENV_AXES" ]
+    [ "$clone_dir" = "SENTINEL_CLONE_DIR" ]
+}
+
+@test "parse does not leak diff_check/issue_mode/post_comment/_rest/_item" {
+    diff_check="SENTINEL_DIFF_CHECK"
+    issue_mode="SENTINEL_ISSUE_MODE"
+    post_comment="SENTINEL_POST_COMMENT"
+    _rest="SENTINEL_REST"
+    _item="SENTINEL_ITEM"
+    devx_pr_verify_merged_parse --env path,eol --no-diff-check \
+        --dry-run --no-comment >/dev/null
+    [ "$diff_check" = "SENTINEL_DIFF_CHECK" ]
+    [ "$issue_mode" = "SENTINEL_ISSUE_MODE" ]
+    [ "$post_comment" = "SENTINEL_POST_COMMENT" ]
+    [ "$_rest" = "SENTINEL_REST" ]
+    [ "$_item" = "SENTINEL_ITEM" ]
+}
+
+# ---------------------------------------------------------------------------
+# #1454 foreign-checkout guard, propagated to this file by issue #1505.
+#
+# Mirrors tests/bats/functions/gh_pr_review.bats — zsh is the case that
+# matters: the guard reads ${BASH_SOURCE[0]}, which bash always populated but
+# zsh never does, so before #1454 the zsh path self-disabled on its first
+# line. The file is re-sourced explicitly rather than read off the loader's
+# own pass because both loaders source with `2>/dev/null` (safe_source /
+# load_category), which would swallow the very stderr under test.
+# ---------------------------------------------------------------------------
+
+@test "zsh: #1505 foreign-checkout guard warns when devx_pr_verify_merged.sh is sourced under zsh" {
+    command -v zsh >/dev/null 2>&1 || skip "zsh not available"
+    command -v git >/dev/null 2>&1 || skip "git not available"
+
+    _setup_foreign_home_1505
+    run_in_zsh '. "$SHELL_COMMON/functions/devx_pr_verify_merged.sh"'
+    assert_success
+    assert_output --partial "[WARN] dotfiles: loaded from a foreign checkout"
+    assert_output --partial "shell-common/functions/devx_pr_verify_merged.sh"
+}
+
+@test "bash: #1505 foreign-checkout guard warns when devx_pr_verify_merged.sh is sourced under bash" {
+    command -v git >/dev/null 2>&1 || skip "git not available"
+
+    _setup_foreign_home_1505
+    run_in_bash '. "$SHELL_COMMON/functions/devx_pr_verify_merged.sh"'
+    assert_success
+    assert_output --partial "[WARN] dotfiles: loaded from a foreign checkout"
+    assert_output --partial "shell-common/functions/devx_pr_verify_merged.sh"
+}

--- a/tests/bats/functions/devx_pr_verify_merged.bats
+++ b/tests/bats/functions/devx_pr_verify_merged.bats
@@ -173,6 +173,33 @@ setup() {
     assert_output --partial "--clone-dir value must not be empty"
 }
 
+@test "--clone-dir with embedded newline -> exit 2 (no injected line)" {
+    run devx_pr_verify_merged_parse --clone-dir "$(printf '/tmp/x\npr=999')"
+    assert_failure 2
+    assert_output --partial "--clone-dir value must not contain a newline"
+    refute_line "pr=999"
+}
+
+@test "--clone-dir= equals form with embedded newline -> exit 2" {
+    run devx_pr_verify_merged_parse "$(printf -- '--clone-dir=/tmp/x\nremote=evil')"
+    assert_failure 2
+    assert_output --partial "--clone-dir value must not contain a newline"
+    refute_line "remote=evil"
+}
+
+@test "remote positional with embedded newline -> exit 2" {
+    run devx_pr_verify_merged_parse "$(printf 'up\nmatrix=full')"
+    assert_failure 2
+    assert_output --partial "remote name must not contain a newline"
+    refute_line "matrix=full"
+}
+
+@test "--clone-dir value with = is kept verbatim" {
+    run devx_pr_verify_merged_parse --clone-dir /tmp/a=b
+    assert_success
+    assert_line "clone_dir=/tmp/a=b"
+}
+
 @test "--no-diff-check -> diff_check=0" {
     run devx_pr_verify_merged_parse --no-diff-check
     assert_success


### PR DESCRIPTION
## Summary
- Add `shell-common/functions/devx_pr_verify_merged.sh`, a pure arg parser for the future `devx:pr-verify-merged` skill, mirroring `devx_pr_verify_live_parse`'s contract and house style.

## Changes
- `feat(devx-pr-verify-merged)`: `devx_pr_verify_merged_parse` resolves `[pr-number] [remote]` positionals plus `--matrix`, `--env`, `--clone-dir`, `--no-diff-check`, `--dry-run`, `--no-issue`, `--no-comment`, `-h`/`--help`/`help`, emitting one `key=value` line per resolved field (`pr remote matrix env_axes clone_dir diff_check issue_mode post_comment`), exit 2 on any arg error — same positional discriminator, empty-value checks, and CSV validation pattern as the sister `devx_pr_verify_live_parse`, including the `#1454`/`#1505` foreign-checkout guard.
- Adds `tests/bats/functions/devx_pr_verify_merged.bats` (52 tests) covering positionals, every flag, error paths, help, the two shell-source foreign-checkout guard cases, and local-variable leak guards.

## Test plan
- [x] `./tests/bats/lib/bats-core/bin/bats tests/bats/functions/devx_pr_verify_merged.bats` — 52 passed, 0 failed
- [x] `./tests/bats/lib/bats-core/bin/bats tests/bats/functions/devx_pr_verify_live.bats` — 63 passed, 0 failed (no collateral damage)
- [x] `shellcheck shell-common/functions/devx_pr_verify_merged.sh` — clean

## Related
Closes #1777

---
<details>
<summary>🤖 AI Metrics · 📊 ~6000 tokens · 👤 ~8 h (1 d) · 🤖 ~1 min</summary>

<!-- ai-metrics:gh-pr -->
📊 ~6000 tokens · 👤 ~8 h (1 d) · 🤖 ~1 min
<!-- /ai-metrics:gh-pr -->

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EuuHQVaJrpVxyEYyFiSAF5
