### PR TITLE
fix(npm): allow-git=all — allow-git 은 boolean 이 아니라 enum이다

### DIFF
--- a/docs/public/changelog.d/2026-09-07-1780.md
+++ b/docs/public/changelog.d/2026-09-07-1780.md
@@ -1,0 +1,1 @@
+- 변경: **`npm/npmrc.public`의 `allow-git`을 `true`에서 `all`로 고쳤다 — npm의 `allow-git`은 boolean이 아니라 enum(`all`/`none`/`root`)이라 이전 값은 어느 것과도 일치하지 않았고, `npx github:owner/repo`를 쓰는 curl|bash 설치(예: 플러그인 마켓플레이스)는 여전히 `EALLOWGIT`으로 막혀 있었다.**

--- a/npm/npmrc.public
+++ b/npm/npmrc.public
@@ -14,11 +14,12 @@
 # Note: public registry (registry.npmjs.org) is npm's default, so no
 #       registry/proxy/cafile lines are needed here — only the prefix.
 #
-# Why allow-git=true:
-#   npm 12+ defaults allow-git to disabled (supply-chain hardening),
+# Why allow-git=all:
+#   npm 12+ defaults allow-git to "none" (supply-chain hardening),
 #   blocking `npx github:owner/repo`-style installs. Some CLI installers
 #   (e.g. plugin marketplaces installed via curl|bash -> npx github:...)
-#   need it enabled.
+#   need it enabled. allow-git is an enum (none/root/all), not a
+#   boolean — "true" is not a valid value.
 
 prefix=${HOME}/.npm-global
-allow-git=true
+allow-git=all


### PR DESCRIPTION
## Summary
- `npm/npmrc.public`의 `allow-git=true`를 `allow-git=all`로 수정한다.
- npm의 `allow-git` config는 boolean이 아니라 enum(`all`/`none`/`root`)이며, `pacote`의 `canUse()`는 값이 정확히 `'all'`이 아니고 root 설치도 아니면 `EALLOWGIT`으로 fetch를 거부한다 — 즉 이전 값 `"true"`는 어느 것과도 일치하지 않아, 애초 이 설정을 넣은 목적(`npx github:owner/repo` 설치 허용)이 여전히 막혀 있었다.
- 주석도 새 값에 맞춰 갱신했다.

## Test plan
- [x] `npm config get allow-git`가 심링크된 `~/.npmrc`(→ `npm/npmrc.public`) 기준으로 `all`을 반환하는지 로컬 확인
- [x] npm 소스(`@npmcli/config` definitions, `pacote/lib/fetcher.js`)를 직접 읽어 `allow-git`이 enum이고 `"true"` 값이 `EALLOWGIT`으로 거부됨을 확인
- [x] pre-commit 훅 통과