### PR TITLE
feat(gb): gb -D 로 remote 개별 브랜치 삭제 지원

### DIFF
--- a/shell-common/functions/git.sh
+++ b/shell-common/functions/git.sh
@@ -221,7 +221,7 @@ _gb_help() {
     ux_bullet "sub-commands"
     ux_bullet_sub "gb -D local                              delete local branches (keeps: main + current + keywords)"
     ux_bullet_sub "gb -D remote [-y] [--all] [<remote>]     delete YOUR OWN branches on the remote SERVER (default: origin, e.g. origin, upstream, keeps: main/master; others' branches are listed but skipped unless --all)"
-    ux_bullet_sub "gb -D [remotes/]<remote>/<branch> [-y]    delete ONE branch on that remote server (as printed by 'gb -a'); falls back to local 'git branch -D' when the remote segment isn't a real remote or a local branch of that literal name exists"
+    ux_bullet_sub "gb -D [remotes/]<remote>/<branch> [-y]    delete ONE branch on that remote server (as printed by 'gb -a', keeps: main/master); falls back to local 'git branch -D' when the remote segment isn't a real remote or a local branch of that literal name exists"
     ux_bullet_sub "gb [flags]                               passthrough to git --no-pager branch"
     ux_bullet "options"
     ux_bullet_sub "-y, --yes                 skip the confirmation prompt (remote deletion is permanent)"
@@ -229,9 +229,11 @@ _gb_help() {
 }
 
 # Delete a single branch on a remote server, from the "remotes/<remote>/<branch>"
-# or "<remote>/<branch>" form `gb -a` prints. Returns 2 (not an error) when the
-# target doesn't look like a remote-branch reference, so the caller falls back
-# to plain `git branch -D` passthrough.
+# or "<remote>/<branch>" form `gb -a` prints. Non-error fallback signals (the
+# caller falls back to `git branch -D`, never an error message): 2 — target
+# isn't a real remote-branch reference (fallback on the raw target); 3 — a
+# local branch of the normalized short name already exists (fallback on that
+# short name, not the raw target — #1781 PR #1782 review, agy BLOCKER).
 _gb_delete_remote_single() {
     if [ -n "${ZSH_VERSION-}" ]; then
         emulate -L sh
@@ -253,7 +255,19 @@ _gb_delete_remote_single() {
     [ "$remote" != "$stripped" ] && [ -n "$branch" ] || return 2
 
     git remote get-url "$remote" >/dev/null 2>&1 || return 2
-    git rev-parse --verify --quiet "refs/heads/$target" >/dev/null 2>&1 && return 2
+    # Check the normalized short form, not the raw $target: a caller passing
+    # the "remotes/<remote>/<branch>" form must still detect a local branch
+    # literally named "<remote>/<branch>".
+    git rev-parse --verify --quiet "refs/heads/$stripped" >/dev/null 2>&1 && return 3
+
+    # Same protected-branch policy as `_gb_clean_remote` — never let this
+    # single-target path delete main/master (#1781 PR #1782 review, agy FOLLOW-UP).
+    case "$branch" in
+        main | master)
+            ux_error "Refusing to delete protected branch '$remote/$branch'"
+            return 1
+            ;;
+    esac
 
     if [ "$assume_yes" -ne 1 ]; then
         if ! ux_confirm "Permanently delete '$remote/$branch' from '$remote'?"; then
@@ -277,12 +291,40 @@ git_branch() {
                 local)  shift 2; _gb_clean_local "$@" ;;
                 remote) shift 2; _gb_clean_remote "$@" ;;
                 */*)
-                    local rc
-                    shift
-                    _gb_delete_remote_single "$@"
-                    rc=$?
-                    [ "$rc" -ne 2 ] && return "$rc"
-                    git --no-pager branch -D "$@"
+                    # Only treat "-D <slash-target>" or "-D <slash-target> -y|--yes"
+                    # as a remote single-branch delete — anything else (extra
+                    # positionals, an unrecognized flag) is ambiguous with
+                    # `git branch -D`'s own multi-branch delete and must fall
+                    # through untouched (#1781 PR #1782 review, codex FOLLOW-UP).
+                    local rc="" fallback_target=""
+                    case "$#" in
+                        2) _gb_delete_remote_single "$2"; rc=$? ;;
+                        3)
+                            case "$3" in
+                                -y | --yes) _gb_delete_remote_single "$2" "$3"; rc=$? ;;
+                            esac
+                            ;;
+                    esac
+                    # rc=2 (not a real remote-branch ref) falls back on the raw
+                    # target as typed; rc=3 (local branch of that short name
+                    # already exists) falls back on the short name — the actual
+                    # local branch — never leaking -y/--yes into `git branch -D`
+                    # (#1781 PR #1782 review, agy FOLLOW-UP). Anything else that
+                    # reached this case (extra positionals, an unrecognized
+                    # flag) never called `_gb_delete_remote_single` at all
+                    # (rc=""), so it falls all the way through to the plain
+                    # passthrough below, unmodified.
+                    case "$rc" in
+                        "") ;;
+                        2) fallback_target="$2" ;;
+                        3) fallback_target="${2#remotes/}" ;;
+                        *) return "$rc" ;;
+                    esac
+                    if [ -n "$fallback_target" ]; then
+                        git --no-pager branch -D "$fallback_target"
+                    else
+                        git --no-pager branch "$@"
+                    fi
                     ;;
                 *)
                     if [ $# -eq 2 ] && git remote get-url "$2" >/dev/null 2>&1 \

--- a/shell-common/functions/git.sh
+++ b/shell-common/functions/git.sh
@@ -221,10 +221,56 @@ _gb_help() {
     ux_bullet "sub-commands"
     ux_bullet_sub "gb -D local                              delete local branches (keeps: main + current + keywords)"
     ux_bullet_sub "gb -D remote [-y] [--all] [<remote>]     delete YOUR OWN branches on the remote SERVER (default: origin, e.g. origin, upstream, keeps: main/master; others' branches are listed but skipped unless --all)"
+    ux_bullet_sub "gb -D [remotes/]<remote>/<branch> [-y]    delete ONE branch on that remote server (as printed by 'gb -a'); falls back to local 'git branch -D' when the remote segment isn't a real remote or a local branch of that literal name exists"
     ux_bullet_sub "gb [flags]                               passthrough to git --no-pager branch"
     ux_bullet "options"
     ux_bullet_sub "-y, --yes                 skip the confirmation prompt (remote deletion is permanent)"
     ux_bullet_sub "    --all                 also delete branches authored by other people (default: your own only, matched by git config user.email)"
+}
+
+# Delete a single branch on a remote server, from the "remotes/<remote>/<branch>"
+# or "<remote>/<branch>" form `gb -a` prints. Returns 2 (not an error) when the
+# target doesn't look like a remote-branch reference, so the caller falls back
+# to plain `git branch -D` passthrough.
+_gb_delete_remote_single() {
+    if [ -n "${ZSH_VERSION-}" ]; then
+        emulate -L sh
+    fi
+
+    local target="$1" assume_yes=0 remote branch stripped
+    shift
+    while [ $# -gt 0 ]; do
+        case "$1" in
+            -y | --yes) assume_yes=1 ;;
+            *) ux_error "Unknown option: $1"; return 1 ;;
+        esac
+        shift
+    done
+
+    stripped="$target"
+    case "$stripped" in
+        remotes/*) stripped="${stripped#remotes/}" ;;
+    esac
+    remote="${stripped%%/*}"
+    branch="${stripped#*/}"
+    [ "$remote" != "$stripped" ] && [ -n "$branch" ] || return 2
+
+    git remote get-url "$remote" >/dev/null 2>&1 || return 2
+    git rev-parse --verify --quiet "refs/heads/$target" >/dev/null 2>&1 && return 2
+
+    if [ "$assume_yes" -ne 1 ]; then
+        if ! ux_confirm "Permanently delete '$remote/$branch' from '$remote'?"; then
+            ux_info "Aborted. No branch deleted."
+            return 0
+        fi
+    fi
+
+    if git push "$remote" --delete "$branch"; then
+        ux_success "Deleted: $remote/$branch"
+    else
+        ux_error "Failed to delete: $remote/$branch"
+        return 1
+    fi
 }
 
 git_branch() {
@@ -233,6 +279,14 @@ git_branch() {
             case "${2:-}" in
                 local)  shift 2; _gb_clean_local "$@" ;;
                 remote) shift 2; _gb_clean_remote "$@" ;;
+                */*)
+                    local rc
+                    shift
+                    _gb_delete_remote_single "$@"
+                    rc=$?
+                    [ "$rc" -ne 2 ] && return "$rc"
+                    git --no-pager branch -D "$@"
+                    ;;
                 *)
                     if [ $# -eq 2 ] && git remote get-url "$2" >/dev/null 2>&1 \
                         && ! git rev-parse --verify --quiet "refs/heads/$2" >/dev/null 2>&1; then

--- a/shell-common/functions/git.sh
+++ b/shell-common/functions/git.sh
@@ -247,10 +247,7 @@ _gb_delete_remote_single() {
         shift
     done
 
-    stripped="$target"
-    case "$stripped" in
-        remotes/*) stripped="${stripped#remotes/}" ;;
-    esac
+    stripped="${target#remotes/}"
     remote="${stripped%%/*}"
     branch="${stripped#*/}"
     [ "$remote" != "$stripped" ] && [ -n "$branch" ] || return 2

--- a/tests/bats/functions/git.bats
+++ b/tests/bats/functions/git.bats
@@ -466,6 +466,82 @@ teardown() {
     refute_output --partial "wt/test/1"
 }
 
+# --- PR #1782 review fixes (#1781) ---
+
+@test "bash: gb -D refuses to delete a protected remote main/master via the single-branch path" {
+    run_in_bash '
+        tmp=$(mktemp -d)
+        trap "rm -rf \"$tmp\"" EXIT INT TERM HUP
+        git init -q -b main --bare "$tmp/remote.git"
+        git clone -q "$tmp/remote.git" "$tmp/work" 2>/dev/null
+        cd "$tmp/work"
+        git config user.email t@t; git config user.name t
+        git commit -q --allow-empty -m init
+        git push -q origin HEAD:main
+        git_branch -D origin/main -y
+        gb_rc=$?
+        printf "REMAINING: "
+        git ls-remote --heads "$tmp/remote.git" | sed "s#.*refs/heads/##" | sort | tr "\n" " "
+        exit "$gb_rc"
+    '
+    assert_failure
+    assert_output --partial "Refusing to delete protected branch"
+    assert_output --partial "REMAINING: main"
+}
+
+@test "bash: gb -D remotes/<remote>/<branch> detects a same-literal local branch even in the remotes/ long form" {
+    run_in_bash '
+        tmp=$(mktemp -d)
+        trap "rm -rf \"$tmp\"" EXIT INT TERM HUP
+        git init -q -b main --bare "$tmp/remote.git"
+        git clone -q "$tmp/remote.git" "$tmp/work" 2>/dev/null
+        cd "$tmp/work"
+        git config user.email t@t; git config user.name t
+        git commit -q --allow-empty -m init
+        git push -q origin HEAD:main
+        git branch "origin/feature"
+        git_branch -D remotes/origin/feature
+    '
+    assert_success
+    assert_output --partial "Deleted branch"
+}
+
+@test "bash: gb -D <slash-branch> <extra-arg> passes through untouched (not misread as remote delete)" {
+    run_in_bash '
+        tmp=$(mktemp -d)
+        trap "rm -rf \"$tmp\"" EXIT INT TERM HUP
+        git init -q -b main --bare "$tmp/remote.git"
+        git clone -q "$tmp/remote.git" "$tmp/work" 2>/dev/null
+        cd "$tmp/work"
+        git config user.email t@t; git config user.name t
+        git commit -q --allow-empty -m init
+        git branch "origin/topic"
+        git branch "other"
+        git_branch -D origin/topic other
+    '
+    assert_success
+    assert_output --partial "Deleted branch origin/topic"
+    assert_output --partial "Deleted branch other"
+}
+
+@test "bash: gb -D <local-branch-name>/<local-branch-name> falls back without leaking -y to git branch -D" {
+    run_in_bash '
+        tmp=$(mktemp -d)
+        trap "rm -rf \"$tmp\"" EXIT INT TERM HUP
+        git init -q -b main --bare "$tmp/remote.git"
+        git clone -q "$tmp/remote.git" "$tmp/work" 2>/dev/null
+        cd "$tmp/work"
+        git config user.email t@t; git config user.name t
+        git commit -q --allow-empty -m init
+        git push -q origin HEAD:main
+        git branch "origin/feature"
+        git_branch -D origin/feature -y
+    '
+    assert_success
+    assert_output --partial "Deleted branch"
+    refute_output --partial "unknown switch"
+}
+
 # --- git worktree functions ---
 
 @test "bash: gwt function exists" {

--- a/tests/bats/functions/git.bats
+++ b/tests/bats/functions/git.bats
@@ -351,6 +351,121 @@ teardown() {
     assert_output --partial "gb -D remote origin"
 }
 
+# --- gb -D remotes/<remote>/<branch> single-branch remote deletion (#1781) ---
+
+@test "bash: gb -D remotes/<remote>/<branch> deletes only that branch" {
+    run_in_bash '
+        tmp=$(mktemp -d)
+        trap "rm -rf \"$tmp\"" EXIT INT TERM HUP
+        git init -q -b main --bare "$tmp/remote.git"
+        git clone -q "$tmp/remote.git" "$tmp/work" 2>/dev/null
+        cd "$tmp/work"
+        git config user.email t@t; git config user.name t
+        git commit -q --allow-empty -m init
+        git push -q origin HEAD:main
+        git push -q origin HEAD:wt/test/1
+        git push -q origin HEAD:wt/test/2
+        git_branch -D remotes/origin/wt/test/1 -y >/dev/null 2>&1
+        printf "REMAINING: "
+        git ls-remote --heads "$tmp/remote.git" | sed "s#.*refs/heads/##" | sort | tr "\n" " "
+    '
+    assert_success
+    assert_output --partial "REMAINING: main wt/test/2"
+    refute_output --partial "wt/test/1"
+}
+
+@test "bash: gb -D <remote>/<branch> short form deletes only that branch" {
+    run_in_bash '
+        tmp=$(mktemp -d)
+        trap "rm -rf \"$tmp\"" EXIT INT TERM HUP
+        git init -q -b main --bare "$tmp/remote.git"
+        git clone -q "$tmp/remote.git" "$tmp/work" 2>/dev/null
+        cd "$tmp/work"
+        git config user.email t@t; git config user.name t
+        git commit -q --allow-empty -m init
+        git push -q origin HEAD:main
+        git push -q origin HEAD:fix/20260907-b78cb1a
+        git_branch -D origin/fix/20260907-b78cb1a -y >/dev/null 2>&1
+        printf "REMAINING: "
+        git ls-remote --heads "$tmp/remote.git" | sed "s#.*refs/heads/##" | sort | tr "\n" " "
+    '
+    assert_success
+    assert_output --partial "REMAINING: main"
+    refute_output --partial "fix/20260907-b78cb1a"
+}
+
+@test "bash: gb -D remotes/<remote>/<branch> without -y prompts and aborts on no" {
+    run_in_bash '
+        tmp=$(mktemp -d)
+        trap "rm -rf \"$tmp\"" EXIT INT TERM HUP
+        git init -q -b main --bare "$tmp/remote.git"
+        git clone -q "$tmp/remote.git" "$tmp/work" 2>/dev/null
+        cd "$tmp/work"
+        git config user.email t@t; git config user.name t
+        git commit -q --allow-empty -m init
+        git push -q origin HEAD:main
+        git push -q origin HEAD:wt/test/1
+        echo n | git_branch -D remotes/origin/wt/test/1
+        printf "REMAINING: "
+        git ls-remote --heads "$tmp/remote.git" | sed "s#.*refs/heads/##" | sort | tr "\n" " "
+    '
+    assert_success
+    assert_output --partial "REMAINING: main wt/test/1"
+}
+
+@test "bash: gb -D remotes/<bogus-remote>/<branch> falls back to passthrough (unknown remote)" {
+    run_in_bash '
+        tmp=$(mktemp -d)
+        trap "rm -rf \"$tmp\"" EXIT INT TERM HUP
+        git init -q -b main --bare "$tmp/remote.git"
+        git clone -q "$tmp/remote.git" "$tmp/work" 2>/dev/null
+        cd "$tmp/work"
+        git config user.email t@t; git config user.name t
+        git commit -q --allow-empty -m init
+        git_branch -D remotes/nope/some/branch
+    '
+    assert_failure
+    assert_output --partial "not found"
+}
+
+@test "bash: gb -D <remote>/<branch> falls back to local delete when a local branch of that literal name exists" {
+    run_in_bash '
+        tmp=$(mktemp -d)
+        trap "rm -rf \"$tmp\"" EXIT INT TERM HUP
+        git init -q -b main --bare "$tmp/remote.git"
+        git clone -q "$tmp/remote.git" "$tmp/work" 2>/dev/null
+        cd "$tmp/work"
+        git config user.email t@t; git config user.name t
+        git commit -q --allow-empty -m init
+        git push -q origin HEAD:main
+        git branch "origin/feature"
+        git_branch -D origin/feature
+    '
+    assert_success
+    assert_output --partial "Deleted branch"
+}
+
+@test "zsh: gb -D remotes/<remote>/<branch> deletes only that branch" {
+    run_in_zsh '
+        tmp=$(mktemp -d)
+        trap "rm -rf \"$tmp\"" EXIT INT TERM HUP
+        git init -q -b main --bare "$tmp/remote.git"
+        git clone -q "$tmp/remote.git" "$tmp/work" 2>/dev/null
+        cd "$tmp/work"
+        git config user.email t@t; git config user.name t
+        git commit -q --allow-empty -m init
+        git push -q origin HEAD:main
+        git push -q origin HEAD:wt/test/1
+        git push -q origin HEAD:wt/test/2
+        git_branch -D remotes/origin/wt/test/1 -y >/dev/null 2>&1
+        printf "REMAINING: "
+        git ls-remote --heads "$tmp/remote.git" | sed "s#.*refs/heads/##" | sort | tr "\n" " "
+    '
+    assert_success
+    assert_output --partial "REMAINING: main wt/test/2"
+    refute_output --partial "wt/test/1"
+}
+
 # --- git worktree functions ---
 
 @test "bash: gwt function exists" {


### PR DESCRIPTION
## Summary
- `gb -a`가 출력하는 `remotes/<remote>/<branch>` (또는 `<remote>/<branch>`) 형태를 그대로 받아 해당 브랜치 하나만 원격 서버에서 삭제하는 `gb -D` 문법을 추가한다.

## Changes
- `shell-common/functions/git.sh`: `_gb_delete_remote_single` 신설 — 첫 슬래시 세그먼트를 remote로, 나머지를 branch로 파싱해 `git push <remote> --delete <branch>` 실행. 기본은 확인 프롬프트, `-y`/`--yes`로 스킵. remote가 실재하지 않거나 같은 리터럴 이름의 로컬 브랜치가 존재하면 rc=2를 반환해 `git_branch`가 기존 `git branch -D` passthrough로 안전하게 fallback.
- `tests/bats/functions/git.bats`: 신규 문법(`remotes/<remote>/<branch>`, `<remote>/<branch>`), `-y` 없을 때 프롬프트 후 abort, 존재하지 않는 remote로의 fallback, 로컬 브랜치 동명 시 fallback 커버하는 bats 6건 추가(bash 5 + zsh 1).

## Test plan
- [x] `./tests/bats/lib/bats-core/bin/bats tests/bats/functions/git.bats` — 36/36 green
- [x] `shellcheck -s bash shell-common/functions/git.sh` — clean

## Related
Closes #1781

---
<details>
<summary>🤖 AI Metrics · 📊 ~2500 tokens · 👤 ~8 h · 🤖 ~2 min</summary>

<!-- ai-metrics:gh-pr -->
📊 ~2500 tokens · 👤 ~8 h · 🤖 ~2 min
<!-- /ai-metrics:gh-pr -->

</details>
