### PR TITLE
feat(skills): Antigravity용 네임스페이스 기반 skills 심볼릭 링크 일괄 등록 스크립트 추가 (#1784)

### DIFF
--- a/scripts/setup-skills-ssot.sh
+++ b/scripts/setup-skills-ssot.sh
@@ -631,6 +631,12 @@ else
     log_warning "Antigravity(agy) 를 찾지 못했습니다. 건너뜁니다: ${HOME}/.gemini/antigravity-cli / PATH"
 fi
 
+# 3c. Gemini / Antigravity 네임스페이스(<namespace>:<skill>) 심볼릭 링크 동기화 (#1784)
+NAMESPACE_SYNC_SCRIPT="${DOTFILES_ROOT}/scripts/sync-gemini-skills-namespace.sh"
+if [ -f "$NAMESPACE_SYNC_SCRIPT" ]; then
+    bash "$NAMESPACE_SYNC_SCRIPT" || log_warning "네임스페이스 스킬 동기화 중 경고 발생"
+fi
+
 # 4. Hermes: 전용 네임스페이스 서브디렉토리에서 entry-level 합성 (issue #1376)
 #    루트를 직접 합성하지 않는 이유는 파일 상단 "Hermes 예외" 참고.
 HERMES_SKILLS="${HOME}/.hermes/skills/dotfiles"

--- a/scripts/sync-gemini-skills-namespace.sh
+++ b/scripts/sync-gemini-skills-namespace.sh
@@ -1,0 +1,227 @@
+#!/bin/bash
+# scripts/sync-gemini-skills-namespace.sh: Antigravity/Gemini 네임스페이스 기반 skills 심볼릭 링크 일괄 등록
+#
+# PURPOSE: $WORKSPACE_ROOT 아래 각 <repo>/skills/<skill>/SKILL.md 를 탐색하여
+#          ~/.gemini/config/skills 및 ~/.gemini/skills 에 <namespace>:<skill> 형태의
+#          심볼릭 링크를 일괄 생성/동기화한다 (issue #1784).
+#
+# WHEN TO RUN: 수동 실행 가능, 또는 scripts/setup-skills-ssot.sh 내부에서 자동 호출.
+
+set -e
+
+_SCRIPT_PATH="$(realpath "${BASH_SOURCE[0]}")"
+DOTFILES_ROOT="$(cd "$(dirname "$_SCRIPT_PATH")/.." && pwd)"
+
+# Load UX library
+UX_LIB="${DOTFILES_ROOT}/shell-common/tools/ux_lib/ux_lib.sh"
+if [ -f "$UX_LIB" ]; then
+    # shellcheck source=../shell-common/tools/ux_lib/ux_lib.sh
+    source "$UX_LIB"
+else
+    ux_header() { echo "=== $1 ==="; }
+    ux_section() { echo ""; echo "$1"; }
+    ux_success() { echo "✓ $1"; }
+    ux_info() { echo "ℹ $1"; }
+    ux_warning() { echo "⚠ $1"; }
+    ux_error() { echo "✗ $1" >&2; }
+fi
+
+SKILL_SOURCES_LIB="${DOTFILES_ROOT}/shell-common/functions/skill_sources.sh"
+if [ -f "$SKILL_SOURCES_LIB" ]; then
+    # shellcheck source=../shell-common/functions/skill_sources.sh
+    source "$SKILL_SOURCES_LIB"
+else
+    echo "Error: skill sources library not found at $SKILL_SOURCES_LIB" >&2
+    exit 1
+fi
+
+_usage() {
+    cat <<'USAGE_EOF'
+Usage: sync-gemini-skills-namespace.sh [options]
+
+Options:
+  --dry-run      실제 심볼릭 링크 생성/삭제 없이 대상 목록만 출력
+  --prune        더 이상 유효하지 않은 네임스페이스 심볼릭 링크 정리 (기본 활성화)
+  --no-prune     stale 심볼릭 링크 정리 비활성화
+  -h, --help     도움말 출력 후 종료
+
+대상 디렉터리:
+  - ~/.gemini/config/skills/ (Antigravity CLI)
+  - ~/.gemini/skills/        (Gemini CLI)
+USAGE_EOF
+}
+
+DRY_RUN=0
+PRUNE=1
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --dry-run)
+            DRY_RUN=1
+            shift
+            ;;
+        --prune)
+            PRUNE=1
+            shift
+            ;;
+        --no-prune)
+            PRUNE=0
+            shift
+            ;;
+        -h|--help|help)
+            _usage
+            exit 0
+            ;;
+        *)
+            ux_error "알 수 없는 옵션: $1"
+            _usage >&2
+            exit 2
+            ;;
+    esac
+done
+
+WORKSPACE_ROOT_RESOLVED="$(_skill_workspace_root || true)"
+if [ -z "$WORKSPACE_ROOT_RESOLVED" ]; then
+    ux_warning "skill 소스 루트를 찾지 못했습니다 — 동기화를 건너뜁니다."
+    exit 0
+fi
+
+# 네임스페이스 엔트리 수집: <skill_path><TAB><namespace>:<skill_name>
+collect_namespace_skills() {
+    local skill_path skill_name repo namespace entry_name seen="|"
+
+    while IFS= read -r skill_path; do
+        [ -n "$skill_path" ] || continue
+        skill_name="${skill_path##*/}"
+        repo="${skill_path%/*/*}"
+        repo="${repo##*/}"
+
+        # worktree 디렉터리 스킵 (예: *-issue-[0-9]*, 또는 .git 이 파일인 경우)
+        case "$repo" in
+            *-issue-[0-9]*) continue ;;
+        esac
+        [ -f "${skill_path%/*/*}/.git" ] && continue
+
+        namespace="${repo%-skills}"
+        entry_name="${namespace}:${skill_name}"
+
+        case "$seen" in
+            *"|${entry_name}|"*) continue ;;
+        esac
+        seen="${seen}${entry_name}|"
+
+        printf "%s\t%s\n" "$skill_path" "$entry_name"
+    done <<< "$(_skill_workspace_dirs "$WORKSPACE_ROOT_RESOLVED")"
+}
+
+_agy_is_installed() {
+    [ -d "${HOME}/.gemini/antigravity-cli" ] && return 0
+    command -v agy >/dev/null 2>&1
+}
+
+# 심볼릭 링크 동기화 대상 디렉터리
+TARGET_DIRS=()
+if _agy_is_installed || [ -d "${HOME}/.gemini/config/skills" ]; then
+    TARGET_DIRS+=("${HOME}/.gemini/config/skills")
+fi
+if [ -d "${HOME}/.gemini" ]; then
+    TARGET_DIRS+=("${HOME}/.gemini/skills")
+fi
+
+if [ ${#TARGET_DIRS[@]} -eq 0 ]; then
+    ux_info "Gemini / Antigravity 설정 디렉터리가 없어 동기화를 건너뜁니다."
+    exit 0
+fi
+
+SKILL_ENTRIES="$(collect_namespace_skills)"
+if [ -z "$SKILL_ENTRIES" ]; then
+    ux_warning "등록할 네임스페이스 스킬이 없습니다."
+    exit 0
+fi
+
+entry_count="$(printf '%s\n' "$SKILL_ENTRIES" | grep -c .)"
+ux_header "Gemini / Antigravity 네임스페이스 스킬 동기화"
+ux_info "발견된 스킬: ${entry_count}개 (루트: ${WORKSPACE_ROOT_RESOLVED})"
+[ "$DRY_RUN" -eq 1 ] && ux_warning "DRY-RUN 모드: 실제 링크를 생성하거나 삭제하지 않습니다."
+
+for target_dir in "${TARGET_DIRS[@]}"; do
+    ux_section "대상: ${target_dir}"
+    [ "$DRY_RUN" -eq 0 ] && mkdir -p "$target_dir"
+
+    linked=0
+    unchanged=0
+    pruned=0
+
+    while IFS=$'\t' read -r src_path link_name; do
+        [ -n "$src_path" ] && [ -n "$link_name" ] || continue
+        dest_link="${target_dir}/${link_name}"
+        src_real="$(readlink -f "$src_path" 2>/dev/null || printf '%s' "$src_path")"
+
+        if [ -L "$dest_link" ]; then
+            dest_real="$(readlink -f "$dest_link" 2>/dev/null || true)"
+            if [ "$dest_real" = "$src_real" ]; then
+                unchanged=$((unchanged + 1))
+                continue
+            fi
+        fi
+
+        if [ "$DRY_RUN" -eq 1 ]; then
+            ux_info "[dry-run] link: ${link_name} -> ${src_path}"
+            linked=$((linked + 1))
+        else
+            ln -sfn "$src_path" "$dest_link"
+            linked=$((linked + 1))
+        fi
+    done <<< "$SKILL_ENTRIES"
+
+    # Stale prune: target_dir 내의 *:* 형태 symlink 중 유효하지 않거나 소스가 사라진 것 정리
+    if [ "$PRUNE" -eq 1 ]; then
+        for existing in "$target_dir"/*; do
+            [ -L "$existing" ] || continue
+            fname="${existing##*/}"
+            case "$fname" in
+                *:*) ;;
+                *) continue ;; # 네임스페이스 심볼릭 링크만 관리
+            esac
+
+            # link 가 가리키는 대상이 없거나 존재하지 않는 디렉터리인 경우
+            if [ ! -e "$existing" ]; then
+                if [ "$DRY_RUN" -eq 1 ]; then
+                    ux_info "[dry-run] prune (broken): ${fname}"
+                    pruned=$((pruned + 1))
+                else
+                    rm -f "$existing"
+                    pruned=$((pruned + 1))
+                fi
+                continue
+            fi
+
+            # 소스 목록에 포함되어 있는지 확인
+            existing_target="$(readlink -f "$existing" 2>/dev/null || true)"
+            is_valid=0
+            while IFS=$'\t' read -r chk_src chk_name; do
+                if [ "$chk_name" = "$fname" ]; then
+                    chk_real="$(readlink -f "$chk_src" 2>/dev/null || true)"
+                    if [ "$chk_real" = "$existing_target" ]; then
+                        is_valid=1
+                        break
+                    fi
+                fi
+            done <<< "$SKILL_ENTRIES"
+
+            if [ "$is_valid" -eq 0 ]; then
+                if [ "$DRY_RUN" -eq 1 ]; then
+                    ux_info "[dry-run] prune (unmanaged/stale): ${fname}"
+                    pruned=$((pruned + 1))
+                else
+                    rm -f "$existing"
+                    pruned=$((pruned + 1))
+                fi
+            fi
+        done
+    fi
+
+    ux_success "완료: 신규/갱신 ${linked}개, 유지 ${unchanged}개, 정리 ${pruned}개"
+done
+
+ux_success "네임스페이스 스킬 동기화 완료"

--- a/scripts/sync-gemini-skills-namespace.sh
+++ b/scripts/sync-gemini-skills-namespace.sh
@@ -102,7 +102,10 @@ collect_namespace_skills() {
         esac
         [ -f "${skill_path%/*/*}/.git" ] && continue
 
-        namespace="${repo%-skills}"
+        case "$repo" in
+            *-skills) namespace="${repo%-skills}" ;;
+            *) namespace="$repo" ;;
+        esac
         entry_name="${namespace}:${skill_name}"
 
         case "$seen" in
@@ -138,6 +141,13 @@ if [ -z "$SKILL_ENTRIES" ]; then
     ux_warning "등록할 네임스페이스 스킬이 없습니다."
     exit 0
 fi
+
+# O(1) 조회를 위한 associative array 구성
+declare -A SKILL_MAP=()
+while IFS=$'\t' read -r src_path link_name; do
+    [ -n "$src_path" ] && [ -n "$link_name" ] || continue
+    SKILL_MAP["$link_name"]="$(readlink -f "$src_path" 2>/dev/null || printf '%s' "$src_path")"
+done <<< "$SKILL_ENTRIES"
 
 entry_count="$(printf '%s\n' "$SKILL_ENTRIES" | grep -c .)"
 ux_header "Gemini / Antigravity 네임스페이스 스킬 동기화"
@@ -176,6 +186,7 @@ for target_dir in "${TARGET_DIRS[@]}"; do
 
     # Stale prune: target_dir 내의 *:* 형태 symlink 중 유효하지 않거나 소스가 사라진 것 정리
     if [ "$PRUNE" -eq 1 ]; then
+        shopt -s nullglob
         for existing in "$target_dir"/*; do
             [ -L "$existing" ] || continue
             fname="${existing##*/}"
@@ -196,20 +207,11 @@ for target_dir in "${TARGET_DIRS[@]}"; do
                 continue
             fi
 
-            # 소스 목록에 포함되어 있는지 확인
+            # 소스 목록에 포함되어 있는지 O(1) 해시맵 검사
             existing_target="$(readlink -f "$existing" 2>/dev/null || true)"
-            is_valid=0
-            while IFS=$'\t' read -r chk_src chk_name; do
-                if [ "$chk_name" = "$fname" ]; then
-                    chk_real="$(readlink -f "$chk_src" 2>/dev/null || true)"
-                    if [ "$chk_real" = "$existing_target" ]; then
-                        is_valid=1
-                        break
-                    fi
-                fi
-            done <<< "$SKILL_ENTRIES"
+            expected_target="${SKILL_MAP[$fname]:-}"
 
-            if [ "$is_valid" -eq 0 ]; then
+            if [ -z "$expected_target" ] || [ "$expected_target" != "$existing_target" ]; then
                 if [ "$DRY_RUN" -eq 1 ]; then
                     ux_info "[dry-run] prune (unmanaged/stale): ${fname}"
                     pruned=$((pruned + 1))
@@ -219,6 +221,7 @@ for target_dir in "${TARGET_DIRS[@]}"; do
                 fi
             fi
         done
+        shopt -u nullglob
     fi
 
     ux_success "완료: 신규/갱신 ${linked}개, 유지 ${unchanged}개, 정리 ${pruned}개"

--- a/tests/bats/tools/sync_gemini_skills_namespace.bats
+++ b/tests/bats/tools/sync_gemini_skills_namespace.bats
@@ -1,0 +1,142 @@
+#!/usr/bin/env bats
+# tests/bats/tools/sync_gemini_skills_namespace.bats
+# Validate scripts/sync-gemini-skills-namespace.sh (issue #1784)
+
+load '../test_helper'
+
+SYNC_SCRIPT="${DOTFILES_ROOT}/scripts/sync-gemini-skills-namespace.sh"
+UX_LIB_SOURCE="${DOTFILES_ROOT}/shell-common/tools/ux_lib/ux_lib.sh"
+SKILL_SOURCES_LIB_SOURCE="${DOTFILES_ROOT}/shell-common/functions/skill_sources.sh"
+
+setup() {
+    setup_isolated_home
+
+    FIXTURE_DOTFILES="${TEST_TEMP_HOME}/fixture-dotfiles"
+    FIXTURE_HOME="${TEST_TEMP_HOME}/fixture-home"
+    WORKSPACE="${FIXTURE_HOME}/para/project/skills"
+
+    mkdir -p \
+        "${FIXTURE_DOTFILES}/scripts" \
+        "${FIXTURE_DOTFILES}/shell-common/tools/ux_lib" \
+        "${FIXTURE_DOTFILES}/shell-common/functions" \
+        "${FIXTURE_HOME}/.gemini/config/skills" \
+        "${FIXTURE_HOME}/.gemini/skills"
+
+    cp "$SYNC_SCRIPT" "${FIXTURE_DOTFILES}/scripts/sync-gemini-skills-namespace.sh"
+    cp "$UX_LIB_SOURCE" "${FIXTURE_DOTFILES}/shell-common/tools/ux_lib/ux_lib.sh"
+    cp "$SKILL_SOURCES_LIB_SOURCE" "${FIXTURE_DOTFILES}/shell-common/functions/skill_sources.sh"
+
+    # Create dummy skill repos (mindepth 4 maxdepth 4: <root>/<repo>/skills/<skill>/SKILL.md)
+    mkdir -p \
+        "${WORKSPACE}/gh-flow-skills/skills/issue" \
+        "${WORKSPACE}/gh-flow-skills/skills/autopilot" \
+        "${WORKSPACE}/gh-issue-skills/skills/make-issue" \
+        "${WORKSPACE}/authoring-skills/skills/skill-check"
+
+    cat > "${WORKSPACE}/gh-flow-skills/skills/issue/SKILL.md" <<'SKILLEOF'
+---
+name: issue
+description: issue skill
+---
+SKILLEOF
+    cat > "${WORKSPACE}/gh-flow-skills/skills/autopilot/SKILL.md" <<'SKILLEOF'
+---
+name: autopilot
+description: autopilot skill
+---
+SKILLEOF
+    cat > "${WORKSPACE}/gh-issue-skills/skills/make-issue/SKILL.md" <<'SKILLEOF'
+---
+name: make-issue
+description: make-issue skill
+---
+SKILLEOF
+    cat > "${WORKSPACE}/authoring-skills/skills/skill-check/SKILL.md" <<'SKILLEOF'
+---
+name: skill-check
+description: skill check skill
+---
+SKILLEOF
+
+    export FIXTURE_DOTFILES FIXTURE_HOME WORKSPACE
+}
+
+teardown() {
+    teardown_isolated_home
+}
+
+run_sync() {
+    HOME="$FIXTURE_HOME" WORKSPACE_ROOT="$WORKSPACE" \
+        run bash "${FIXTURE_DOTFILES}/scripts/sync-gemini-skills-namespace.sh" "$@"
+}
+
+@test "sync-gemini-skills-namespace: creates namespaced symlinks in agy and gemini dirs (#1784)" {
+    run_sync
+    assert_success
+
+    local agy_dir="${FIXTURE_HOME}/.gemini/config/skills"
+    local gem_dir="${FIXTURE_HOME}/.gemini/skills"
+
+    for target in "$agy_dir" "$gem_dir"; do
+        [ -L "${target}/gh-flow:issue" ]
+        [ "$(readlink -f "${target}/gh-flow:issue")" = "$(readlink -f "${WORKSPACE}/gh-flow-skills/skills/issue")" ]
+        [ -L "${target}/gh-flow:autopilot" ]
+        [ "$(readlink -f "${target}/gh-flow:autopilot")" = "$(readlink -f "${WORKSPACE}/gh-flow-skills/skills/autopilot")" ]
+        [ -L "${target}/gh-issue:make-issue" ]
+        [ "$(readlink -f "${target}/gh-issue:make-issue")" = "$(readlink -f "${WORKSPACE}/gh-issue-skills/skills/make-issue")" ]
+        [ -L "${target}/authoring:skill-check" ]
+        [ "$(readlink -f "${target}/authoring:skill-check")" = "$(readlink -f "${WORKSPACE}/authoring-skills/skills/skill-check")" ]
+    done
+}
+
+@test "sync-gemini-skills-namespace: dry-run does not create symlinks (#1784)" {
+    run_sync --dry-run
+    assert_success
+    assert_output --partial "DRY-RUN 모드"
+    assert_output --partial "gh-flow:issue"
+
+    local agy_dir="${FIXTURE_HOME}/.gemini/config/skills"
+    [ ! -e "${agy_dir}/gh-flow:issue" ]
+}
+
+@test "sync-gemini-skills-namespace: idempotent on multiple runs (#1784)" {
+    run_sync
+    assert_success
+
+    run_sync
+    assert_success
+    assert_output --partial "유지 4개"
+}
+
+@test "sync-gemini-skills-namespace: prunes stale namespaced links (#1784)" {
+    run_sync
+    assert_success
+
+    local agy_dir="${FIXTURE_HOME}/.gemini/config/skills"
+    [ -L "${agy_dir}/gh-flow:autopilot" ]
+
+    # Remove autopilot skill
+    rm -rf "${WORKSPACE}/gh-flow-skills/skills/autopilot"
+
+    run_sync
+    assert_success
+    [ ! -e "${agy_dir}/gh-flow:autopilot" ]
+    [ -L "${agy_dir}/gh-flow:issue" ]
+}
+
+@test "sync-gemini-skills-namespace: skips worktree repos (#1784)" {
+    mkdir -p "${WORKSPACE}/gh-flow-skills-issue-99-1/skills/shadowed"
+    printf 'gitdir: elsewhere\n' > "${WORKSPACE}/gh-flow-skills-issue-99-1/.git"
+    cat > "${WORKSPACE}/gh-flow-skills-issue-99-1/skills/shadowed/SKILL.md" <<'SKILLEOF'
+---
+name: shadowed
+---
+SKILLEOF
+
+    run_sync
+    assert_success
+
+    local agy_dir="${FIXTURE_HOME}/.gemini/config/skills"
+    [ ! -e "${agy_dir}/gh-flow:shadowed" ]
+    [ ! -e "${agy_dir}/gh-flow-skills-issue-99-1:shadowed" ]
+}


### PR DESCRIPTION
## 개요
- Antigravity CLI(agy)에서 Claude Code 스타일의 `<plugin>:<skill>` 네임스페이스 호출을 지원하기 위한 심볼릭 링크 동기화 스크립트 `scripts/sync-gemini-skills-namespace.sh` 추가
- `scripts/setup-skills-ssot.sh` 3c 단계에 통합하여 agy 스킬 합성 후 자동 실행
- Bats 테스트 및 회귀 테스트 추가

## 주요 변경 사항
1. `scripts/sync-gemini-skills-namespace.sh`:
   - `$WORKSPACE_ROOT` (`~/para/project/skills`) 아래의 모든 `<repo>/skills/<skill>/SKILL.md`를 스캔
   - 저장소 이름 접미사 `-skills`를 제거하여 네임스페이스 도출 (예: `gh-flow-skills` -> `gh-flow:issue`)
   - `~/.gemini/config/skills` 및 `~/.gemini/skills`에 `<namespace>:<skill>` 심볼릭 링크 생성
   - `--dry-run`, `--prune` / `--no-prune` 플래그 지원
   - git worktree (`*-issue-[0-9]*` 및 `.git` 파일) 자동 제외
   - 비관리 `*:*` stale 심볼릭 링크 안전 prune (단일 이름 심볼릭 링크는 보존)
2. `scripts/setup-skills-ssot.sh`:
   - Step 3c에 `sync-gemini-skills-namespace.sh` 연동
3. `tests/bats/tools/sync_gemini_skills_namespace.bats`:
   - 링크 생성, dry-run, 멱등성, stale prune, worktree skip 등 5개 테스트 케이스 검증 통과

Closes #1784