### PR TITLE
refactor(skills): 순정 Gemini CLI 지원 제거 및 agy 단일화 (#1787)

### DIFF
--- a/agy/AGENTS.md
+++ b/agy/AGENTS.md
@@ -45,32 +45,29 @@ PATH SSOT 로 관리한다. 따라서:
   `export PATH=".../.local/bin:$PATH"` 라인이 다시 나타나면 그것은
   `agy install` 이 재삽입한 중복이므로 제거한다.
 
-## Skill 검색 경로 (#1731)
+## Skill 검색 경로 (#1731, #1787)
 
-`agy` 는 `~/.gemini/` 를 Gemini 와 공유하지만 **skill 검색 경로는 상속하지
-않는다**. `agy` 의 Global Customizations Root 는 `~/.gemini/config/` 이고,
+`agy` 는 `~/.gemini/` 를 사용하지만 **skill 검색 경로는 독자적이다**.
+`agy` 의 Global Customizations Root 는 `~/.gemini/config/` 이고,
 skill 은 그 아래 `skills/<name>/SKILL.md` 에서만 발견된다. 워크스페이스
-루트는 `<workspace>/.agents/skills/` 다. `~/.gemini/skills` 는 `agy` 가
-전혀 읽지 않는다.
+루트는 `<workspace>/.agents/skills/` 다. 순정 `gemini` CLI 전용이던
+`~/.gemini/skills` 는 지원이 제거되어 `agy` 단일 경로(`~/.gemini/config/skills`)로
+일원화되었다 (#1787).
 
 | 경로 | 읽는 도구 |
 |---|---|
 | `~/.gemini/config/skills/<name>/` | `agy` (global) |
 | `<workspace>/.agents/skills/<name>/` | `agy` (workspace) |
 | `~/.gemini/antigravity-cli/builtin/skills/` | `agy` 내장 (수정 금지) |
-| `~/.gemini/skills/<name>/` | 순정 `gemini` CLI 전용 — `agy` 는 무시 |
+| `~/.gemini/skills/` | 레거시 경로 (순정 gemini 제거로 폐기/정리됨, #1787) |
 
-따라서 `scripts/setup-skills-ssot.sh` 는 Gemini 블록과 별개로 `agy` 전용
-합성 블록(`AGY_SKILLS`)을 갖는다. 두 경로 모두에 합성하므로 어느 CLI 를
-쓰든 워크스페이스 15-repo 스킬이 보인다.
-
-`#1684` 가 "agy 에 repo 스킬이 하나도 안 보인다" 로 FAIL 한 원인이 이
-상속 가정이었다 (#1410 Phase 4-5 G-1).
+따라서 `scripts/setup-skills-ssot.sh` 는 `agy` 단일 경로(`AGY_SKILLS`)만
+합성하며, 잔여 `~/.gemini/skills` symlink 는 자동 정리한다 (#1787).
 
 ## Non-Goals
 
 - `antigravity`(WSL 이 상속한 Windows VS Code 계열 GUI 실행기) 통합 — 별개 도구.
-- Gemini CLI(`gemini` 바이너리) 자체 제거 — 이 모듈은 shell 통합 레이어만 다룬다.
+- 순정 `gemini` CLI 지원 복구 — agy 로 완전히 단일화됨 (#1787).
 
 ## References
 

--- a/claude/AGENTS.md
+++ b/claude/AGENTS.md
@@ -53,7 +53,7 @@ marketplace repo 로 분리됐고, `claude/skills/` 원본은 Phase 4 에서 삭
 
 ### 절대 하지 말 것
 
-- `~/.claude*/skills/`, `~/.gemini/skills/`, `~/.gemini/config/skills/`, `~/.codex/skills/`, `~/.config/opencode/skills/` 직접 편집 금지
+- `~/.claude*/skills/`, `~/.gemini/config/skills/`, `~/.codex/skills/`, `~/.config/opencode/skills/` 직접 편집 금지
 - 스킬은 워크스페이스 repo(`~/para/project/skills/<repo>/skills/`)에서만 생성/수정 — 합성 대상 디렉토리에서 직접 만들지 말 것
 - Codex `.system/` 디렉토리 삭제 금지 (Codex 내장 스킬)
 
@@ -83,8 +83,7 @@ marketplace repo 로 분리됐고, `claude/skills/` 원본은 Phase 4 에서 삭
 # 모든 환경 공통 (issue #791 — CLI 모두 entry-level 합성)
 ~/.codex/skills/<name>                   -> <workspace>/<repo>/skills/<name> (entry symlink, #707 → #791)
 ~/.config/opencode/skills/<name>         -> <workspace>/<repo>/skills/<name> (entry symlink, #791)
-~/.gemini/skills/<name>                  -> <workspace>/<repo>/skills/<name> (entry symlink, #791 — 순정 gemini)
-~/.gemini/config/skills/<name>           -> <workspace>/<repo>/skills/<name> (entry symlink, #1731 — agy)
+~/.gemini/config/skills/<name>           -> <workspace>/<repo>/skills/<name> (entry symlink, #1731 — agy, #1787)
 ```
 
 `statusline-tokens.sh` (#1380) 은 계정 dir 로 링크하지 **않는다** — `statusline-command.sh` 가 자기 경로의 symlink 를 따라간 뒤 형제 파일로 source 하므로 SSOT 한 곳에만 있으면 직접 실행/symlink 경로 양쪽에서 해석된다. 없으면 세션 누적 토큰 세그먼트만 빠지고 나머지는 정상 렌더된다.

--- a/scripts/setup-skills-ssot.sh
+++ b/scripts/setup-skills-ssot.sh
@@ -13,11 +13,14 @@
 #     ${WORKSPACE_ROOT:-$HOME/para/project/skills}/<repo>/skills/<skill>/SKILL.md
 #
 # 연결 전략 (issue #791 / #1376 — 아래 CLI 모두 entry-level 합성):
-#   - entry-level 합성 디렉토리 (#707 / #791 / #1376):
+#   - entry-level 합성 디렉토리 (#707 / #791 / #1376 / #1787):
 #     ~/.config/opencode/skills/<skill>     → <workspace>/<repo>/skills/<skill>
-#     ~/.gemini/skills/<skill>              → <workspace>/<repo>/skills/<skill>
 #     ~/.gemini/config/skills/<skill>       → <workspace>/<repo>/skills/<skill>  (agy)
 #     ~/.hermes/skills/dotfiles/<skill>     → <workspace>/<repo>/skills/<skill>
+#
+#   - 순정 Gemini CLI 지원 제거 및 agy 단일화 (#1787):
+#     순정 gemini CLI 는 agy(Antigravity CLI)로 완전히 대체되었으며,
+#     ~/.gemini/skills 에 대한 합성은 중단되고 기존 잔여 링크는 정리된다.
 #
 #   - Hermes 예외 (#1376, NF-1): Hermes 는 다른 CLI 와 달리 ~/.hermes/skills/
 #     루트를 자체 hub/curator 가 능동적으로 관리한다 (.hub/, .bundled_manifest,
@@ -29,7 +32,7 @@
 #     ~/.codex/skills/.system                          ← local (codex managed)
 #     ~/.codex/skills/<custom-skill>                   → <workspace>/<repo>/skills/<skill>
 #
-#   - 마이그레이션 (#791): 기존 opencode/gemini 의 디렉토리-단위 symlink 는
+#   - 마이그레이션 (#791): 기존 opencode 의 디렉토리-단위 symlink 는
 #     entry-level 합성으로 변환된다. 사용자가 직접 만든 symlink (target 이
 #     관리 대상 밖이면서 살아 있는 경우) 는 보존 + warn.
 #
@@ -37,12 +40,9 @@
 # 모두 동일 layout (Hermes 만 서브디렉토리 — 위 예외 참고) 이므로 외부에서
 # 추가된 symlink 도 합성 대상 전부에 동일하게 적용된다.
 #
-# Antigravity CLI (agy) 는 전용 분기를 갖는다 (#1731). agy 는 OAuth 토큰을
-# ~/.gemini/antigravity-cli/ 에 두어 Gemini 런타임을 공유하지만, skill 검색
-# 경로까지 상속하지는 않는다 — agy 의 Global Customizations Root 는
-# ~/.gemini/config/ 이고 skill 은 그 아래 skills/ 에서만 발견된다.
-# ~/.gemini/skills 는 agy 가 읽지 않으므로 (#1684 에서 FAIL 로 실측),
-# 두 경로 모두에 합성한다. 상세: agy/AGENTS.md.
+# Antigravity CLI (agy) 는 자체 경로를 갖는다 (#1731, #1787). agy 의 Global
+# Customizations Root 는 ~/.gemini/config/ 이고 skill 은 그 아래 skills/ 에서만 발견된다.
+# 상세: agy/AGENTS.md.
 
 # --- Constants ---
 
@@ -602,12 +602,15 @@ else
     done <<< "$CODEX_HOME_LIST"
 fi
 
-# 3. Gemini: entry-level 합성 (issue #791 — 5 CLI 공통 layout)
+# 3. Gemini: 순정 Gemini CLI 지원 제거 및 ~/.gemini/skills 정리 (#1787)
+#    순정 gemini CLI 대신 agy(Antigravity CLI)를 사용하므로, 레거시
+#    ~/.gemini/skills 디렉토리 내부 symlink 및 빈 디렉토리를 정리한다.
 GEMINI_SKILLS="${HOME}/.gemini/skills"
-if [ ! -d "${HOME}/.gemini" ]; then
-    log_warning "Gemini 설정 디렉토리가 없습니다. 건너뜁니다: ${HOME}/.gemini"
-else
-    link_skills_compose "gemini" "$GEMINI_SKILLS"
+if [ -L "$GEMINI_SKILLS" ]; then
+    rm -f "$GEMINI_SKILLS"
+elif [ -d "$GEMINI_SKILLS" ]; then
+    find "$GEMINI_SKILLS" -mindepth 1 -maxdepth 1 -type l -exec rm -f {} +
+    rmdir "$GEMINI_SKILLS" 2>/dev/null || true
 fi
 
 # 3b. Antigravity CLI (agy): 자체 Global Customizations Root 에서 합성 (#1731).
@@ -684,7 +687,6 @@ if [ -n "${CODEX_HOME_LIST:-}" ]; then
         verify_link "codex" "${codex_home}/skills" "codex"
     done <<< "$CODEX_HOME_LIST"
 fi
-[ -d "${HOME}/.gemini" ] && verify_link "gemini" "$GEMINI_SKILLS" "compose"
 _agy_is_installed && verify_link "agy" "$AGY_SKILLS" "compose"
 [ -d "${HOME}/.hermes" ] && verify_link "hermes" "$HERMES_SKILLS" "compose"
 

--- a/scripts/sync-gemini-skills-namespace.sh
+++ b/scripts/sync-gemini-skills-namespace.sh
@@ -1,9 +1,9 @@
 #!/bin/bash
-# scripts/sync-gemini-skills-namespace.sh: Antigravity/Gemini 네임스페이스 기반 skills 심볼릭 링크 일괄 등록
+# scripts/sync-gemini-skills-namespace.sh: Antigravity(agy) 네임스페이스 기반 skills 심볼릭 링크 일괄 등록
 #
 # PURPOSE: $WORKSPACE_ROOT 아래 각 <repo>/skills/<skill>/SKILL.md 를 탐색하여
-#          ~/.gemini/config/skills 및 ~/.gemini/skills 에 <namespace>:<skill> 형태의
-#          심볼릭 링크를 일괄 생성/동기화한다 (issue #1784).
+#          ~/.gemini/config/skills 에 <namespace>:<skill> 형태의
+#          심볼릭 링크를 일괄 생성/동기화한다 (issue #1784, #1787).
 #
 # WHEN TO RUN: 수동 실행 가능, 또는 scripts/setup-skills-ssot.sh 내부에서 자동 호출.
 
@@ -47,7 +47,6 @@ Options:
 
 대상 디렉터리:
   - ~/.gemini/config/skills/ (Antigravity CLI)
-  - ~/.gemini/skills/        (Gemini CLI)
 USAGE_EOF
 }
 
@@ -122,17 +121,14 @@ _agy_is_installed() {
     command -v agy >/dev/null 2>&1
 }
 
-# 심볼릭 링크 동기화 대상 디렉터리
+# 심볼릭 링크 동기화 대상 디렉터리 (Antigravity CLI 단일 경로, #1787)
 TARGET_DIRS=()
 if _agy_is_installed || [ -d "${HOME}/.gemini/config/skills" ]; then
     TARGET_DIRS+=("${HOME}/.gemini/config/skills")
 fi
-if [ -d "${HOME}/.gemini" ]; then
-    TARGET_DIRS+=("${HOME}/.gemini/skills")
-fi
 
 if [ ${#TARGET_DIRS[@]} -eq 0 ]; then
-    ux_info "Gemini / Antigravity 설정 디렉터리가 없어 동기화를 건너뜁니다."
+    ux_info "Antigravity 설정 디렉터리가 없어 동기화를 건너뜁니다."
     exit 0
 fi
 
@@ -150,7 +146,7 @@ while IFS=$'\t' read -r src_path link_name; do
 done <<< "$SKILL_ENTRIES"
 
 entry_count="$(printf '%s\n' "$SKILL_ENTRIES" | grep -c .)"
-ux_header "Gemini / Antigravity 네임스페이스 스킬 동기화"
+ux_header "Antigravity 네임스페이스 스킬 동기화"
 ux_info "발견된 스킬: ${entry_count}개 (루트: ${WORKSPACE_ROOT_RESOLVED})"
 [ "$DRY_RUN" -eq 1 ] && ux_warning "DRY-RUN 모드: 실제 링크를 생성하거나 삭제하지 않습니다."
 

--- a/tests/bats/tools/setup_skills_ssot.bats
+++ b/tests/bats/tools/setup_skills_ssot.bats
@@ -165,18 +165,17 @@ run_setup() {
     done
 }
 
-@test "gemini: fresh install creates entry-level synthesis directory (#791)" {
+@test "gemini: legacy ~/.gemini/skills symlinks are cleaned up and dir removed (#1787)" {
     seed_gemini_home
+    local g_dir="${FIXTURE_HOME}/.gemini/skills"
+    mkdir -p "$g_dir"
+    ln -s "${BASE_REPO}/skills/alpha" "${g_dir}/alpha"
+    ln -s "${BASE_REPO}/skills/beta" "${g_dir}/beta"
 
     run_setup
     assert_success
 
-    local g_dir="${FIXTURE_HOME}/.gemini/skills"
-    [ -d "$g_dir" ] && [ ! -L "$g_dir" ]
-    for s in alpha beta gamma; do
-        [ -L "${g_dir}/${s}" ]
-        [ "$(readlink -f "${g_dir}/${s}")" = "$(readlink -f "${BASE_REPO}/skills/${s}")" ]
-    done
+    [ ! -e "$g_dir" ]
 }
 
 @test "opencode: legacy dir-symlink migrates to entry-level synthesis (#791)" {
@@ -199,24 +198,6 @@ run_setup() {
     done
 }
 
-@test "gemini: legacy dir-symlink migrates to entry-level synthesis (#791)" {
-    seed_gemini_home
-    # Dangling — the #1680 cutover removed the target (see opencode twin).
-    ln -s "${FIXTURE_DOTFILES}/claude/skills" "${FIXTURE_HOME}/.gemini/skills"
-    [ -L "${FIXTURE_HOME}/.gemini/skills" ]
-
-    run_setup
-    assert_success
-    assert_output --partial "[gemini] legacy dir-symlink"
-
-    local g_dir="${FIXTURE_HOME}/.gemini/skills"
-    [ ! -L "$g_dir" ]
-    [ -d "$g_dir" ]
-    for s in alpha beta gamma; do
-        [ -L "${g_dir}/${s}" ]
-    done
-}
-
 @test "opencode: synthesis is idempotent on re-run (#791)" {
     seed_opencode_home
 
@@ -231,21 +212,6 @@ run_setup() {
     after="$(ls -la "${FIXTURE_HOME}/.config/opencode/skills")"
 
     [ "$before" = "$after" ]
-}
-
-@test "gemini: user symlink to non-SSOT location is preserved + warned (#791)" {
-    seed_gemini_home
-    # User-managed symlink pointing somewhere other than the SSOT.
-    mkdir -p "${TEST_TEMP_HOME}/elsewhere/skills"
-    ln -s "${TEST_TEMP_HOME}/elsewhere/skills" "${FIXTURE_HOME}/.gemini/skills"
-
-    run_setup
-    assert_success
-    assert_output --partial "[gemini] 사용자 symlink"
-
-    # The user's symlink must NOT have been clobbered.
-    [ -L "${FIXTURE_HOME}/.gemini/skills" ]
-    [ "$(readlink "${FIXTURE_HOME}/.gemini/skills")" = "${TEST_TEMP_HOME}/elsewhere/skills" ]
 }
 
 @test "hermes: config dir absent is a non-fatal warn + skip (#1376)" {
@@ -483,9 +449,9 @@ run_setup_with_workspace() {
     [ -L "${oc_dir}/delta" ]
 }
 
-@test "workspace: skills reach every harness including codex (#1652 F-4)" {
+@test "workspace: skills reach every harness including codex (#1652 F-4, #1787)" {
     seed_opencode_home
-    seed_gemini_home
+    seed_agy_home
     seed_hermes_home
     seed_workspace_skill "$(default_workspace_root)" "packaging-skills" "delta"
 
@@ -493,7 +459,7 @@ run_setup_with_workspace() {
     assert_success
 
     [ -L "${FIXTURE_HOME}/.config/opencode/skills/delta" ]
-    [ -L "${FIXTURE_HOME}/.gemini/skills/delta" ]
+    [ -L "${FIXTURE_HOME}/.gemini/config/skills/delta" ]
     [ -L "${FIXTURE_HOME}/.hermes/skills/dotfiles/delta" ]
     [ -L "${FIXTURE_HOME}/.codex/skills/delta" ]
 }
@@ -811,36 +777,6 @@ seed_legacy_entries() {
     ln -s "${FIXTURE_DOTFILES}/claude/skills/legacy-orphan/" "${dir}/legacy-orphan"
 }
 
-@test "gemini: legacy entry shadowing a live source is relinked (#1732)" {
-    seed_gemini_home
-    run_setup
-    assert_success
-
-    local g_dir="${FIXTURE_HOME}/.gemini/skills"
-    seed_legacy_entries "$g_dir"
-
-    run_setup
-    assert_success
-
-    [ -L "${g_dir}/alpha" ]
-    [ -e "${g_dir}/alpha" ]
-    [ "$(readlink -f "${g_dir}/alpha")" = "$(readlink -f "${BASE_REPO}/skills/alpha")" ]
-}
-
-@test "gemini: legacy entry with no live source is pruned (#1732)" {
-    seed_gemini_home
-    run_setup
-    assert_success
-
-    local g_dir="${FIXTURE_HOME}/.gemini/skills"
-    seed_legacy_entries "$g_dir"
-
-    run_setup
-    assert_success
-
-    [ ! -L "${g_dir}/legacy-orphan" ]
-}
-
 @test "opencode: legacy entries are cleaned across every harness (#1732)" {
     seed_opencode_home
     seed_hermes_home
@@ -881,76 +817,6 @@ seed_legacy_entries() {
 # The counter-case that keeps the fix honest: a broken link pointing
 # somewhere that is NOT the deleted SSOT (a temporarily unmounted user
 # mount, say) still holds recoverable user intent — preserve it.
-@test "gemini: broken entry outside the legacy SSOT is preserved (#1732)" {
-    seed_gemini_home
-    run_setup
-    assert_success
-
-    local g_dir="${FIXTURE_HOME}/.gemini/skills"
-    rm -f "${g_dir}/beta"
-    ln -s "${TEST_TEMP_HOME}/unmounted/skills/beta" "${g_dir}/beta"
-
-    run_setup
-    assert_success
-    assert_output --partial "[gemini] 사용자 symlink 보존"
-
-    [ -L "${g_dir}/beta" ]
-    [ "$(readlink "${g_dir}/beta")" = "${TEST_TEMP_HOME}/unmounted/skills/beta" ]
-}
-
-# A worktree checkout resolves DOTFILES_ROOT to the worktree path, while
-# the stranded links were written against the main checkout. Matching on
-# DOTFILES_ROOT alone therefore misses every one of them — exactly the
-# state a re-run from a worktree has to be able to repair.
-@test "gemini: legacy entries are cleaned when run from a git worktree (#1732)" {
-    seed_gemini_home
-
-    git -C "$FIXTURE_DOTFILES" init -q
-    git -C "$FIXTURE_DOTFILES" config user.email t@example.com
-    git -C "$FIXTURE_DOTFILES" config user.name t
-    git -C "$FIXTURE_DOTFILES" add -A
-    git -C "$FIXTURE_DOTFILES" commit -qm init
-    local wt="${TEST_TEMP_HOME}/wt-dotfiles"
-    git -C "$FIXTURE_DOTFILES" worktree add -q -b wt/test "$wt"
-
-    run_setup
-    assert_success
-    local g_dir="${FIXTURE_HOME}/.gemini/skills"
-    seed_legacy_entries "$g_dir"
-
-    # Run from the worktree — DOTFILES_ROOT is now "$wt", but the links
-    # still name "$FIXTURE_DOTFILES".
-    run_setup "$wt"
-    assert_success
-
-    [ -e "${g_dir}/alpha" ]
-    [ "$(readlink -f "${g_dir}/alpha")" = "$(readlink -f "${BASE_REPO}/skills/alpha")" ]
-    [ ! -L "${g_dir}/legacy-orphan" ]
-}
-
-# 레거시 링크가 상대 경로로 적혀 있어도 같은 판정을 받아야 한다 (#1732,
-# agy FOLLOW-UP). 스크립트 자신은 항상 절대 경로로 링크를 만들지만, 수동/
-# 외부 도구가 만든 상대 경로 링크는 절대 경로 prefix 매칭을 그냥 빠져나간다.
-@test "gemini: relative-path legacy entry is cleaned too (#1732)" {
-    seed_gemini_home
-    run_setup
-    assert_success
-
-    local g_dir="${FIXTURE_HOME}/.gemini/skills"
-    local rel
-    rel="$(realpath -m --relative-to="$g_dir" "${FIXTURE_DOTFILES}/claude/skills")"
-    rm -f "${g_dir}/alpha"
-    ln -s "${rel}/alpha" "${g_dir}/alpha"
-    ln -s "${rel}/legacy-orphan" "${g_dir}/legacy-orphan"
-
-    run_setup
-    assert_success
-
-    [ -e "${g_dir}/alpha" ]
-    [ "$(readlink -f "${g_dir}/alpha")" = "$(readlink -f "${BASE_REPO}/skills/alpha")" ]
-    [ ! -L "${g_dir}/legacy-orphan" ]
-}
-
 # ---------------------------------------------------------------------
 # issue #1731 — Antigravity CLI (agy) 전용 합성 (근거: agy/AGENTS.md)
 # ---------------------------------------------------------------------
@@ -967,7 +833,7 @@ run_setup_without_agy() {
         run bash "${FIXTURE_DOTFILES}/scripts/setup-skills-ssot.sh"
 }
 
-@test "agy: composes into its own ~/.gemini/config/skills root (#1731)" {
+@test "agy: composes into its own ~/.gemini/config/skills root (#1731, #1787)" {
     seed_agy_home
 
     run_setup
@@ -980,21 +846,19 @@ run_setup_without_agy() {
         [ "$(readlink -f "${a_dir}/${s}")" = "$(readlink -f "${BASE_REPO}/skills/${s}")" ]
     done
 
-    # agy 루트는 Gemini 루트를 대체하지 않고 **추가**된다: seed_agy_home 이
-    # 만든 ~/.gemini 때문에 Gemini 블록도 함께 돌아 두 경로가 모두 채워진다
-    # (PR #1734 codex FOLLOW-UP — 예전 테스트명은 반대를 주장했다).
-    [ -L "${FIXTURE_HOME}/.gemini/skills/alpha" ]
+    # 순정 gemini skills 경로는 더 이상 합성되지 않는다 (#1787)
+    [ ! -e "${FIXTURE_HOME}/.gemini/skills" ]
 }
 
-@test "agy: neither state dir nor binary skips the fan-out (#1731)" {
+@test "agy: neither state dir nor binary skips the fan-out (#1731, #1787)" {
     # ~/.gemini 는 있지만 agy 는 설치되지 않은 순정 Gemini 환경.
     seed_gemini_home
 
     run_setup_without_agy
     assert_success
     [ ! -e "${FIXTURE_HOME}/.gemini/config/skills" ]
-    # Gemini 자신의 합성은 영향을 받지 않는다.
-    [ -L "${FIXTURE_HOME}/.gemini/skills/alpha" ]
+    # 순정 Gemini 경로는 더 이상 합성되지 않는다 (#1787).
+    [ ! -e "${FIXTURE_HOME}/.gemini/skills" ]
 }
 
 @test "agy: binary on PATH alone triggers the fan-out (#1731, agy FOLLOW-UP)" {

--- a/tests/bats/tools/sync_gemini_skills_namespace.bats
+++ b/tests/bats/tools/sync_gemini_skills_namespace.bats
@@ -70,23 +70,24 @@ run_sync() {
         run bash "${FIXTURE_DOTFILES}/scripts/sync-gemini-skills-namespace.sh" "$@"
 }
 
-@test "sync-gemini-skills-namespace: creates namespaced symlinks in agy and gemini dirs (#1784)" {
+@test "sync-gemini-skills-namespace: creates namespaced symlinks in agy dir (#1784, #1787)" {
     run_sync
     assert_success
 
     local agy_dir="${FIXTURE_HOME}/.gemini/config/skills"
     local gem_dir="${FIXTURE_HOME}/.gemini/skills"
 
-    for target in "$agy_dir" "$gem_dir"; do
-        [ -L "${target}/gh-flow:issue" ]
-        [ "$(readlink -f "${target}/gh-flow:issue")" = "$(readlink -f "${WORKSPACE}/gh-flow-skills/skills/issue")" ]
-        [ -L "${target}/gh-flow:autopilot" ]
-        [ "$(readlink -f "${target}/gh-flow:autopilot")" = "$(readlink -f "${WORKSPACE}/gh-flow-skills/skills/autopilot")" ]
-        [ -L "${target}/gh-issue:make-issue" ]
-        [ "$(readlink -f "${target}/gh-issue:make-issue")" = "$(readlink -f "${WORKSPACE}/gh-issue-skills/skills/make-issue")" ]
-        [ -L "${target}/authoring:skill-check" ]
-        [ "$(readlink -f "${target}/authoring:skill-check")" = "$(readlink -f "${WORKSPACE}/authoring-skills/skills/skill-check")" ]
-    done
+    [ -L "${agy_dir}/gh-flow:issue" ]
+    [ "$(readlink -f "${agy_dir}/gh-flow:issue")" = "$(readlink -f "${WORKSPACE}/gh-flow-skills/skills/issue")" ]
+    [ -L "${agy_dir}/gh-flow:autopilot" ]
+    [ "$(readlink -f "${agy_dir}/gh-flow:autopilot")" = "$(readlink -f "${WORKSPACE}/gh-flow-skills/skills/autopilot")" ]
+    [ -L "${agy_dir}/gh-issue:make-issue" ]
+    [ "$(readlink -f "${agy_dir}/gh-issue:make-issue")" = "$(readlink -f "${WORKSPACE}/gh-issue-skills/skills/make-issue")" ]
+    [ -L "${agy_dir}/authoring:skill-check" ]
+    [ "$(readlink -f "${agy_dir}/authoring:skill-check")" = "$(readlink -f "${WORKSPACE}/authoring-skills/skills/skill-check")" ]
+
+    # 순정 gemini skills 디렉토리에는 네임스페이스 링크가 생성되지 않는다 (#1787)
+    [ ! -e "${gem_dir}/gh-flow:issue" ]
 }
 
 @test "sync-gemini-skills-namespace: dry-run does not create symlinks (#1784)" {


### PR DESCRIPTION
## Summary
순정 `gemini` CLI에 대한 지원을 중단(deprecate)하고 Antigravity CLI(`agy`)의 단일 경로(`~/.gemini/config/skills`)로 일원화합니다.

- `scripts/setup-skills-ssot.sh`: 레거시 `GEMINI_SKILLS`(`~/.gemini/skills`) 합성 블록 제거 및 기존 잔여 symlink/디렉토리 자동 정리(cleanup) 로직 추가
- `scripts/sync-gemini-skills-namespace.sh`: 대상 경로에서 `~/.gemini/skills` 제거 및 Antigravity 단일 경로로 간소화
- `agy/AGENTS.md`, `claude/AGENTS.md`: 순정 Gemini 제거 및 agy 단일 경로 채택 문서화
- `tests/bats/tools/setup_skills_ssot.bats`, `tests/bats/tools/sync_gemini_skills_namespace.bats`: 단위 테스트 케이스 갱신 및 검증 완료

Closes #1787