### PR TITLE
feat(plugin): skills 하위 저장소 일괄 최신화 스크립트 추가 (git-pull-skills) (#1783)

### DIFF
--- a/claude/plugin/git-pull-skills.sh
+++ b/claude/plugin/git-pull-skills.sh
@@ -1,0 +1,220 @@
+#!/usr/bin/env bash
+# claude/plugin/git-pull-skills.sh
+#
+# Batch fetch/pull/rebase all git repositories under ~/para/project/skills.
+# Safely skips dirty trees and detached/non-main branches.
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# Load UX library for semantic log colors (#1114)
+UX_LIB="$SCRIPT_DIR/../../shell-common/tools/ux_lib/ux_lib.sh"
+if [ -t 1 ] && [ -r "$UX_LIB" ]; then
+	# shellcheck source=../../shell-common/tools/ux_lib/ux_lib.sh
+	source "$UX_LIB"
+else
+	UX_PRIMARY="" UX_SUCCESS="" UX_ERROR="" UX_WARNING="" UX_INFO="" UX_MUTED="" UX_RESET="" UX_BOLD=""
+	ux_header() { printf '\n=== %s ===\n' "$1"; }
+	ux_section() { printf '\n--- %s ---\n' "$1"; }
+	ux_success() { printf 'OK: %s\n' "$1"; }
+	ux_error() { printf 'ERR: %s\n' "$1" >&2; }
+	ux_warning() { printf 'WARN: %s\n' "$1"; }
+	ux_info() { printf 'INFO: %s\n' "$1"; }
+	ux_bullet() { printf '  * %s\n' "$1"; }
+fi
+
+TARGET_DIR="${SKILLS_DIR:-$HOME/para/project/skills}"
+DRY_RUN=false
+ALL_BRANCHES=false
+
+_usage() {
+	cat <<USAGE
+Usage: git-pull-skills.sh [options]
+
+Options:
+  --dry-run             Check repository status and incoming updates without pulling
+  --all-branches        Pull non-main branches if tracking remote exists (default: skips non-main branches)
+  --target <dir>        Target directory to search for git repositories (default: ~/para/project/skills)
+  -h, --help, help      Show this help message
+USAGE
+}
+
+# Parse options
+while [ $# -gt 0 ]; do
+	case "$1" in
+	--dry-run)
+		DRY_RUN=true
+		shift
+		;;
+	--all-branches)
+		ALL_BRANCHES=true
+		shift
+		;;
+	--target)
+		if [ -z "${2:-}" ]; then
+			echo "${UX_ERROR}Error: --target requires a directory argument.${UX_RESET}" >&2
+			exit 2
+		fi
+		TARGET_DIR="$2"
+		shift 2
+		;;
+	--target=*)
+		TARGET_DIR="${1#*=}"
+		shift
+		;;
+	-h | --help | help)
+		_usage
+		exit 0
+		;;
+	*)
+		echo "${UX_ERROR}Unknown argument: $1${UX_RESET}" >&2
+		_usage >&2
+		exit 2
+		;;
+	esac
+done
+
+if [ ! -d "$TARGET_DIR" ]; then
+	ux_error "Target directory does not exist: $TARGET_DIR"
+	exit 1
+fi
+
+ux_header "Git Pull Skills: $TARGET_DIR"
+if $DRY_RUN; then
+	ux_info "Mode: DRY-RUN (no working directory modifications)"
+fi
+
+TOTAL=0
+UPDATED=0
+UP_TO_DATE=0
+SKIPPED_DIRTY=0
+SKIPPED_BRANCH=0
+SKIPPED_NOT_GIT=0
+FAILED=0
+
+# Iterate over subdirectories sorted alphabetically
+while IFS= read -r repo_dir; do
+	[ -n "$repo_dir" ] || continue
+	repo_name="$(basename "$repo_dir")"
+	TOTAL=$((TOTAL + 1))
+
+	# 1. Check if git repo
+	if ! git -C "$repo_dir" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+		ux_warning "$repo_name: not a git repository (skipped)"
+		SKIPPED_NOT_GIT=$((SKIPPED_NOT_GIT + 1))
+		continue
+	fi
+
+	# 2. Check current branch
+	branch="$(git -C "$repo_dir" branch --show-current 2>/dev/null || true)"
+	if [ -z "$branch" ]; then
+		ux_warning "$repo_name: detached HEAD (skipped)"
+		SKIPPED_BRANCH=$((SKIPPED_BRANCH + 1))
+		continue
+	fi
+
+	# Skip non-main/master branches by default unless --all-branches is set
+	if ! $ALL_BRANCHES && [ "$branch" != "main" ] && [ "$branch" != "master" ]; then
+		ux_info "$repo_name: on non-main branch '$branch' (skipped, use --all-branches to include)"
+		SKIPPED_BRANCH=$((SKIPPED_BRANCH + 1))
+		continue
+	fi
+
+	# 3. Check dirty state (uncommitted changes)
+	status_porcelain="$(git -C "$repo_dir" status --porcelain 2>/dev/null || true)"
+	if [ -n "$status_porcelain" ]; then
+		ux_warning "$repo_name: dirty working tree on '$branch' (skipped)"
+		SKIPPED_DIRTY=$((SKIPPED_DIRTY + 1))
+		continue
+	fi
+
+	# 4. Check remote origin
+	if ! git -C "$repo_dir" config --get remote.origin.url >/dev/null 2>&1; then
+		ux_warning "$repo_name: no remote 'origin' configured (skipped)"
+		SKIPPED_BRANCH=$((SKIPPED_BRANCH + 1))
+		continue
+	fi
+
+	# Fetch origin
+	if ! git -C "$repo_dir" fetch origin >/dev/null 2>&1; then
+		ux_error "$repo_name: git fetch origin failed"
+		FAILED=$((FAILED + 1))
+		continue
+	fi
+
+	# Determine tracking remote ref
+	remote_ref="origin/$branch"
+	if ! git -C "$repo_dir" rev-parse --verify "$remote_ref" >/dev/null 2>&1; then
+		# If branch is master/main and origin only has the other one, check fallback
+		if [ "$branch" = "master" ] && git -C "$repo_dir" rev-parse --verify "origin/main" >/dev/null 2>&1; then
+			remote_ref="origin/main"
+		elif [ "$branch" = "main" ] && git -C "$repo_dir" rev-parse --verify "origin/master" >/dev/null 2>&1; then
+			remote_ref="origin/master"
+		else
+			ux_warning "$repo_name: remote ref '$remote_ref' not found (skipped)"
+			SKIPPED_BRANCH=$((SKIPPED_BRANCH + 1))
+			continue
+		fi
+	fi
+
+	# Compare local branch with remote ref
+	local_sha="$(git -C "$repo_dir" rev-parse HEAD 2>/dev/null)"
+	remote_sha="$(git -C "$repo_dir" rev-parse "$remote_ref" 2>/dev/null)"
+
+	if [ "$local_sha" = "$remote_sha" ]; then
+		ux_success "$repo_name: up-to-date ($branch)"
+		UP_TO_DATE=$((UP_TO_DATE + 1))
+		continue
+	fi
+
+	# Check divergence
+	base_sha="$(git -C "$repo_dir" merge-base HEAD "$remote_ref" 2>/dev/null || true)"
+	if [ "$base_sha" = "$remote_sha" ]; then
+		ux_info "$repo_name: local is ahead of $remote_ref ($branch)"
+		UP_TO_DATE=$((UP_TO_DATE + 1))
+		continue
+	fi
+
+	if $DRY_RUN; then
+		if [ "$base_sha" = "$local_sha" ]; then
+			ux_info "$repo_name: updates available from $remote_ref (dry-run)"
+		else
+			ux_warning "$repo_name: diverged from $remote_ref (dry-run, rebase required)"
+		fi
+		UPDATED=$((UPDATED + 1))
+		continue
+	fi
+
+	# Pull / rebase
+	if git -C "$repo_dir" pull --ff-only origin "$branch" >/dev/null 2>&1; then
+		ux_success "$repo_name: updated via ff-only ($branch)"
+		UPDATED=$((UPDATED + 1))
+	elif git -C "$repo_dir" rebase "$remote_ref" >/dev/null 2>&1; then
+		ux_success "$repo_name: updated via rebase ($remote_ref)"
+		UPDATED=$((UPDATED + 1))
+	else
+		# Abort rebase if in progress to keep repo clean
+		git -C "$repo_dir" rebase --abort >/dev/null 2>&1 || true
+		ux_error "$repo_name: update failed (conflict or rebase error)"
+		FAILED=$((FAILED + 1))
+	fi
+
+done < <(find "$TARGET_DIR" -mindepth 1 -maxdepth 1 -type d | LC_ALL=C sort)
+
+ux_section "Summary"
+ux_bullet "Total scanned: $TOTAL"
+if $DRY_RUN; then
+	ux_bullet "Updates available: $UPDATED"
+else
+	ux_bullet "Updated: $UPDATED"
+fi
+ux_bullet "Up to date: $UP_TO_DATE"
+ux_bullet "Skipped (dirty): $SKIPPED_DIRTY"
+ux_bullet "Skipped (non-main / detached): $SKIPPED_BRANCH"
+ux_bullet "Skipped (not git): $SKIPPED_NOT_GIT"
+if [ "$FAILED" -gt 0 ]; then
+	ux_bullet "Failed: $FAILED"
+	exit 1
+fi
+
+exit 0

--- a/docs/guide/commands/claude-plugins.md
+++ b/docs/guide/commands/claude-plugins.md
@@ -13,7 +13,7 @@
 
 - Usage: claude-plugins-help [section|--list|--all]
 - sections
-    - commands: open_claude_plugins | list-plugins | claude-plugin-list | init-plugins-docs | sync-plugins-structure
+    - commands: open_claude_plugins | list-plugins | claude-plugin-list | git-pull-skills | init-plugins-docs | sync-plugins-structure
     - view: view-plugin-info | generate-plugin-doc-ko | create-plugin-structure-ko
     - examples: quick examples for create-plugin-ko
     - ai-tools: claude | agy | codex
@@ -29,6 +29,7 @@
 - open_claude_plugins  - Open marketplace plugins directory in VSCode
 - list-plugins         - List all available marketplaces and their skills
 - claude-plugin-list   - List installed plugins grouped by marketplace (SSOT: installed_plugins.json)
+- git-pull-skills      - Pull latest changes for all skill repositories under ~/para/project/skills
 - init-plugins-docs    - Initialize Korean documentation directory structure
 - sync-plugins-structure - Create directory structure mirroring plugins organization
 

--- a/shell-common/aliases/claude_plugins.sh
+++ b/shell-common/aliases/claude_plugins.sh
@@ -31,5 +31,9 @@ alias create-plugin-structure-ko='create_plugin_structure_ko'
 # Process plugin directory recursively
 alias process-plugin-ko='process_plugin_directory_ko'
 
+# Pull latest changes for all skills repositories
+alias git-pull-skills='${HOME}/dotfiles/claude/plugin/git-pull-skills.sh'
+
 # Show help for plugin management
 alias plugins-help='claude_plugins_help'
+

--- a/shell-common/functions/claude_plugins_help.sh
+++ b/shell-common/functions/claude_plugins_help.sh
@@ -7,7 +7,7 @@ case $- in *i*) ;; *) [ -n "${DOTFILES_FORCE_INIT-}" ] || return 0 ;; esac
 _claude_plugins_help_summary() {
     ux_info "Usage: claude-plugins-help [section|--list|--all]"
     ux_bullet "sections"
-    ux_bullet_sub "commands: open_claude_plugins | list-plugins | claude-plugin-list | init-plugins-docs | sync-plugins-structure"
+    ux_bullet_sub "commands: open_claude_plugins | list-plugins | claude-plugin-list | git-pull-skills | init-plugins-docs | sync-plugins-structure"
     ux_bullet_sub "view: view-plugin-info | generate-plugin-doc-ko | create-plugin-structure-ko"
     ux_bullet_sub "examples: quick examples for create-plugin-ko"
     ux_bullet_sub "ai-tools: claude | agy | codex"
@@ -32,6 +32,7 @@ _claude_plugins_help_rows_commands() {
     ux_bullet "open_claude_plugins  - Open marketplace plugins directory in VSCode"
     ux_bullet "list-plugins         - List all available marketplaces and their skills"
     ux_bullet "claude-plugin-list   - List installed plugins grouped by marketplace (SSOT: installed_plugins.json)"
+    ux_bullet "git-pull-skills      - Pull latest changes for all skill repositories under ~/para/project/skills"
     ux_bullet "init-plugins-docs    - Initialize Korean documentation directory structure"
     ux_bullet "sync-plugins-structure - Create directory structure mirroring plugins organization"
 }

--- a/tests/bats/tools/git_pull_skills.bats
+++ b/tests/bats/tools/git_pull_skills.bats
@@ -1,0 +1,119 @@
+#!/usr/bin/env bats
+# tests/bats/tools/git_pull_skills.bats
+# Validate git-pull-skills.sh: syntax, options, and repo synchronization.
+
+load '../test_helper'
+
+SCRIPT_UNDER_TEST="${DOTFILES_ROOT}/claude/plugin/git-pull-skills.sh"
+
+setup() {
+    setup_isolated_home
+}
+
+teardown() {
+    teardown_isolated_home
+}
+
+@test "git-pull-skills.sh passes bash syntax check" {
+    run bash -n "$SCRIPT_UNDER_TEST"
+    assert_success
+}
+
+@test "git-pull-skills.sh --help displays usage" {
+    run bash "$SCRIPT_UNDER_TEST" --help
+    assert_success
+    assert_output --partial "Usage: git-pull-skills.sh"
+    assert_output --partial "--dry-run"
+    assert_output --partial "--target"
+}
+
+@test "git-pull-skills.sh fails gracefully on missing target" {
+    run bash "$SCRIPT_UNDER_TEST" --target "/nonexistent_path_12345"
+    assert_failure
+    assert_output --partial "Target directory does not exist"
+}
+
+@test "git-pull-skills.sh synchronizes out-of-date git repository" {
+    local test_skills_dir="${TEST_TEMP_HOME}/skills"
+    mkdir -p "$test_skills_dir"
+
+    # Setup remote bare repo
+    local remote_repo="${TEST_TEMP_HOME}/remote.git"
+    git init --bare "$remote_repo" >/dev/null 2>&1
+
+    # Setup upstream clone to push initial commit
+    local upstream_clone="${TEST_TEMP_HOME}/upstream"
+    git clone "$remote_repo" "$upstream_clone" >/dev/null 2>&1
+    (
+        cd "$upstream_clone"
+        git checkout -b main >/dev/null 2>&1
+        echo "v1" > file.txt
+        git config user.name "Test"
+        git config user.email "test@example.com"
+        git add file.txt
+        git commit -m "commit 1" >/dev/null 2>&1
+        git push origin main >/dev/null 2>&1
+    )
+
+    # Setup local clone inside test_skills_dir
+    local local_repo="${test_skills_dir}/sample-skill"
+    git clone -b main "$remote_repo" "$local_repo" >/dev/null 2>&1
+    (
+        cd "$local_repo"
+        git config user.name "Test"
+        git config user.email "test@example.com"
+    )
+
+    # Push commit 2 to remote
+    (
+        cd "$upstream_clone"
+        echo "v2" > file.txt
+        git commit -am "commit 2" >/dev/null 2>&1
+        git push origin main >/dev/null 2>&1
+    )
+
+    # Dry-run check
+    run bash "$SCRIPT_UNDER_TEST" --target "$test_skills_dir" --dry-run
+    assert_success
+    assert_output --partial "sample-skill: updates available from origin/main (dry-run)"
+    assert_output --partial "Updates available: 1"
+
+    # Verify local file is still v1
+    [ "$(cat "${local_repo}/file.txt")" = "v1" ]
+
+    # Real run
+    run bash "$SCRIPT_UNDER_TEST" --target "$test_skills_dir"
+    assert_success
+    assert_output --partial "sample-skill: updated via ff-only (main)"
+    assert_output --partial "Updated: 1"
+
+    # Verify local file is now v2
+    [ "$(cat "${local_repo}/file.txt")" = "v2" ]
+}
+
+@test "git-pull-skills.sh skips dirty repository" {
+    local test_skills_dir="${TEST_TEMP_HOME}/skills"
+    mkdir -p "$test_skills_dir"
+
+    local remote_repo="${TEST_TEMP_HOME}/remote.git"
+    git init --bare "$remote_repo" >/dev/null 2>&1
+
+    local local_repo="${test_skills_dir}/dirty-skill"
+    git clone "$remote_repo" "$local_repo" >/dev/null 2>&1
+    (
+        cd "$local_repo"
+        git checkout -b main >/dev/null 2>&1
+        git config user.name "Test"
+        git config user.email "test@example.com"
+        echo "v1" > file.txt
+        git add file.txt
+        git commit -m "commit 1" >/dev/null 2>&1
+        git push origin main >/dev/null 2>&1
+        echo "dirty changes" >> file.txt
+    )
+
+    run bash "$SCRIPT_UNDER_TEST" --target "$test_skills_dir"
+    assert_success
+    assert_output --partial "dirty-skill: dirty working tree on 'main' (skipped)"
+    assert_output --partial "Skipped (dirty): 1"
+}


### PR DESCRIPTION
Closes #1783

## 개요
- `~/para/project/skills` 하위의 여러 skill 저장소들을 일괄 탐색하여 최신 upstream/origin 변경 사항을 안전하게 pull/rebase하는 유틸리티 `claude/plugin/git-pull-skills.sh` 스크립트를 추가합니다.
- `shell-common/aliases/claude_plugins.sh` 에 `git-pull-skills` alias를 등록하여 어디서든 쉽게 호출할 수 있도록 연동합니다.
- `claude_plugins_help.sh` 및 `docs/guide/commands/claude-plugins.md` 에 관련 도움말과 명령어 목록을 반영합니다.

## 변경 내용
- `claude/plugin/git-pull-skills.sh`:
  - `--dry-run`, `--target <dir>`, `--all-branches` 옵션 지원
  - git 저장소 여부 확인, dirty 워킹 트리 보존 및 스킵, detached HEAD 및 non-main 브랜치 안전 처리
  - `ux_lib.sh` 기반의 직관적인 상태/결과 요약 리포트 출력
- `shell-common/aliases/claude_plugins.sh`:
  - `alias git-pull-skills='${HOME}/dotfiles/claude/plugin/git-pull-skills.sh'` 등록
- `shell-common/functions/claude_plugins_help.sh` 및 문서 갱신
- `tests/bats/tools/git_pull_skills.bats`: bats 단위 테스트 추가